### PR TITLE
DOC: Remove redundant narrative

### DIFF
--- a/docs/overview/overview_7_multi_wavelength.rst
+++ b/docs/overview/overview_7_multi_wavelength.rst
@@ -27,11 +27,6 @@ is straight forward.
 .. code-block:: python
 
     color_list = ["g", "r"]
-
-pixel_scales_list = [0.08, 0.12]
-
-.. code-block:: python
-
     pixel_scales_list = [0.08, 0.12]
 
 Multi-wavelength imaging datasets do not use any new objects or class in **PyAutoGalaxy**.


### PR DESCRIPTION
The narrative is just a copy of the code and does not tell me anything the code isn't saying. If you must keep the narrative, please explain what `pixel_scales_list = [0.08, 0.12]` is trying to do instead.

https://github.com/astropy/astropy.github.com/pull/491#issuecomment-1215349065