### PR TITLE
Typo: Pypi -> PyPI

### DIFF
--- a/docs/installation/overview.rst
+++ b/docs/installation/overview.rst
@@ -6,7 +6,7 @@ Overview
 **PyAutoGalaxy** requires Python 3.6+ and support the Linux, MacOS and Windows operating systems.
 
 **PyAutoGalaxy** can be installed via the Python distribution `Anaconda <https://www.anaconda.com/>`_ or using
-`Pypi <https://pypi.org/>`_ to ``pip install`` **PyAutoGalaxy** into your Python distribution.
+`PyPI <https://pypi.org/>`_ to ``pip install`` **PyAutoGalaxy** into your Python distribution.
 
 We recommend Anaconda as it manages the installation of many major libraries used by **PyAutoGalaxy** (e.g. numpy, scipy,
 matplotlib, etc.) making installation more straight forward. Windows users must use Anaconda.


### PR DESCRIPTION
Just a minor typo fix.

https://github.com/astropy/astropy.github.com/pull/491#issuecomment-1215349065