### PR TITLE
moved grid_scaled_2d_for_marching_squares_from

### DIFF
--- a/autogalaxy/gui/clicker.py
+++ b/autogalaxy/gui/clicker.py
@@ -50,8 +50,8 @@ class Clicker:
                         y_pixels_max = y
                         x_pixels_max = x
 
-            grid_arcsec = self.image.mask.grid_scaled_from(
-                grid_pixels_1d=aa.Grid2D.manual_native(
+            grid_arcsec = self.image.mask.grid_scaled_2d_from(
+                grid_pixels_2d=aa.Grid2D.manual_native(
                     grid=[[[y_pixels_max + 0.5, x_pixels_max + 0.5]]],
                     pixel_scales=self.pixel_scales,
                 )

--- a/test_autogalaxy/operate/test_deflections.py
+++ b/test_autogalaxy/operate/test_deflections.py
@@ -5,6 +5,8 @@ from skimage import measure
 
 import autogalaxy as ag
 
+from autogalaxy.operate.deflections import grid_scaled_2d_for_marching_squares_from
+
 
 def critical_curve_via_magnification_from(mass_profile, grid):
 
@@ -23,8 +25,10 @@ def critical_curve_via_magnification_from(mass_profile, grid):
         contour_x, contour_y = contours[jj].T
         pixel_coord = np.stack((contour_x, contour_y), axis=-1)
 
-        critical_curve = grid.mask.grid_scaled_for_marching_squares_from(
-            grid_pixels_1d=pixel_coord, shape_native=magnification.sub_shape_native
+        critical_curve = grid_scaled_2d_for_marching_squares_from(
+            grid_pixels_2d=pixel_coord,
+            shape_native=magnification.sub_shape_native,
+            mask=grid.mask
         )
 
         critical_curves.append(critical_curve)

--- a/test_autogalaxy/plane/test_plane.py
+++ b/test_autogalaxy/plane/test_plane.py
@@ -28,8 +28,8 @@ def critical_curve_via_magnification_via_plane_from(plane, grid):
         contour_x, contour_y = contours[jj].T
         pixel_coord = np.stack((contour_x, contour_y), axis=-1)
 
-        critical_curve = grid.mask.grid_scaled_for_marching_squares_from(
-            grid_pixels_1d=pixel_coord, shape_native=magnification.sub_shape_native
+        critical_curve = grid.mask.grid_scaled_2d_for_marching_squares_from(
+            grid_pixels_2d=pixel_coord, shape_native=magnification.sub_shape_native
         )
 
         critical_curve = np.array(grid=critical_curve)


### PR DESCRIPTION
Refactor method associated with the geometry of a mask into a standalone module, in order to separate concerns.