### PR TITLE
DOC: Remove redundant asterisk

### DIFF
--- a/docs/overview/overview_7_multi_wavelength.rst
+++ b/docs/overview/overview_7_multi_wavelength.rst
@@ -136,7 +136,7 @@ We do this using the combined analysis object as follows:
 .. code-block:: python
 
     analysis = analysis.with_free_parameters(
-        *[model.galaxies.galaxy.bulge.intensity, model.galaxies.galaxy.disk.intensity]
+        model.galaxies.galaxy.bulge.intensity, model.galaxies.galaxy.disk.intensity
     )
 
 In this simple overview, this has added two additional free parameters to the model whereby:


### PR DESCRIPTION
I could be missing something here but why use `*` when you can pass the arguments without it?

https://github.com/astropy/astropy.github.com/pull/491#issuecomment-1215349065