### PR TITLE
DOC: Remove broken URL

### DIFF
--- a/docs/general/likelihood_function.rst
+++ b/docs/general/likelihood_function.rst
@@ -15,7 +15,3 @@ their likelihood function.
 Links to every notebook are provided at the GitHub repository linked to below. We recommend authors link to this
 GitHub repository (as opposed to direct links to each) because the URLs to notebooks on the ``autogalaxy_workspace``
 may change after papers are published.
-
-By linking to this repository a permanent URL is provided.
-
-https://github.com/Jammy2211/autogalaxy_likelihood_function


### PR DESCRIPTION
Either fix the URL (https://github.com/Jammy2211/autogalaxy_likelihood_function) or remove it like this patch proposes. When I click on the link, I get 404 error.

Bonus: Consider adding linkcheck job to your CI.

https://github.com/astropy/astropy.github.com/pull/491#issuecomment-1215349065