### PR TITLE
Feature/remove manual api

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -30,7 +30,7 @@ from autoarray.operators.transformer import TransformerNUFFT  # noqa
 from autoarray.layout.layout import Layout2D  # noqa
 from autoarray.structures.arrays.uniform_1d import Array1D  # noqa
 from autoarray.structures.arrays.uniform_2d import Array2D  # noqa
-from autoarray.structures.values import ValuesIrregular  # noqa
+from autoarray.structures.arrays.irregular import ArrayIrregular  # noqa
 from autoarray.structures.header import Header  # noqa
 from autoarray.structures.grids.uniform_1d import Grid1D  # noqa
 from autoarray.structures.grids.uniform_2d import Grid2D  # noqa

--- a/autogalaxy/analysis/result.py
+++ b/autogalaxy/analysis/result.py
@@ -158,7 +158,7 @@ class ResultDataset(Result):
 
         The hyper model image is the sum of the hyper galaxy image of every individual galaxy.
         """
-        hyper_model_image = aa.Array2D.manual_mask(
+        hyper_model_image = aa.Array2D(
             array=np.zeros(self.mask.derive_mask.sub_1.pixels_in_mask),
             mask=self.mask.derive_mask.sub_1,
         )

--- a/autogalaxy/analysis/result.py
+++ b/autogalaxy/analysis/result.py
@@ -159,7 +159,7 @@ class ResultDataset(Result):
         The hyper model image is the sum of the hyper galaxy image of every individual galaxy.
         """
         hyper_model_image = aa.Array2D(
-            array=np.zeros(self.mask.derive_mask.sub_1.pixels_in_mask),
+            values=np.zeros(self.mask.derive_mask.sub_1.pixels_in_mask),
             mask=self.mask.derive_mask.sub_1,
         )
 

--- a/autogalaxy/analysis/result.py
+++ b/autogalaxy/analysis/result.py
@@ -159,8 +159,8 @@ class ResultDataset(Result):
         The hyper model image is the sum of the hyper galaxy image of every individual galaxy.
         """
         hyper_model_image = aa.Array2D.manual_mask(
-            array=np.zeros(self.mask.derived_masks.sub_1.pixels_in_mask),
-            mask=self.mask.derived_masks.sub_1,
+            array=np.zeros(self.mask.derive_mask.sub_1.pixels_in_mask),
+            mask=self.mask.derive_mask.sub_1,
         )
 
         for path, galaxy in self.path_galaxy_tuples:

--- a/autogalaxy/fixtures.py
+++ b/autogalaxy/fixtures.py
@@ -195,14 +195,14 @@ def make_fit_quantity_7x7_vector_yx_2d():
 
 
 def make_hyper_model_image_7x7():
-    return ag.Array2D.manual_mask(
+    return ag.Array2D(
         np.full(fill_value=5.0, shape=make_mask_2d_7x7().pixels_in_mask),
         mask=make_mask_2d_7x7(),
     )
 
 
 def make_hyper_galaxy_image_0_7x7():
-    return ag.Array2D.manual_mask(
+    return ag.Array2D(
         np.full(fill_value=2.0, shape=make_mask_2d_7x7().pixels_in_mask),
         mask=make_mask_2d_7x7(),
     )
@@ -218,7 +218,7 @@ def make_hyper_galaxy_image_path_dict_7x7():
 
 
 def make_hyper_galaxy_image_1_7x7():
-    return ag.Array2D.manual_mask(
+    return ag.Array2D(
         np.full(fill_value=3.0, shape=make_mask_2d_7x7().pixels_in_mask),
         mask=make_mask_2d_7x7(),
     )

--- a/autogalaxy/galaxy/galaxy.py
+++ b/autogalaxy/galaxy/galaxy.py
@@ -472,7 +472,7 @@ class Galaxy(af.ModelObject, OperateImageList, OperateDeflections, Dictable):
 
         would return:
 
-        ValuesIrregular(values=[axis_ratio_0, axis_ratio_1])
+        ArrayIrregular(values=[axis_ratio_0, axis_ratio_1])
 
         If a galaxy has three mass profiles and we want the `MassProfile` centres, the following:
 
@@ -503,7 +503,7 @@ class Galaxy(af.ModelObject, OperateImageList, OperateDeflections, Dictable):
         if attributes == []:
             return None
         elif isinstance(attributes[0], float):
-            return aa.ValuesIrregular(values=attributes)
+            return aa.ArrayIrregular(values=attributes)
         elif isinstance(attributes[0], tuple):
             return aa.Grid2DIrregular(values=attributes)
 

--- a/autogalaxy/galaxy/galaxy.py
+++ b/autogalaxy/galaxy/galaxy.py
@@ -505,7 +505,7 @@ class Galaxy(af.ModelObject, OperateImageList, OperateDeflections, Dictable):
         elif isinstance(attributes[0], float):
             return aa.ValuesIrregular(values=attributes)
         elif isinstance(attributes[0], tuple):
-            return aa.Grid2DIrregular(grid=attributes)
+            return aa.Grid2DIrregular(values=attributes)
 
     def luminosity_within_circle_from(self, radius: float):
         """

--- a/autogalaxy/galaxy/plot/galaxy_plotters.py
+++ b/autogalaxy/galaxy/plot/galaxy_plotters.py
@@ -779,7 +779,7 @@ class GalaxyPDFPlotter(GalaxyPlotter):
 
             visuals_1d = visuals_1d_via_light_obj_list + visuals_1d_with_shaded_region
 
-            median_image_1d = aa.Array1D.manual_slim(
+            median_image_1d = aa.Array1D.without_mask(
                 array=median_image_1d, pixel_scales=self.grid.pixel_scale
             )
 
@@ -829,7 +829,7 @@ class GalaxyPDFPlotter(GalaxyPlotter):
 
             visuals_1d = visuals_1d_via_lensing_obj_list + visuals_1d_with_shaded_region
 
-            median_convergence_1d = aa.Array1D.manual_slim(
+            median_convergence_1d = aa.Array1D.without_mask(
                 array=median_convergence_1d, pixel_scales=self.grid.pixel_scale
             )
 
@@ -879,7 +879,7 @@ class GalaxyPDFPlotter(GalaxyPlotter):
 
             visuals_1d = visuals_1d_via_lensing_obj_list + visuals_1d_with_shaded_region
 
-            median_potential_1d = aa.Array1D.manual_slim(
+            median_potential_1d = aa.Array1D.without_mask(
                 array=median_potential_1d, pixel_scales=self.grid.pixel_scale
             )
 

--- a/autogalaxy/galaxy/plot/galaxy_plotters.py
+++ b/autogalaxy/galaxy/plot/galaxy_plotters.py
@@ -779,8 +779,8 @@ class GalaxyPDFPlotter(GalaxyPlotter):
 
             visuals_1d = visuals_1d_via_light_obj_list + visuals_1d_with_shaded_region
 
-            median_image_1d = aa.Array1D.without_mask(
-                array=median_image_1d, pixel_scales=self.grid.pixel_scale
+            median_image_1d = aa.Array1D.no_mask(
+                values=median_image_1d, pixel_scales=self.grid.pixel_scale
             )
 
             self.mat_plot_1d.plot_yx(
@@ -829,8 +829,8 @@ class GalaxyPDFPlotter(GalaxyPlotter):
 
             visuals_1d = visuals_1d_via_lensing_obj_list + visuals_1d_with_shaded_region
 
-            median_convergence_1d = aa.Array1D.without_mask(
-                array=median_convergence_1d, pixel_scales=self.grid.pixel_scale
+            median_convergence_1d = aa.Array1D.no_mask(
+                values=median_convergence_1d, pixel_scales=self.grid.pixel_scale
             )
 
             self.mat_plot_1d.plot_yx(
@@ -879,8 +879,8 @@ class GalaxyPDFPlotter(GalaxyPlotter):
 
             visuals_1d = visuals_1d_via_lensing_obj_list + visuals_1d_with_shaded_region
 
-            median_potential_1d = aa.Array1D.without_mask(
-                array=median_potential_1d, pixel_scales=self.grid.pixel_scale
+            median_potential_1d = aa.Array1D.no_mask(
+                values=median_potential_1d, pixel_scales=self.grid.pixel_scale
             )
 
             self.mat_plot_1d.plot_yx(

--- a/autogalaxy/gui/clicker.py
+++ b/autogalaxy/gui/clicker.py
@@ -52,7 +52,7 @@ class Clicker:
 
             grid_arcsec = self.image.mask.grid_scaled_2d_from(
                 grid_pixels_2d=aa.Grid2D(
-                    grid=[[[y_pixels_max + 0.5, x_pixels_max + 0.5]]],
+                    values=[[[y_pixels_max + 0.5, x_pixels_max + 0.5]]],
                     pixel_scales=self.pixel_scales,
                 )
             )

--- a/autogalaxy/gui/clicker.py
+++ b/autogalaxy/gui/clicker.py
@@ -51,7 +51,7 @@ class Clicker:
                         x_pixels_max = x
 
             grid_arcsec = self.image.mask.grid_scaled_2d_from(
-                grid_pixels_2d=aa.Grid2D.manual_native(
+                grid_pixels_2d=aa.Grid2D(
                     grid=[[[y_pixels_max + 0.5, x_pixels_max + 0.5]]],
                     pixel_scales=self.pixel_scales,
                 )

--- a/autogalaxy/operate/deflections.py
+++ b/autogalaxy/operate/deflections.py
@@ -220,7 +220,7 @@ class OperateDeflections(Dictable):
 
     def convergence_2d_via_hessian_from(
         self, grid, buffer: float = 0.01
-    ) -> aa.ValuesIrregular:
+    ) -> aa.ArrayIrregular:
         """
         Returns the convergence of the lensing object, which is computed from the 2D deflection angle map via the
         Hessian using the expression (see equation 56 https://www.tau.ac.il/~lab3/MICROLENSING/JeruLect.pdf):
@@ -283,7 +283,7 @@ class OperateDeflections(Dictable):
 
     def magnification_2d_via_hessian_from(
         self, grid, buffer: float = 0.01, deflections_func=None
-    ) -> aa.ValuesIrregular:
+    ) -> aa.ArrayIrregular:
         """
         Returns the 2D magnification map of lensing object, which is computed from the 2D deflection angle map
         via the Hessian using the expressions (see equation 60 https://www.tau.ac.il/~lab3/MICROLENSING/JeruLect.pdf):

--- a/autogalaxy/operate/deflections.py
+++ b/autogalaxy/operate/deflections.py
@@ -11,9 +11,9 @@ from autogalaxy.util.shear_field import ShearYX2DIrregular
 
 
 def grid_scaled_2d_for_marching_squares_from(
-        grid_pixels_2d : aa.Grid2D,
-        shape_native : Tuple[int, int],
-        mask: aa.Mask2D,
+    grid_pixels_2d: aa.Grid2D,
+    shape_native: Tuple[int, int],
+    mask: aa.Mask2D,
 ) -> aa.Grid2D:
     from autoarray.structures.grids.uniform_2d import Grid2D
 

--- a/autogalaxy/operate/deflections.py
+++ b/autogalaxy/operate/deflections.py
@@ -122,7 +122,7 @@ class OperateDeflections(Dictable):
 
         shear_yx = self.shear_yx_2d_via_jacobian_from(grid=grid, jacobian=jacobian)
 
-        return aa.Array2D(array=1 - convergence - shear_yx.magnitudes, mask=grid.mask)
+        return aa.Array2D(values=1 - convergence - shear_yx.magnitudes, mask=grid.mask)
 
     @precompute_jacobian
     def radial_eigen_value_from(self, grid, jacobian=None) -> aa.Array2D:
@@ -144,7 +144,7 @@ class OperateDeflections(Dictable):
 
         shear = self.shear_yx_2d_via_jacobian_from(grid=grid, jacobian=jacobian)
 
-        return aa.Array2D(array=1 - convergence + shear.magnitudes, mask=grid.mask)
+        return aa.Array2D(values=1 - convergence + shear.magnitudes, mask=grid.mask)
 
     def magnification_2d_from(self, grid) -> aa.Array2D:
         """
@@ -160,7 +160,7 @@ class OperateDeflections(Dictable):
 
         det_jacobian = jacobian[0][0] * jacobian[1][1] - jacobian[0][1] * jacobian[1][0]
 
-        return aa.Array2D(array=1 / det_jacobian, mask=grid.mask)
+        return aa.Array2D(values=1 / det_jacobian, mask=grid.mask)
 
     def hessian_from(self, grid, buffer: float = 0.01, deflections_func=None) -> Tuple:
         """
@@ -279,7 +279,7 @@ class OperateDeflections(Dictable):
         shear_yx_2d[:, 0] = hessian_xy
         shear_yx_2d[:, 1] = 0.5 * (hessian_xx - hessian_yy)
 
-        return ShearYX2DIrregular(vectors=shear_yx_2d, grid=grid)
+        return ShearYX2DIrregular(values=shear_yx_2d, grid=grid)
 
     def magnification_2d_via_hessian_from(
         self, grid, buffer: float = 0.01, deflections_func=None
@@ -660,25 +660,25 @@ class OperateDeflections(Dictable):
         # TODO : Can probably make this work on irregular grid? Is there any point?
 
         a11 = aa.Array2D(
-            array=1.0
+            values=1.0
             - np.gradient(deflections.native[:, :, 1], grid.native[0, :, 1], axis=1),
             mask=grid.mask,
         )
 
         a12 = aa.Array2D(
-            array=-1.0
+            values=-1.0
             * np.gradient(deflections.native[:, :, 1], grid.native[:, 0, 0], axis=0),
             mask=grid.mask,
         )
 
         a21 = aa.Array2D(
-            array=-1.0
+            values=-1.0
             * np.gradient(deflections.native[:, :, 0], grid.native[0, :, 1], axis=1),
             mask=grid.mask,
         )
 
         a22 = aa.Array2D(
-            array=1
+            values=1
             - np.gradient(deflections.native[:, :, 0], grid.native[:, 0, 0], axis=0),
             mask=grid.mask,
         )
@@ -707,7 +707,7 @@ class OperateDeflections(Dictable):
         """
         convergence = 1 - 0.5 * (jacobian[0][0] + jacobian[1][1])
 
-        return aa.Array2D(array=convergence, mask=grid.mask)
+        return aa.Array2D(values=convergence, mask=grid.mask)
 
     @precompute_jacobian
     def shear_yx_2d_via_jacobian_from(
@@ -738,5 +738,5 @@ class OperateDeflections(Dictable):
         shear_yx_2d[:, 1] = 0.5 * (jacobian[1][1] - jacobian[0][0])
 
         if isinstance(grid, aa.Grid2DIrregular):
-            return ShearYX2DIrregular(vectors=shear_yx_2d, grid=grid)
-        return ShearYX2D(vectors=shear_yx_2d, grid=grid, mask=grid.mask)
+            return ShearYX2DIrregular(values=shear_yx_2d, grid=grid)
+        return ShearYX2D(values=shear_yx_2d, grid=grid, mask=grid.mask)

--- a/autogalaxy/operate/deflections.py
+++ b/autogalaxy/operate/deflections.py
@@ -34,7 +34,7 @@ def grid_scaled_2d_for_marching_squares_from(
     grid_scaled_1d[:, 0] -= pixel_scales[0] / (2.0 * sub_size)
     grid_scaled_1d[:, 1] += pixel_scales[1] / (2.0 * sub_size)
 
-    return Grid2D(grid=grid_scaled_1d, mask=mask)
+    return grid_scaled_1d
 
 
 def precompute_jacobian(func):
@@ -659,25 +659,25 @@ class OperateDeflections(Dictable):
 
         # TODO : Can probably make this work on irregular grid? Is there any point?
 
-        a11 = aa.Array2D.manual_mask(
+        a11 = aa.Array2D(
             array=1.0
             - np.gradient(deflections.native[:, :, 1], grid.native[0, :, 1], axis=1),
             mask=grid.mask,
         )
 
-        a12 = aa.Array2D.manual_mask(
+        a12 = aa.Array2D(
             array=-1.0
             * np.gradient(deflections.native[:, :, 1], grid.native[:, 0, 0], axis=0),
             mask=grid.mask,
         )
 
-        a21 = aa.Array2D.manual_mask(
+        a21 = aa.Array2D(
             array=-1.0
             * np.gradient(deflections.native[:, :, 0], grid.native[0, :, 1], axis=1),
             mask=grid.mask,
         )
 
-        a22 = aa.Array2D.manual_mask(
+        a22 = aa.Array2D(
             array=1
             - np.gradient(deflections.native[:, :, 0], grid.native[:, 0, 0], axis=0),
             mask=grid.mask,

--- a/autogalaxy/operate/image.py
+++ b/autogalaxy/operate/image.py
@@ -406,6 +406,7 @@ class OperateImageGalaxies(OperateImageList):
         galaxy_image_2d_not_operated_dict = self.galaxy_image_2d_dict_from(
             grid=grid, operated_only=False
         )
+
         galaxy_blurring_image_2d_not_operated_dict = self.galaxy_image_2d_dict_from(
             grid=blurring_grid, operated_only=False
         )

--- a/autogalaxy/plane/plane.py
+++ b/autogalaxy/plane/plane.py
@@ -286,7 +286,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
 
             else:
 
-                hyper_noise_map = aa.Array2D.manual_mask(
+                hyper_noise_map = aa.Array2D(
                     array=np.zeros(noise_map.mask.derive_mask.sub_1.pixels_in_mask),
                     mask=noise_map.mask.derive_mask.sub_1,
                 )

--- a/autogalaxy/plane/plane.py
+++ b/autogalaxy/plane/plane.py
@@ -357,7 +357,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
 
         would return:
 
-        ValuesIrregular(values=[axis_ratio_0, axis_ratio_1])
+        ArrayIrregular(values=[axis_ratio_0, axis_ratio_1])
 
         If a galaxy has three mass profiles and we want their centres, the following:
 
@@ -387,7 +387,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
         if attributes == []:
             return None
         elif isinstance(attributes[0], float):
-            return aa.ValuesIrregular(values=attributes)
+            return aa.ArrayIrregular(values=attributes)
         elif isinstance(attributes[0], tuple):
             return aa.Grid2DIrregular(values=attributes)
 
@@ -402,7 +402,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
 
         would return:
 
-        [ValuesIrregular(values=[axis_ratio_0]), ValuesIrregular(values=[axis_ratio_1])]
+        [ArrayIrregular(values=[axis_ratio_0]), ArrayIrregular(values=[axis_ratio_1])]
 
         If a plane has two galaxies, the first with a mass profile and the second with two mass profiles ,the following:
 

--- a/autogalaxy/plane/plane.py
+++ b/autogalaxy/plane/plane.py
@@ -173,7 +173,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
     def plane_image_2d_from(self, grid: aa.type.Grid2DLike) -> "PlaneImage":
         return plane_util.plane_image_of_galaxies_from(
             shape=grid.mask.shape,
-            grid=grid.mask.derived_grids.unmasked_sub_1,
+            grid=grid.mask.derive_grid.all_false_sub_1,
             galaxies=self.galaxies,
         )
 
@@ -287,8 +287,8 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
             else:
 
                 hyper_noise_map = aa.Array2D.manual_mask(
-                    array=np.zeros(noise_map.mask.derived_masks.sub_1.pixels_in_mask),
-                    mask=noise_map.mask.derived_masks.sub_1,
+                    array=np.zeros(noise_map.mask.derive_mask.sub_1.pixels_in_mask),
+                    mask=noise_map.mask.derive_mask.sub_1,
                 )
 
                 hyper_noise_map_list.append(hyper_noise_map)

--- a/autogalaxy/plane/plane.py
+++ b/autogalaxy/plane/plane.py
@@ -287,7 +287,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
             else:
 
                 hyper_noise_map = aa.Array2D(
-                    array=np.zeros(noise_map.mask.derive_mask.sub_1.pixels_in_mask),
+                    values=np.zeros(noise_map.mask.derive_mask.sub_1.pixels_in_mask),
                     mask=noise_map.mask.derive_mask.sub_1,
                 )
 
@@ -389,7 +389,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
         elif isinstance(attributes[0], float):
             return aa.ValuesIrregular(values=attributes)
         elif isinstance(attributes[0], tuple):
-            return aa.Grid2DIrregular(grid=attributes)
+            return aa.Grid2DIrregular(values=attributes)
 
     def extract_attributes_of_galaxies(self, cls, attr_name, filter_nones=False):
         """
@@ -410,8 +410,8 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
 
         would return:
         [
-            Grid2DIrregular(grid=[(centre_y_0, centre_x_0)]),
-            Grid2DIrregular(grid=[(centre_y_0, centre_x_0), (centre_y_1, centre_x_1)])
+            Grid2DIrregular(values=[(centre_y_0, centre_x_0)]),
+            Grid2DIrregular(values=[(centre_y_0, centre_x_0), (centre_y_1, centre_x_1)])
         ]
 
         If a Profile does not have a certain entry, it is replaced with a None. Nones can be removed by

--- a/autogalaxy/plane/plane.py
+++ b/autogalaxy/plane/plane.py
@@ -173,7 +173,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
     def plane_image_2d_from(self, grid: aa.type.Grid2DLike) -> "PlaneImage":
         return plane_util.plane_image_of_galaxies_from(
             shape=grid.mask.shape,
-            grid=grid.mask.unmasked_grid_sub_1,
+            grid=grid.mask.derived_grids.unmasked_sub_1,
             galaxies=self.galaxies,
         )
 

--- a/autogalaxy/plot/get_visuals/two_d.py
+++ b/autogalaxy/plot/get_visuals/two_d.py
@@ -69,7 +69,7 @@ class GetVisuals2D(aplt.GetVisuals2D):
         if isinstance(light_obj, LightProfile):
 
             light_profile_centres = self.get(
-                "light_profile_centres", aa.Grid2DIrregular(grid=[light_obj.centre])
+                "light_profile_centres", aa.Grid2DIrregular(values=[light_obj.centre])
             )
 
         else:
@@ -121,7 +121,7 @@ class GetVisuals2D(aplt.GetVisuals2D):
         if isinstance(mass_obj, MassProfile):
 
             mass_profile_centres = self.get(
-                "mass_profile_centres", aa.Grid2DIrregular(grid=[mass_obj.centre])
+                "mass_profile_centres", aa.Grid2DIrregular(values=[mass_obj.centre])
             )
 
         else:
@@ -222,7 +222,7 @@ class GetVisuals2D(aplt.GetVisuals2D):
         vis.Visuals2D
             A collection of attributes that can be plotted by a `Plotter` object.
         """
-        origin = self.get("origin", value=aa.Grid2DIrregular(grid=[grid.origin]))
+        origin = self.get("origin", value=aa.Grid2DIrregular(values=[grid.origin]))
 
         light_profile_centres = self.get(
             "light_profile_centres",

--- a/autogalaxy/plot/mass_plotter.py
+++ b/autogalaxy/plot/mass_plotter.py
@@ -89,7 +89,7 @@ class MassPlotter(Plotter):
         if deflections_y:
 
             deflections = self.mass_obj.deflections_yx_2d_from(grid=self.grid)
-            deflections_y = aa.Array2D.manual_mask(
+            deflections_y = aa.Array2D(
                 array=deflections.slim[:, 0], mask=self.grid.mask
             )
 
@@ -105,7 +105,7 @@ class MassPlotter(Plotter):
         if deflections_x:
 
             deflections = self.mass_obj.deflections_yx_2d_from(grid=self.grid)
-            deflections_x = aa.Array2D.manual_mask(
+            deflections_x = aa.Array2D(
                 array=deflections.slim[:, 1], mask=self.grid.mask
             )
 

--- a/autogalaxy/plot/mass_plotter.py
+++ b/autogalaxy/plot/mass_plotter.py
@@ -90,7 +90,7 @@ class MassPlotter(Plotter):
 
             deflections = self.mass_obj.deflections_yx_2d_from(grid=self.grid)
             deflections_y = aa.Array2D(
-                array=deflections.slim[:, 0], mask=self.grid.mask
+                values=deflections.slim[:, 0], mask=self.grid.mask
             )
 
             self.mat_plot_2d.plot_array(
@@ -106,7 +106,7 @@ class MassPlotter(Plotter):
 
             deflections = self.mass_obj.deflections_yx_2d_from(grid=self.grid)
             deflections_x = aa.Array2D(
-                array=deflections.slim[:, 1], mask=self.grid.mask
+                values=deflections.slim[:, 1], mask=self.grid.mask
             )
 
             self.mat_plot_2d.plot_array(

--- a/autogalaxy/profiles/geometry_profiles.py
+++ b/autogalaxy/profiles/geometry_profiles.py
@@ -143,7 +143,7 @@ class SphProfile(GeometryProfile):
             The (y, x) coordinates in the original reference frame of the grid.
         """
         transformed = np.subtract(grid, self.centre)
-        return Grid2DTransformedNumpy(grid=transformed)
+        return Grid2DTransformedNumpy(values=transformed)
 
     @aa.grid_dec.grid_2d_to_structure
     def transformed_from_reference_frame_grid_from(self, grid):
@@ -343,12 +343,12 @@ class EllProfile(SphProfile):
         """
         if self.__class__.__name__.endswith("Sph"):
             return super().transformed_to_reference_frame_grid_from(
-                grid=Grid2DTransformedNumpy(grid=grid)
+                grid=Grid2DTransformedNumpy(values=grid)
             )
         transformed = aa.util.geometry.transform_grid_2d_to_reference_frame(
             grid_2d=grid, centre=self.centre, angle=self.angle
         )
-        return Grid2DTransformedNumpy(grid=transformed)
+        return Grid2DTransformedNumpy(values=transformed)
 
     @aa.grid_dec.grid_2d_to_structure
     def transformed_from_reference_frame_grid_from(
@@ -367,7 +367,7 @@ class EllProfile(SphProfile):
         """
         if self.__class__.__name__.startswith("Sph"):
             return super().transformed_from_reference_frame_grid_from(
-                grid=Grid2DTransformedNumpy(grid=grid)
+                grid=Grid2DTransformedNumpy(values=grid)
             )
 
         return aa.util.geometry.transform_grid_2d_from_reference_frame(

--- a/autogalaxy/profiles/mass/abstract/abstract.py
+++ b/autogalaxy/profiles/mass/abstract/abstract.py
@@ -40,7 +40,8 @@ class MassProfile(EllProfile, OperateDeflections):
         deflections_x_2d = np.gradient(potential.native, grid.native[0, :, 1], axis=1)
 
         return aa.Grid2D(
-            grid=np.stack((deflections_y_2d, deflections_x_2d), axis=-1), mask=grid.mask
+            values=np.stack((deflections_y_2d, deflections_x_2d), axis=-1),
+            mask=grid.mask,
         )
 
     def convergence_2d_from(self, grid):
@@ -282,4 +283,4 @@ class MassProfile(EllProfile, OperateDeflections):
                 if isinstance(attribute, float):
                     return aa.ValuesIrregular(values=[attribute])
                 if isinstance(attribute, tuple):
-                    return aa.Grid2DIrregular(grid=[attribute])
+                    return aa.Grid2DIrregular(values=[attribute])

--- a/autogalaxy/profiles/mass/abstract/abstract.py
+++ b/autogalaxy/profiles/mass/abstract/abstract.py
@@ -262,7 +262,7 @@ class MassProfile(EllProfile, OperateDeflections):
 
         would return:
 
-        ValuesIrregular(values=[axis_ratio_0, axis_ratio_1])
+        ArrayIrregular(values=[axis_ratio_0, axis_ratio_1])
 
         If a galaxy has three mass profiles and we want the `MassProfile` centres, the following:
 
@@ -281,6 +281,6 @@ class MassProfile(EllProfile, OperateDeflections):
                 attribute = getattr(self, attr_name)
 
                 if isinstance(attribute, float):
-                    return aa.ValuesIrregular(values=[attribute])
+                    return aa.ArrayIrregular(values=[attribute])
                 if isinstance(attribute, tuple):
                     return aa.Grid2DIrregular(values=[attribute])

--- a/autogalaxy/profiles/mass/abstract/abstract.py
+++ b/autogalaxy/profiles/mass/abstract/abstract.py
@@ -39,7 +39,7 @@ class MassProfile(EllProfile, OperateDeflections):
         deflections_y_2d = np.gradient(potential.native, grid.native[:, 0, 0], axis=0)
         deflections_x_2d = np.gradient(potential.native, grid.native[0, :, 1], axis=1)
 
-        return aa.Grid2D.manual_mask(
+        return aa.Grid2D(
             grid=np.stack((deflections_y_2d, deflections_x_2d), axis=-1), mask=grid.mask
         )
 

--- a/autogalaxy/profiles/mass/total/isothermal.py
+++ b/autogalaxy/profiles/mass/total/isothermal.py
@@ -137,7 +137,7 @@ class Isothermal(PowerLaw):
             grid=np.vstack((shear_y, shear_x)).T
         )
 
-        return aa.VectorYX2DIrregular(vectors=shear_field, grid=grid)
+        return aa.VectorYX2DIrregular(values=shear_field, grid=grid)
 
 
 class IsothermalSph(Isothermal):

--- a/autogalaxy/quantity/dataset_quantity.py
+++ b/autogalaxy/quantity/dataset_quantity.py
@@ -91,8 +91,8 @@ class DatasetQuantity(AbstractDataset):
 
             if data.shape[0:-1] == noise_map.shape[0:]:
 
-                noise_map = aa.VectorYX2D._manual_native(
-                    vectors=np.stack((noise_map, noise_map), axis=-1),
+                noise_map = aa.VectorYX2D.no_mask(
+                    values=np.stack((noise_map, noise_map), axis=-1),
                     pixel_scales=data.pixel_scales,
                     sub_size=data.sub_size,
                     origin=data.origin,

--- a/autogalaxy/quantity/dataset_quantity.py
+++ b/autogalaxy/quantity/dataset_quantity.py
@@ -91,7 +91,7 @@ class DatasetQuantity(AbstractDataset):
 
             if data.shape[0:-1] == noise_map.shape[0:]:
 
-                noise_map = aa.VectorYX2D.manual_native(
+                noise_map = aa.VectorYX2D._manual_native(
                     vectors=np.stack((noise_map, noise_map), axis=-1),
                     pixel_scales=data.pixel_scales,
                     sub_size=data.sub_size,

--- a/autogalaxy/quantity/dataset_quantity.py
+++ b/autogalaxy/quantity/dataset_quantity.py
@@ -187,8 +187,8 @@ class DatasetQuantity(AbstractDataset):
         else:
             unmasked_dataset = self.unmasked
 
-        data = self.data.apply_mask(mask=mask.derived_masks.sub_1)
-        noise_map = self.noise_map.apply_mask(mask=mask.derived_masks.sub_1)
+        data = self.data.apply_mask(mask=mask.derive_mask.sub_1)
+        noise_map = self.noise_map.apply_mask(mask=mask.derive_mask.sub_1)
 
         dataset = DatasetQuantity(
             data=data, noise_map=noise_map, settings=self.settings

--- a/autogalaxy/util/shear_field.py
+++ b/autogalaxy/util/shear_field.py
@@ -11,38 +11,38 @@ logger = logging.getLogger(__name__)
 
 class AbstractShearField:
     @property
-    def ellipticities(self) -> aa.ValuesIrregular:
+    def ellipticities(self) -> aa.ArrayIrregular:
         """
         If we treat this vector field as a set of weak lensing shear measurements, the galaxy ellipticity each vector
         corresponds too.
         """
-        return aa.ValuesIrregular(
+        return aa.ArrayIrregular(
             values=np.sqrt(self.slim[:, 0] ** 2 + self.slim[:, 1] ** 2.0)
         )
 
     @property
-    def semi_major_axes(self) -> aa.ValuesIrregular:
+    def semi_major_axes(self) -> aa.ArrayIrregular:
         """
         If we treat this vector field as a set of weak lensing shear measurements, the semi-major axis of each
         galaxy ellipticity that each vector corresponds too.
         """
-        return aa.ValuesIrregular(values=3 * (1 + self.ellipticities))
+        return aa.ArrayIrregular(values=3 * (1 + self.ellipticities))
 
     @property
-    def semi_minor_axes(self) -> aa.ValuesIrregular:
+    def semi_minor_axes(self) -> aa.ArrayIrregular:
         """
         If we treat this vector field as a set of weak lensing shear measurements, the semi-minor axis of each
         galaxy ellipticity that each vector corresponds too.
         """
-        return aa.ValuesIrregular(values=3 * (1 - self.ellipticities))
+        return aa.ArrayIrregular(values=3 * (1 - self.ellipticities))
 
     @property
-    def phis(self) -> aa.ValuesIrregular:
+    def phis(self) -> aa.ArrayIrregular:
         """
         If we treat this vector field as a set of weak lensing shear measurements, the position angle defined
         counter clockwise from the positive x-axis of each galaxy ellipticity that each vector corresponds too.
         """
-        return aa.ValuesIrregular(
+        return aa.ArrayIrregular(
             values=np.arctan2(self.slim[:, 0], self.slim[:, 1]) * 180.0 / np.pi / 2.0
         )
 

--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -70,5 +70,5 @@ the intensity versus radius in 1D).
 
    Mask1D
    Array1D
-   ValuesIrregular
+   ArrayIrregular
    Grid1D

--- a/docs/overview/overview_3_modeling.rst
+++ b/docs/overview/overview_3_modeling.rst
@@ -291,7 +291,7 @@ plotted.
 
 .. code-block:: python
 
-    plane_plotter = aplt.PlanePlotter(plane=result.max_log_likelihood_plane, grid=mask.masked_grid)
+    plane_plotter = aplt.PlanePlotter(plane=result.max_log_likelihood_plane, grid=mask.derived_grids.masked_grid)
     plane_plotter.subplot_plane()
 
     fit_imaging_plotter = aplt.FitImagingPlotter(fit=result.max_log_likelihood_fit)

--- a/docs/overview/overview_3_modeling.rst
+++ b/docs/overview/overview_3_modeling.rst
@@ -291,7 +291,7 @@ plotted.
 
 .. code-block:: python
 
-    plane_plotter = aplt.PlanePlotter(plane=result.max_log_likelihood_plane, grid=mask.derived_grids.masked_grid)
+    plane_plotter = aplt.PlanePlotter(plane=result.max_log_likelihood_plane, grid=mask.derive_grid.masked)
     plane_plotter.subplot_plane()
 
     fit_imaging_plotter = aplt.FitImagingPlotter(fit=result.max_log_likelihood_fit)

--- a/test_autogalaxy/analysis/test_clump_model.py
+++ b/test_autogalaxy/analysis/test_clump_model.py
@@ -4,7 +4,7 @@ import autogalaxy as ag
 
 def test__clumps():
 
-    centres = ag.Grid2DIrregular(grid=[(1.0, 1.0)])
+    centres = ag.Grid2DIrregular(values=[(1.0, 1.0)])
 
     clump_model = ag.ClumpModel(
         redshift=0.5, centres=centres, light_cls=ag.lp.SersicSph
@@ -46,7 +46,7 @@ def test__clumps():
 
 def test__clumps_light_only():
 
-    centres = ag.Grid2DIrregular(grid=[(1.0, 1.0)])
+    centres = ag.Grid2DIrregular(values=[(1.0, 1.0)])
 
     clump_model = ag.ClumpModel(
         redshift=0.5,
@@ -65,7 +65,7 @@ def test__clumps_light_only():
 
 def test__clumps_mass_only():
 
-    centres = ag.Grid2DIrregular(grid=[(1.0, 1.0)])
+    centres = ag.Grid2DIrregular(values=[(1.0, 1.0)])
 
     clump_model = ag.ClumpModel(
         redshift=0.5,
@@ -84,7 +84,7 @@ def test__clumps_mass_only():
 
 def test__einstein_radius_max():
 
-    centres = ag.Grid2DIrregular(grid=[(1.0, 1.0)])
+    centres = ag.Grid2DIrregular(values=[(1.0, 1.0)])
 
     clump_model = ag.ClumpModel(
         redshift=0.5,

--- a/test_autogalaxy/galaxy/test_galaxy.py
+++ b/test_autogalaxy/galaxy/test_galaxy.py
@@ -694,7 +694,7 @@ def test__cannot_pass_light_or_mass_list():
 
 def test__decorator__grid_iterate_in__iterates_array_result_correctly(gal_x1_lp):
 
-    mask = ag.Mask2D.manual(
+    mask = ag.Mask2D(
         mask=[
             [True, True, True, True, True],
             [True, False, False, False, True],
@@ -742,7 +742,7 @@ def test__decorator__grid_iterate_in__iterates_array_result_correctly(gal_x1_lp)
 
 def test__decorator__grid_iterate_in__iterates_grid_result_correctly(gal_x1_mp):
 
-    mask = ag.Mask2D.manual(
+    mask = ag.Mask2D(
         mask=[
             [True, True, True, True, True],
             [True, False, False, False, True],

--- a/test_autogalaxy/galaxy/test_galaxy.py
+++ b/test_autogalaxy/galaxy/test_galaxy.py
@@ -35,7 +35,7 @@ def test__cls_list_from(lp_0, lp_linear_0):
 
 def test__image_1d_from(sub_grid_1d_7, lp_0, lp_1, gal_x2_lp):
 
-    grid = ag.Grid2D.without_mask(grid=[[[1.05, -0.55]]], pixel_scales=1.0)
+    grid = ag.Grid2D.no_mask(values=[[[1.05, -0.55]]], pixel_scales=1.0)
 
     lp_image = lp_0.image_1d_from(grid=grid)
     lp_image += lp_1.image_1d_from(grid=grid)
@@ -116,9 +116,7 @@ def test__luminosity_within_circle(lp_0, lp_1, gal_x2_lp):
 
 def test__convergence_1d_from(sub_grid_1d_7, mp_0, gal_x1_mp, mp_1, gal_x2_mp):
 
-    grid = ag.Grid2D.without_mask(
-        grid=[[[1.05, -0.55], [2.05, -0.55]]], pixel_scales=1.0
-    )
+    grid = ag.Grid2D.no_mask(values=[[[1.05, -0.55], [2.05, -0.55]]], pixel_scales=1.0)
 
     mp_convergence = mp_0.convergence_1d_from(grid=grid)
     mp_convergence += mp_1.convergence_1d_from(grid=grid)
@@ -129,9 +127,7 @@ def test__convergence_1d_from(sub_grid_1d_7, mp_0, gal_x1_mp, mp_1, gal_x2_mp):
 
     # Test explicitly for a profile with an offset centre and ellipticity, given the 1D to 2D projections are nasty.
 
-    grid = ag.Grid2D.without_mask(
-        grid=[[(1.05, -0.55), (2.05, -0.55)]], pixel_scales=1.0
-    )
+    grid = ag.Grid2D.no_mask(values=[[(1.05, -0.55), (2.05, -0.55)]], pixel_scales=1.0)
 
     elliptical_mp = ag.mp.Isothermal(
         centre=(0.5, 1.0), ell_comps=(0.2, 0.3), einstein_radius=1.0
@@ -173,7 +169,7 @@ def test__convergence_2d_from(sub_grid_2d_7x7, mp_0, gal_x1_mp, mp_1, gal_x2_mp)
 
 def test__potential_1d_from(sub_grid_1d_7, mp_0, gal_x1_mp, mp_1, gal_x2_mp):
 
-    grid = ag.Grid2D.without_mask(grid=[[[1.05, -0.55]]], pixel_scales=1.0)
+    grid = ag.Grid2D.no_mask(values=[[[1.05, -0.55]]], pixel_scales=1.0)
 
     mp_potential = mp_0.potential_1d_from(grid=grid)
     mp_potential += mp_1.potential_1d_from(grid=grid)
@@ -184,9 +180,7 @@ def test__potential_1d_from(sub_grid_1d_7, mp_0, gal_x1_mp, mp_1, gal_x2_mp):
 
     # Test explicitly for a profile with an offset centre and ellipticity, given the 1D to 2D projections are nasty.
 
-    grid = ag.Grid2D.without_mask(
-        grid=[[(1.05, -0.55), (2.05, -0.55)]], pixel_scales=1.0
-    )
+    grid = ag.Grid2D.no_mask(values=[[(1.05, -0.55), (2.05, -0.55)]], pixel_scales=1.0)
 
     elliptical_mp = ag.mp.Isothermal(
         centre=(0.5, 1.0), ell_comps=(0.2, 0.3), einstein_radius=1.0

--- a/test_autogalaxy/galaxy/test_galaxy.py
+++ b/test_autogalaxy/galaxy/test_galaxy.py
@@ -35,7 +35,7 @@ def test__cls_list_from(lp_0, lp_linear_0):
 
 def test__image_1d_from(sub_grid_1d_7, lp_0, lp_1, gal_x2_lp):
 
-    grid = ag.Grid2D.manual_native([[[1.05, -0.55]]], pixel_scales=1.0)
+    grid = ag.Grid2D.without_mask(grid=[[[1.05, -0.55]]], pixel_scales=1.0)
 
     lp_image = lp_0.image_1d_from(grid=grid)
     lp_image += lp_1.image_1d_from(grid=grid)
@@ -116,7 +116,9 @@ def test__luminosity_within_circle(lp_0, lp_1, gal_x2_lp):
 
 def test__convergence_1d_from(sub_grid_1d_7, mp_0, gal_x1_mp, mp_1, gal_x2_mp):
 
-    grid = ag.Grid2D.manual_native([[[1.05, -0.55], [2.05, -0.55]]], pixel_scales=1.0)
+    grid = ag.Grid2D.without_mask(
+        grid=[[[1.05, -0.55], [2.05, -0.55]]], pixel_scales=1.0
+    )
 
     mp_convergence = mp_0.convergence_1d_from(grid=grid)
     mp_convergence += mp_1.convergence_1d_from(grid=grid)
@@ -127,7 +129,9 @@ def test__convergence_1d_from(sub_grid_1d_7, mp_0, gal_x1_mp, mp_1, gal_x2_mp):
 
     # Test explicitly for a profile with an offset centre and ellipticity, given the 1D to 2D projections are nasty.
 
-    grid = ag.Grid2D.manual_native([[(1.05, -0.55), (2.05, -0.55)]], pixel_scales=1.0)
+    grid = ag.Grid2D.without_mask(
+        grid=[[(1.05, -0.55), (2.05, -0.55)]], pixel_scales=1.0
+    )
 
     elliptical_mp = ag.mp.Isothermal(
         centre=(0.5, 1.0), ell_comps=(0.2, 0.3), einstein_radius=1.0
@@ -169,7 +173,7 @@ def test__convergence_2d_from(sub_grid_2d_7x7, mp_0, gal_x1_mp, mp_1, gal_x2_mp)
 
 def test__potential_1d_from(sub_grid_1d_7, mp_0, gal_x1_mp, mp_1, gal_x2_mp):
 
-    grid = ag.Grid2D.manual_native([[[1.05, -0.55]]], pixel_scales=1.0)
+    grid = ag.Grid2D.without_mask(grid=[[[1.05, -0.55]]], pixel_scales=1.0)
 
     mp_potential = mp_0.potential_1d_from(grid=grid)
     mp_potential += mp_1.potential_1d_from(grid=grid)
@@ -180,7 +184,9 @@ def test__potential_1d_from(sub_grid_1d_7, mp_0, gal_x1_mp, mp_1, gal_x2_mp):
 
     # Test explicitly for a profile with an offset centre and ellipticity, given the 1D to 2D projections are nasty.
 
-    grid = ag.Grid2D.manual_native([[(1.05, -0.55), (2.05, -0.55)]], pixel_scales=1.0)
+    grid = ag.Grid2D.without_mask(
+        grid=[[(1.05, -0.55), (2.05, -0.55)]], pixel_scales=1.0
+    )
 
     elliptical_mp = ag.mp.Isothermal(
         centre=(0.5, 1.0), ell_comps=(0.2, 0.3), einstein_radius=1.0
@@ -269,8 +275,6 @@ def test__deflections_yx_2d_from(sub_grid_2d_7x7, gal_x2_mp):
 def test__no_mass_profile__quantities_returned_as_0s_of_shape_grid(
     sub_grid_2d_7x7, mp_0, gal_x1_mp, mp_1, gal_x2_mp
 ):
-
-    grid = ag.Grid2D.manual_native(grid=[[[1.05, -0.55]]], pixel_scales=1.0)
 
     galaxy = ag.Galaxy(redshift=0.5)
 

--- a/test_autogalaxy/imaging/test_fit_imaging.py
+++ b/test_autogalaxy/imaging/test_fit_imaging.py
@@ -560,11 +560,11 @@ def test___unmasked_blurred_images(masked_imaging_7x7):
 
 def test__subtracted_images_of_galaxies(masked_imaging_7x7_no_blur):
 
-    g0 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=np.ones(1)))
+    g0 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=np.ones(9)))
 
-    g1 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=2.0 * np.ones(1)))
+    g1 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=2.0 * np.ones(9)))
 
-    g2 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=3.0 * np.ones(1)))
+    g2 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=3.0 * np.ones(9)))
 
     plane = ag.Plane(redshift=0.5, galaxies=[g0, g1, g2])
 
@@ -576,19 +576,19 @@ def test__subtracted_images_of_galaxies(masked_imaging_7x7_no_blur):
     assert fit.subtracted_images_of_galaxies_list[1].slim[0] == -3.0 or np.nan
     assert fit.subtracted_images_of_galaxies_list[2].slim[0] == -2.0 or np.nan
 
-    g0 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=np.ones(1)))
-
-    g1 = ag.Galaxy(redshift=0.5)
-
-    g2 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=3.0 * np.ones(1)))
-
-    plane = ag.Plane(redshift=0.5, galaxies=[g0, g1, g2])
-
-    fit = ag.FitImaging(dataset=masked_imaging_7x7_no_blur, plane=plane)
-
-    assert fit.subtracted_images_of_galaxies_list[0].slim[0] == -2.0 or np.nan
-    assert fit.subtracted_images_of_galaxies_list[1].slim[0] == -3.0 or np.nan
-    assert fit.subtracted_images_of_galaxies_list[2].slim[0] == 0.0 or np.nan
+    # g0 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=np.ones(16)))
+    #
+    # g1 = ag.Galaxy(redshift=0.5)
+    #
+    # g2 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=3.0 * np.ones(16)))
+    #
+    # plane = ag.Plane(redshift=0.5, galaxies=[g0, g1, g2])
+    #
+    # fit = ag.FitImaging(dataset=masked_imaging_7x7_no_blur, plane=plane)
+    #
+    # assert fit.subtracted_images_of_galaxies_list[0].slim[0] == -2.0 or np.nan
+    # assert fit.subtracted_images_of_galaxies_list[1].slim[0] == -3.0 or np.nan
+    # assert fit.subtracted_images_of_galaxies_list[2].slim[0] == 0.0 or np.nan
 
 
 def test__light_profile_linear__intensity_dict(masked_imaging_7x7):

--- a/test_autogalaxy/imaging/test_fit_imaging.py
+++ b/test_autogalaxy/imaging/test_fit_imaging.py
@@ -570,9 +570,15 @@ def test__subtracted_images_of_galaxies(masked_imaging_7x7_no_blur):
 
     fit = ag.FitImaging(dataset=masked_imaging_7x7_no_blur, plane=plane)
 
-    assert fit.subtracted_images_of_galaxies_list[0].slim[0] == pytest.approx(0.520383, 1.0e-4)
-    assert fit.subtracted_images_of_galaxies_list[1].slim[0] == pytest.approx(0.360511, 1.0e-4)
-    assert fit.subtracted_images_of_galaxies_list[2].slim[0] == pytest.approx(0.840127, 1.0e-4)
+    assert fit.subtracted_images_of_galaxies_list[0].slim[0] == pytest.approx(
+        0.520383, 1.0e-4
+    )
+    assert fit.subtracted_images_of_galaxies_list[1].slim[0] == pytest.approx(
+        0.360511, 1.0e-4
+    )
+    assert fit.subtracted_images_of_galaxies_list[2].slim[0] == pytest.approx(
+        0.840127, 1.0e-4
+    )
 
 
 def test__light_profile_linear__intensity_dict(masked_imaging_7x7):

--- a/test_autogalaxy/imaging/test_fit_imaging.py
+++ b/test_autogalaxy/imaging/test_fit_imaging.py
@@ -560,35 +560,19 @@ def test___unmasked_blurred_images(masked_imaging_7x7):
 
 def test__subtracted_images_of_galaxies(masked_imaging_7x7_no_blur):
 
-    g0 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=np.ones(9)))
+    g0 = ag.Galaxy(redshift=0.5, bulge=ag.lp.Sersic(intensity=1.0))
 
-    g1 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=2.0 * np.ones(9)))
+    g1 = ag.Galaxy(redshift=0.5)
 
-    g2 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=3.0 * np.ones(9)))
+    g2 = ag.Galaxy(redshift=0.5, bulge=ag.lp.Sersic(intensity=3.0))
 
     plane = ag.Plane(redshift=0.5, galaxies=[g0, g1, g2])
 
     fit = ag.FitImaging(dataset=masked_imaging_7x7_no_blur, plane=plane)
 
-    fit.subtracted_images_of_galaxies_list  # This stops a nan from being computed in the assertion, which is weird.
-
-    assert fit.subtracted_images_of_galaxies_list[0].slim[0] == -4.0 or np.nan
-    assert fit.subtracted_images_of_galaxies_list[1].slim[0] == -3.0 or np.nan
-    assert fit.subtracted_images_of_galaxies_list[2].slim[0] == -2.0 or np.nan
-
-    # g0 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=np.ones(16)))
-    #
-    # g1 = ag.Galaxy(redshift=0.5)
-    #
-    # g2 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=3.0 * np.ones(16)))
-    #
-    # plane = ag.Plane(redshift=0.5, galaxies=[g0, g1, g2])
-    #
-    # fit = ag.FitImaging(dataset=masked_imaging_7x7_no_blur, plane=plane)
-    #
-    # assert fit.subtracted_images_of_galaxies_list[0].slim[0] == -2.0 or np.nan
-    # assert fit.subtracted_images_of_galaxies_list[1].slim[0] == -3.0 or np.nan
-    # assert fit.subtracted_images_of_galaxies_list[2].slim[0] == 0.0 or np.nan
+    assert fit.subtracted_images_of_galaxies_list[0].slim[0] == pytest.approx(0.520383, 1.0e-4)
+    assert fit.subtracted_images_of_galaxies_list[1].slim[0] == pytest.approx(0.360511, 1.0e-4)
+    assert fit.subtracted_images_of_galaxies_list[2].slim[0] == pytest.approx(0.840127, 1.0e-4)
 
 
 def test__light_profile_linear__intensity_dict(masked_imaging_7x7):

--- a/test_autogalaxy/imaging/test_imaging.py
+++ b/test_autogalaxy/imaging/test_imaging.py
@@ -127,7 +127,7 @@ def test__simulator__simulate_imaging_from_galaxy__source_galaxy__compare_to_ima
 
     grid = ag.Grid2D.uniform(shape_native=(11, 11), pixel_scales=0.2, sub_size=1)
 
-    psf = ag.Kernel2D.manual_native(array=[[1.0]], pixel_scales=0.2)
+    psf = ag.Kernel2D.without_mask(array=[[1.0]], pixel_scales=0.2)
 
     simulator = ag.SimulatorImaging(
         psf=psf,

--- a/test_autogalaxy/imaging/test_imaging.py
+++ b/test_autogalaxy/imaging/test_imaging.py
@@ -127,7 +127,7 @@ def test__simulator__simulate_imaging_from_galaxy__source_galaxy__compare_to_ima
 
     grid = ag.Grid2D.uniform(shape_native=(11, 11), pixel_scales=0.2, sub_size=1)
 
-    psf = ag.Kernel2D.without_mask(array=[[1.0]], pixel_scales=0.2)
+    psf = ag.Kernel2D.no_mask(values=[[1.0]], pixel_scales=0.2)
 
     simulator = ag.SimulatorImaging(
         psf=psf,

--- a/test_autogalaxy/interferometer/test_fit_interferometer.py
+++ b/test_autogalaxy/interferometer/test_fit_interferometer.py
@@ -6,20 +6,20 @@ import autogalaxy as ag
 
 def test__model_visibilities(interferometer_7):
 
-    g0 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=np.ones(2)))
+    g0 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=np.ones(9)))
     plane = ag.Plane(galaxies=[g0])
 
     fit = ag.FitInterferometer(dataset=interferometer_7, plane=plane)
 
     assert fit.model_visibilities.slim[0] == pytest.approx(
-        np.array([1.2933 + 0.2829j]), 1.0e-4
+        np.array([1.48496 + 0.0]), 1.0e-4
     )
-    assert fit.log_likelihood == pytest.approx(-27.06284, 1.0e-4)
+    assert fit.log_likelihood == pytest.approx(-34.16859, 1.0e-4)
 
 
 def test__noise_map__with_and_without_hyper_background(interferometer_7):
 
-    g0 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=np.ones(2)))
+    g0 = ag.Galaxy(redshift=0.5, bulge=ag.m.MockLightProfile(image_2d=np.ones(9)))
     plane = ag.Plane(galaxies=[g0])
 
     fit = ag.FitInterferometer(dataset=interferometer_7, plane=plane)
@@ -35,7 +35,7 @@ def test__noise_map__with_and_without_hyper_background(interferometer_7):
     )
 
     assert (fit.noise_map.slim == np.full(fill_value=3.0 + 3.0j, shape=(7,))).all()
-    assert fit.log_likelihood == pytest.approx(-30.24288, 1.0e-4)
+    assert fit.log_likelihood == pytest.approx(-33.40099, 1.0e-4)
 
 
 def test__fit_figure_of_merit(interferometer_7):

--- a/test_autogalaxy/interferometer/test_simulate_and_fit_interferometer.py
+++ b/test_autogalaxy/interferometer/test_simulate_and_fit_interferometer.py
@@ -51,7 +51,7 @@ def test__perfect_fit__chi_squared_0():
         uv_wavelengths_path=path.join(file_path, "uv_wavelengths.fits"),
     )
 
-    real_space_mask = ag.Mask2D.unmasked(
+    real_space_mask = ag.Mask2D.all_false(
         shape_native=(51, 51), pixel_scales=0.1, sub_size=2
     )
 

--- a/test_autogalaxy/operate/test_deflections.py
+++ b/test_autogalaxy/operate/test_deflections.py
@@ -57,7 +57,7 @@ def caustics_via_magnification_from(mass_profile, grid):
 
 def test__hessian_from():
 
-    grid = ag.Grid2DIrregular(grid=[(0.5, 0.5), (1.0, 1.0)])
+    grid = ag.Grid2DIrregular(values=[(0.5, 0.5), (1.0, 1.0)])
 
     sie = ag.mp.Isothermal(
         centre=(0.0, 0.0), ell_comps=(0.0, -0.111111), einstein_radius=2.0
@@ -70,7 +70,7 @@ def test__hessian_from():
     assert hessian_yx == pytest.approx(np.array([-1.388165, -0.694099]), 1.0e-4)
     assert hessian_xx == pytest.approx(np.array([1.3883824, 0.694127]), 1.0e-4)
 
-    grid = ag.Grid2DIrregular(grid=[(1.0, 0.0), (0.0, 1.0)])
+    grid = ag.Grid2DIrregular(values=[(1.0, 0.0), (0.0, 1.0)])
 
     hessian_yy, hessian_xy, hessian_yx, hessian_xx = sie.hessian_from(grid=grid)
 
@@ -84,7 +84,7 @@ def test__convergence_2d_via_hessian_from():
 
     buffer = 0.0001
     grid = ag.Grid2DIrregular(
-        grid=[(1.075, -0.125), (-0.875, -0.075), (-0.925, -0.075), (0.075, 0.925)]
+        values=[(1.075, -0.125), (-0.875, -0.075), (-0.925, -0.075), (0.075, 0.925)]
     )
 
     sis = ag.mp.Isothermal(
@@ -110,7 +110,7 @@ def test__convergence_2d_via_hessian_from():
 
 def test__magnification_2d_via_hessian_from():
 
-    grid = ag.Grid2DIrregular(grid=[(0.5, 0.5), (1.0, 1.0)])
+    grid = ag.Grid2DIrregular(values=[(0.5, 0.5), (1.0, 1.0)])
 
     sie = ag.mp.Isothermal(
         centre=(0.0, 0.0), ell_comps=(0.0, -0.111111), einstein_radius=2.0

--- a/test_autogalaxy/operate/test_deflections.py
+++ b/test_autogalaxy/operate/test_deflections.py
@@ -28,7 +28,7 @@ def critical_curve_via_magnification_from(mass_profile, grid):
         critical_curve = grid_scaled_2d_for_marching_squares_from(
             grid_pixels_2d=pixel_coord,
             shape_native=magnification.sub_shape_native,
-            mask=grid.mask
+            mask=grid.mask,
         )
 
         critical_curves.append(critical_curve)

--- a/test_autogalaxy/operate/test_image.py
+++ b/test_autogalaxy/operate/test_image.py
@@ -104,7 +104,7 @@ def test__unmasked_blurred_image_2d_from():
         pixel_scales=1.0,
     )
 
-    mask = ag.Mask2D.manual(
+    mask = ag.Mask2D(
         mask=[[True, True, True], [True, False, True], [True, True, True]],
         pixel_scales=1.0,
         sub_size=1,
@@ -253,7 +253,7 @@ def test__unmasked_blurred_image_2d_list_from():
         pixel_scales=1.0,
     )
 
-    mask = ag.Mask2D.manual(
+    mask = ag.Mask2D(
         mask=[[True, True, True], [True, False, True], [True, True, True]],
         pixel_scales=1.0,
         sub_size=1,

--- a/test_autogalaxy/operate/test_image.py
+++ b/test_autogalaxy/operate/test_image.py
@@ -99,7 +99,7 @@ def test__x1_plane__padded_image__compare_to_galaxy_images_using_padded_grid_sta
 
 def test__unmasked_blurred_image_2d_from():
 
-    psf = ag.Kernel2D.manual_native(
+    psf = ag.Kernel2D.without_mask(
         array=(np.array([[0.0, 3.0, 0.0], [0.0, 1.0, 2.0], [0.0, 0.0, 0.0]])),
         pixel_scales=1.0,
     )
@@ -248,7 +248,7 @@ def test__blurred_image_2d_list_from(
 
 
 def test__unmasked_blurred_image_2d_list_from():
-    psf = ag.Kernel2D.manual_native(
+    psf = ag.Kernel2D.without_mask(
         array=(np.array([[0.0, 3.0, 0.0], [0.0, 1.0, 2.0], [0.0, 0.0, 0.0]])),
         pixel_scales=1.0,
     )

--- a/test_autogalaxy/operate/test_image.py
+++ b/test_autogalaxy/operate/test_image.py
@@ -99,8 +99,8 @@ def test__x1_plane__padded_image__compare_to_galaxy_images_using_padded_grid_sta
 
 def test__unmasked_blurred_image_2d_from():
 
-    psf = ag.Kernel2D.without_mask(
-        array=(np.array([[0.0, 3.0, 0.0], [0.0, 1.0, 2.0], [0.0, 0.0, 0.0]])),
+    psf = ag.Kernel2D.no_mask(
+        values=(np.array([[0.0, 3.0, 0.0], [0.0, 1.0, 2.0], [0.0, 0.0, 0.0]])),
         pixel_scales=1.0,
     )
 
@@ -248,8 +248,8 @@ def test__blurred_image_2d_list_from(
 
 
 def test__unmasked_blurred_image_2d_list_from():
-    psf = ag.Kernel2D.without_mask(
-        array=(np.array([[0.0, 3.0, 0.0], [0.0, 1.0, 2.0], [0.0, 0.0, 0.0]])),
+    psf = ag.Kernel2D.no_mask(
+        values=(np.array([[0.0, 3.0, 0.0], [0.0, 1.0, 2.0], [0.0, 0.0, 0.0]])),
         pixel_scales=1.0,
     )
 

--- a/test_autogalaxy/plane/test_plane.py
+++ b/test_autogalaxy/plane/test_plane.py
@@ -698,7 +698,9 @@ def test__plane_image_2d_from(sub_grid_2d_7x7):
     plane = ag.Plane(galaxies=[galaxy], redshift=None)
 
     plane_image_from_func = ag.plane.plane.plane_util.plane_image_of_galaxies_from(
-        shape=(7, 7), grid=sub_grid_2d_7x7.mask.unmasked_grid_sub_1, galaxies=[galaxy]
+        shape=(7, 7),
+        grid=sub_grid_2d_7x7.mask.derived_grids.unmasked_sub_1,
+        galaxies=[galaxy],
     )
 
     plane_image_from_plane = plane.plane_image_2d_from(grid=sub_grid_2d_7x7)

--- a/test_autogalaxy/plane/test_plane.py
+++ b/test_autogalaxy/plane/test_plane.py
@@ -699,7 +699,7 @@ def test__plane_image_2d_from(sub_grid_2d_7x7):
 
     plane_image_from_func = ag.plane.plane.plane_util.plane_image_of_galaxies_from(
         shape=(7, 7),
-        grid=sub_grid_2d_7x7.mask.derived_grids.unmasked_sub_1,
+        grid=sub_grid_2d_7x7.mask.derive_grid.all_false_sub_1,
         galaxies=[galaxy],
     )
 
@@ -711,7 +711,7 @@ def test__plane_image_2d_from(sub_grid_2d_7x7):
     # -1.6, -0.8, 0.0, 0.8, 1.6. The origin -1.6, -1.6 of the model_galaxy means its brighest pixel should be
     # index 0 of the 1D grid and (0,0) of the 2d plane data.
 
-    mask = ag.Mask2D.unmasked(shape_native=(5, 5), pixel_scales=1.0, sub_size=1)
+    mask = ag.Mask2D.all_false(shape_native=(5, 5), pixel_scales=1.0, sub_size=1)
 
     grid = ag.Grid2D.from_mask(mask=mask)
 
@@ -932,7 +932,7 @@ def test__galaxy_redshifts_gives_list_of_redshifts():
 
 def test__grid_iterate_in__iterates_grid_correctly(gal_x1_lp):
 
-    mask = ag.Mask2D.manual(
+    mask = ag.Mask2D(
         mask=[
             [True, True, True, True, True],
             [True, False, False, False, True],
@@ -983,7 +983,7 @@ def test__grid_iterate_in__iterates_grid_correctly(gal_x1_lp):
 
 def test__grid_iterate_in__iterates_grid_result_correctly(gal_x1_mp):
 
-    mask = ag.Mask2D.manual(
+    mask = ag.Mask2D(
         mask=[
             [True, True, True, True, True],
             [True, False, False, False, True],

--- a/test_autogalaxy/plane/test_plane.py
+++ b/test_autogalaxy/plane/test_plane.py
@@ -473,8 +473,8 @@ def test__deflections_yx_2d_from(sub_grid_2d_7x7):
 
 def test__contribution_map_list():
 
-    hyper_model_image = ag.Array2D.without_mask([[2.0, 4.0, 10.0]], pixel_scales=1.0)
-    hyper_galaxy_image = ag.Array2D.without_mask([[1.0, 5.0, 8.0]], pixel_scales=1.0)
+    hyper_model_image = ag.Array2D.no_mask([[2.0, 4.0, 10.0]], pixel_scales=1.0)
+    hyper_galaxy_image = ag.Array2D.no_mask([[1.0, 5.0, 8.0]], pixel_scales=1.0)
 
     hyper_galaxy_0 = ag.HyperGalaxy(contribution_factor=5.0)
     hyper_galaxy_1 = ag.HyperGalaxy(contribution_factor=10.0)
@@ -523,8 +523,8 @@ def test__contribution_map_list():
 
     assert (sum(plane.contribution_map_list) == plane.contribution_map).all()
 
-    hyper_model_image = ag.Array2D.without_mask([[2.0, 4.0, 10.0]], pixel_scales=1.0)
-    hyper_galaxy_image = ag.Array2D.without_mask([[1.0, 5.0, 8.0]], pixel_scales=1.0)
+    hyper_model_image = ag.Array2D.no_mask([[2.0, 4.0, 10.0]], pixel_scales=1.0)
+    hyper_galaxy_image = ag.Array2D.no_mask([[1.0, 5.0, 8.0]], pixel_scales=1.0)
 
     hyper_galaxy = ag.HyperGalaxy(contribution_factor=5.0)
 
@@ -562,7 +562,7 @@ def test__contribution_map_list():
 
 
 def test__hyper_noise_map_list_from():
-    noise_map = ag.Array2D.without_mask(array=[[1.0, 2.0, 3.0]], pixel_scales=1.0)
+    noise_map = ag.Array2D.no_mask(values=[[1.0, 2.0, 3.0]], pixel_scales=1.0)
 
     hyper_galaxy_0 = ag.HyperGalaxy(
         contribution_factor=0.0, noise_factor=1.0, noise_power=1.0
@@ -571,15 +571,13 @@ def test__hyper_noise_map_list_from():
         contribution_factor=3.0, noise_factor=1.0, noise_power=2.0
     )
 
-    hyper_model_image = ag.Array2D.without_mask(
-        array=[[0.5, 1.0, 1.5]], pixel_scales=1.0
-    )
+    hyper_model_image = ag.Array2D.no_mask(values=[[0.5, 1.0, 1.5]], pixel_scales=1.0)
 
-    hyper_galaxy_image_0 = ag.Array2D.without_mask(
-        array=[[0.0, 1.0, 1.5]], pixel_scales=1.0
+    hyper_galaxy_image_0 = ag.Array2D.no_mask(
+        values=[[0.0, 1.0, 1.5]], pixel_scales=1.0
     )
-    hyper_galaxy_image_1 = ag.Array2D.without_mask(
-        array=[[1.0, 1.0, 1.5]], pixel_scales=1.0
+    hyper_galaxy_image_1 = ag.Array2D.no_mask(
+        values=[[1.0, 1.0, 1.5]], pixel_scales=1.0
     )
 
     galaxy_0 = ag.Galaxy(
@@ -605,14 +603,10 @@ def test__hyper_noise_map_list_from():
         np.array([0.73468, (2.0 * 0.75) ** 2.0, 3.0**2.0]), 1.0e-4
     )
 
-    noise_map = ag.Array2D.without_mask(array=[[5.0, 3.0, 1.0]], pixel_scales=1.0)
+    noise_map = ag.Array2D.no_mask(values=[[5.0, 3.0, 1.0]], pixel_scales=1.0)
 
-    hyper_model_image = ag.Array2D.without_mask(
-        array=[[2.0, 4.0, 10.0]], pixel_scales=1.0
-    )
-    hyper_galaxy_image = ag.Array2D.without_mask(
-        array=[[1.0, 5.0, 8.0]], pixel_scales=1.0
-    )
+    hyper_model_image = ag.Array2D.no_mask(values=[[2.0, 4.0, 10.0]], pixel_scales=1.0)
+    hyper_galaxy_image = ag.Array2D.no_mask(values=[[1.0, 5.0, 8.0]], pixel_scales=1.0)
 
     hyper_galaxy_0 = ag.HyperGalaxy(contribution_factor=5.0)
     hyper_galaxy_1 = ag.HyperGalaxy(contribution_factor=10.0)
@@ -682,7 +676,7 @@ def test__hyper_noise_map_list_from():
 
     # No Galaxies
 
-    noise_map = ag.Array2D.without_mask(array=[[5.0, 3.0, 1.0]], pixel_scales=1.0)
+    noise_map = ag.Array2D.no_mask(values=[[5.0, 3.0, 1.0]], pixel_scales=1.0)
 
     plane = ag.Plane(redshift=0.5, galaxies=[ag.Galaxy(redshift=0.5)])
     hyper_noise_map = plane.hyper_noise_map_from(noise_map=noise_map)

--- a/test_autogalaxy/plane/test_plane.py
+++ b/test_autogalaxy/plane/test_plane.py
@@ -473,8 +473,8 @@ def test__deflections_yx_2d_from(sub_grid_2d_7x7):
 
 def test__contribution_map_list():
 
-    hyper_model_image = ag.Array2D.manual_native([[2.0, 4.0, 10.0]], pixel_scales=1.0)
-    hyper_galaxy_image = ag.Array2D.manual_native([[1.0, 5.0, 8.0]], pixel_scales=1.0)
+    hyper_model_image = ag.Array2D.without_mask([[2.0, 4.0, 10.0]], pixel_scales=1.0)
+    hyper_galaxy_image = ag.Array2D.without_mask([[1.0, 5.0, 8.0]], pixel_scales=1.0)
 
     hyper_galaxy_0 = ag.HyperGalaxy(contribution_factor=5.0)
     hyper_galaxy_1 = ag.HyperGalaxy(contribution_factor=10.0)
@@ -523,8 +523,8 @@ def test__contribution_map_list():
 
     assert (sum(plane.contribution_map_list) == plane.contribution_map).all()
 
-    hyper_model_image = ag.Array2D.manual_native([[2.0, 4.0, 10.0]], pixel_scales=1.0)
-    hyper_galaxy_image = ag.Array2D.manual_native([[1.0, 5.0, 8.0]], pixel_scales=1.0)
+    hyper_model_image = ag.Array2D.without_mask([[2.0, 4.0, 10.0]], pixel_scales=1.0)
+    hyper_galaxy_image = ag.Array2D.without_mask([[1.0, 5.0, 8.0]], pixel_scales=1.0)
 
     hyper_galaxy = ag.HyperGalaxy(contribution_factor=5.0)
 
@@ -562,7 +562,7 @@ def test__contribution_map_list():
 
 
 def test__hyper_noise_map_list_from():
-    noise_map = ag.Array2D.manual_native(array=[[1.0, 2.0, 3.0]], pixel_scales=1.0)
+    noise_map = ag.Array2D.without_mask(array=[[1.0, 2.0, 3.0]], pixel_scales=1.0)
 
     hyper_galaxy_0 = ag.HyperGalaxy(
         contribution_factor=0.0, noise_factor=1.0, noise_power=1.0
@@ -571,14 +571,14 @@ def test__hyper_noise_map_list_from():
         contribution_factor=3.0, noise_factor=1.0, noise_power=2.0
     )
 
-    hyper_model_image = ag.Array2D.manual_native(
+    hyper_model_image = ag.Array2D.without_mask(
         array=[[0.5, 1.0, 1.5]], pixel_scales=1.0
     )
 
-    hyper_galaxy_image_0 = ag.Array2D.manual_native(
+    hyper_galaxy_image_0 = ag.Array2D.without_mask(
         array=[[0.0, 1.0, 1.5]], pixel_scales=1.0
     )
-    hyper_galaxy_image_1 = ag.Array2D.manual_native(
+    hyper_galaxy_image_1 = ag.Array2D.without_mask(
         array=[[1.0, 1.0, 1.5]], pixel_scales=1.0
     )
 
@@ -605,12 +605,12 @@ def test__hyper_noise_map_list_from():
         np.array([0.73468, (2.0 * 0.75) ** 2.0, 3.0**2.0]), 1.0e-4
     )
 
-    noise_map = ag.Array2D.manual_native(array=[[5.0, 3.0, 1.0]], pixel_scales=1.0)
+    noise_map = ag.Array2D.without_mask(array=[[5.0, 3.0, 1.0]], pixel_scales=1.0)
 
-    hyper_model_image = ag.Array2D.manual_native(
+    hyper_model_image = ag.Array2D.without_mask(
         array=[[2.0, 4.0, 10.0]], pixel_scales=1.0
     )
-    hyper_galaxy_image = ag.Array2D.manual_native(
+    hyper_galaxy_image = ag.Array2D.without_mask(
         array=[[1.0, 5.0, 8.0]], pixel_scales=1.0
     )
 
@@ -682,7 +682,7 @@ def test__hyper_noise_map_list_from():
 
     # No Galaxies
 
-    noise_map = ag.Array2D.manual_native(array=[[5.0, 3.0, 1.0]], pixel_scales=1.0)
+    noise_map = ag.Array2D.without_mask(array=[[5.0, 3.0, 1.0]], pixel_scales=1.0)
 
     plane = ag.Plane(redshift=0.5, galaxies=[ag.Galaxy(redshift=0.5)])
     hyper_noise_map = plane.hyper_noise_map_from(noise_map=noise_map)

--- a/test_autogalaxy/plot/mat_wrap/test_get_visuals.py
+++ b/test_autogalaxy/plot/mat_wrap/test_get_visuals.py
@@ -124,7 +124,9 @@ def test__2d__via_light_obj_from(lp_0, grid_2d_7x7):
 
     assert visuals_2d_via.origin.in_list == [(0.0, 0.0)]
     assert (visuals_2d_via.mask == grid_2d_7x7.mask).all()
-    assert (visuals_2d_via.border == grid_2d_7x7.mask.border_grid_sub_1.binned).all()
+    assert (
+        visuals_2d_via.border == grid_2d_7x7.mask.derived_grids.border_sub_1.binned
+    ).all()
     assert visuals_2d_via.light_profile_centres.in_list == [lp_0.centre]
     assert visuals_2d_via.vectors == 2
 
@@ -160,7 +162,9 @@ def test__2d__via_mass_obj(mp_0, grid_2d_7x7):
 
     assert visuals_2d_via.origin.in_list == [(0.0, 0.0)]
     assert (visuals_2d_via.mask == grid_2d_7x7.mask).all()
-    assert (visuals_2d_via.border == grid_2d_7x7.mask.border_grid_sub_1.binned).all()
+    assert (
+        visuals_2d_via.border == grid_2d_7x7.mask.derived_grids.border_sub_1.binned
+    ).all()
     assert visuals_2d_via.mass_profile_centres.in_list == [mp_0.centre]
     assert (
         visuals_2d_via.critical_curves[0]
@@ -208,7 +212,9 @@ def test__2d__via_light_mass_obj(gal_x1_lp_x1_mp, grid_2d_7x7):
 
     assert visuals_2d_via.origin.in_list == [(0.0, 0.0)]
     assert (visuals_2d_via.mask == grid_2d_7x7.mask).all()
-    assert (visuals_2d_via.border == grid_2d_7x7.mask.border_grid_sub_1.binned).all()
+    assert (
+        visuals_2d_via.border == grid_2d_7x7.mask.derived_grids.border_sub_1.binned
+    ).all()
     assert visuals_2d_via.light_profile_centres.in_list == [
         gal_x1_lp_x1_mp.light_profile_0.centre
     ]
@@ -264,7 +270,8 @@ def test__via_fit_imaging_from(fit_imaging_x2_galaxy_7x7, grid_2d_7x7):
     assert visuals_2d_via.origin == (1.0, 1.0)
     assert (visuals_2d_via.mask == fit_imaging_x2_galaxy_7x7.mask).all()
     assert (
-        visuals_2d_via.border == fit_imaging_x2_galaxy_7x7.mask.border_grid_sub_1.binned
+        visuals_2d_via.border
+        == fit_imaging_x2_galaxy_7x7.mask.derived_grids.border_sub_1.binned
     ).all()
     assert visuals_2d_via.light_profile_centres.in_list == [(0.0, 0.0), (0.0, 0.0)]
     assert visuals_2d_via.mass_profile_centres.in_list == [(0.0, 0.0)]

--- a/test_autogalaxy/plot/mat_wrap/test_get_visuals.py
+++ b/test_autogalaxy/plot/mat_wrap/test_get_visuals.py
@@ -125,7 +125,7 @@ def test__2d__via_light_obj_from(lp_0, grid_2d_7x7):
     assert visuals_2d_via.origin.in_list == [(0.0, 0.0)]
     assert (visuals_2d_via.mask == grid_2d_7x7.mask).all()
     assert (
-        visuals_2d_via.border == grid_2d_7x7.mask.derived_grids.border_sub_1.binned
+        visuals_2d_via.border == grid_2d_7x7.mask.derive_grid.border_sub_1.binned
     ).all()
     assert visuals_2d_via.light_profile_centres.in_list == [lp_0.centre]
     assert visuals_2d_via.vectors == 2
@@ -163,7 +163,7 @@ def test__2d__via_mass_obj(mp_0, grid_2d_7x7):
     assert visuals_2d_via.origin.in_list == [(0.0, 0.0)]
     assert (visuals_2d_via.mask == grid_2d_7x7.mask).all()
     assert (
-        visuals_2d_via.border == grid_2d_7x7.mask.derived_grids.border_sub_1.binned
+        visuals_2d_via.border == grid_2d_7x7.mask.derive_grid.border_sub_1.binned
     ).all()
     assert visuals_2d_via.mass_profile_centres.in_list == [mp_0.centre]
     assert (
@@ -213,7 +213,7 @@ def test__2d__via_light_mass_obj(gal_x1_lp_x1_mp, grid_2d_7x7):
     assert visuals_2d_via.origin.in_list == [(0.0, 0.0)]
     assert (visuals_2d_via.mask == grid_2d_7x7.mask).all()
     assert (
-        visuals_2d_via.border == grid_2d_7x7.mask.derived_grids.border_sub_1.binned
+        visuals_2d_via.border == grid_2d_7x7.mask.derive_grid.border_sub_1.binned
     ).all()
     assert visuals_2d_via.light_profile_centres.in_list == [
         gal_x1_lp_x1_mp.light_profile_0.centre
@@ -271,7 +271,7 @@ def test__via_fit_imaging_from(fit_imaging_x2_galaxy_7x7, grid_2d_7x7):
     assert (visuals_2d_via.mask == fit_imaging_x2_galaxy_7x7.mask).all()
     assert (
         visuals_2d_via.border
-        == fit_imaging_x2_galaxy_7x7.mask.derived_grids.border_sub_1.binned
+        == fit_imaging_x2_galaxy_7x7.mask.derive_grid.border_sub_1.binned
     ).all()
     assert visuals_2d_via.light_profile_centres.in_list == [(0.0, 0.0), (0.0, 0.0)]
     assert visuals_2d_via.mass_profile_centres.in_list == [(0.0, 0.0)]

--- a/test_autogalaxy/profiles/light/base/test_abstract.py
+++ b/test_autogalaxy/profiles/light/base/test_abstract.py
@@ -76,7 +76,7 @@ def test__image_1d_from__grid_2d_in__returns_1d_image_via_projected_quantities()
 
 
 def test__decorators__grid_iterate_in__iterates_grid_correctly():
-    mask = ag.Mask2D.manual(
+    mask = ag.Mask2D(
         mask=[
             [True, True, True, True, True],
             [True, False, False, False, True],

--- a/test_autogalaxy/profiles/mass/abstract/test_abstract.py
+++ b/test_autogalaxy/profiles/mass/abstract/test_abstract.py
@@ -498,7 +498,7 @@ def test__decorators__convergence_1d_from__grid_2d_in__returns_1d_image_via_proj
 
 def test__decorators__convergence_1d_from__grid_2d_irregular_in__returns_1d_quantities():
 
-    grid_2d = ag.Grid2DIrregular(grid=[[1.0, 1.0], [2.0, 2.0], [4.0, 4.0]])
+    grid_2d = ag.Grid2DIrregular(values=[[1.0, 1.0], [2.0, 2.0], [4.0, 4.0]])
 
     sie = ag.mp.Isothermal(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), einstein_radius=1.0)
 
@@ -521,7 +521,7 @@ def test__decorators__convergence_1d_from__grid_2d_irregular_in__returns_1d_quan
 
 def test__decorators__convergence_1d_from__grid_1d_in__returns_1d_quantities_via_projection():
 
-    grid_1d = ag.Grid1D.manual_native(grid=[1.0, 2.0, 3.0], pixel_scales=1.0)
+    grid_1d = ag.Grid1D.no_mask(values=[1.0, 2.0, 3.0], pixel_scales=1.0)
 
     sie = ag.mp.Isothermal(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), einstein_radius=1.0)
 

--- a/test_autogalaxy/profiles/mass/abstract/test_abstract.py
+++ b/test_autogalaxy/profiles/mass/abstract/test_abstract.py
@@ -574,7 +574,7 @@ def test__decorators__potential_1d_from__grid_2d_in__returns_1d_image_via_projec
 
 def test__decorators__grid_iterate_in__iterates_grid_result_correctly(gal_x1_mp):
 
-    mask = ag.Mask2D.manual(
+    mask = ag.Mask2D(
         mask=[
             [True, True, True, True, True],
             [True, False, False, False, True],

--- a/test_autogalaxy/profiles/mass/sheets/test_external_shear.py
+++ b/test_autogalaxy/profiles/mass/sheets/test_external_shear.py
@@ -18,8 +18,8 @@ def test__deflections_yx_2d_from():
     assert deflections[0, 1] == pytest.approx(-0.011895, 1e-3)
 
     deflections = shear.deflections_yx_2d_from(
-        grid=ag.Grid2D.manual_native(
-            [
+        grid=ag.Grid2D.without_mask(
+            grid=[
                 [[0.1625, 0.1625], [0.1625, 0.1625]],
                 [[0.1625, 0.1625], [0.1625, 0.1625]],
             ],
@@ -56,8 +56,8 @@ def test__convergence_returns_zeros():
     assert (convergence == np.array([0.0, 0.0, 0.0])).all()
 
     convergence = shear.convergence_2d_from(
-        grid=ag.Grid2D.manual_native(
-            [[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
+        grid=ag.Grid2D.without_mask(
+            grid=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
             sub_size=2,
             pixel_scales=(1.0, 1.0),
         )
@@ -85,8 +85,8 @@ def test__potential_returns_zeros():
     assert (potential == np.array([0.0, 0.0, 0.0])).all()
 
     potential = shear.potential_2d_from(
-        grid=ag.Grid2D.manual_native(
-            [[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
+        grid=ag.Grid2D.without_mask(
+            grid=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
             sub_size=2,
             pixel_scales=(1.0, 1.0),
         )

--- a/test_autogalaxy/profiles/mass/sheets/test_external_shear.py
+++ b/test_autogalaxy/profiles/mass/sheets/test_external_shear.py
@@ -18,8 +18,8 @@ def test__deflections_yx_2d_from():
     assert deflections[0, 1] == pytest.approx(-0.011895, 1e-3)
 
     deflections = shear.deflections_yx_2d_from(
-        grid=ag.Grid2D.without_mask(
-            grid=[
+        grid=ag.Grid2D.no_mask(
+            values=[
                 [[0.1625, 0.1625], [0.1625, 0.1625]],
                 [[0.1625, 0.1625], [0.1625, 0.1625]],
             ],
@@ -56,8 +56,8 @@ def test__convergence_returns_zeros():
     assert (convergence == np.array([0.0, 0.0, 0.0])).all()
 
     convergence = shear.convergence_2d_from(
-        grid=ag.Grid2D.without_mask(
-            grid=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
+        grid=ag.Grid2D.no_mask(
+            values=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
             sub_size=2,
             pixel_scales=(1.0, 1.0),
         )
@@ -85,8 +85,8 @@ def test__potential_returns_zeros():
     assert (potential == np.array([0.0, 0.0, 0.0])).all()
 
     potential = shear.potential_2d_from(
-        grid=ag.Grid2D.without_mask(
-            grid=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
+        grid=ag.Grid2D.no_mask(
+            values=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
             sub_size=2,
             pixel_scales=(1.0, 1.0),
         )

--- a/test_autogalaxy/profiles/mass/sheets/test_input_deflections.py
+++ b/test_autogalaxy/profiles/mass/sheets/test_input_deflections.py
@@ -9,13 +9,13 @@ grid = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [2.0, 4.0]])
 
 def test__deflections_yx_2d_from__grid_coordinates_overlap_image_grid_of_deflections():
 
-    deflections_y = ag.Array2D.without_mask(
-        array=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    deflections_y = ag.Array2D.no_mask(
+        values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
-    deflections_x = ag.Array2D.without_mask(
-        array=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    deflections_x = ag.Array2D.no_mask(
+        values=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
@@ -41,8 +41,8 @@ def test__deflections_yx_2d_from__grid_coordinates_overlap_image_grid_of_deflect
     assert deflections[:, 0] == pytest.approx(deflections_y, 1.0e-4)
     assert deflections[:, 1] == pytest.approx(deflections_x, 1.0e-4)
 
-    grid = ag.Grid2D.without_mask(
-        grid=np.array(
+    grid = ag.Grid2D.no_mask(
+        values=np.array(
             [
                 [0.1, 0.0],
                 [0.0, 0.0],
@@ -67,13 +67,13 @@ def test__deflections_yx_2d_from__grid_coordinates_overlap_image_grid_of_deflect
 
 def test__deflections_yx_2d_from__grid_coordinates_dont_overlap_image_grid_of_deflections__uses_interpolation():
 
-    deflections_y = ag.Array2D.without_mask(
-        array=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    deflections_y = ag.Array2D.no_mask(
+        values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
-    deflections_x = ag.Array2D.without_mask(
-        array=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    deflections_x = ag.Array2D.no_mask(
+        values=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
@@ -89,8 +89,8 @@ def test__deflections_yx_2d_from__grid_coordinates_dont_overlap_image_grid_of_de
         image_plane_grid=image_plane_grid,
     )
 
-    grid = ag.Grid2D.without_mask(
-        grid=np.array(
+    grid = ag.Grid2D.no_mask(
+        values=np.array(
             [
                 [0.05, 0.03],
                 [0.02, 0.01],
@@ -115,13 +115,13 @@ def test__deflections_yx_2d_from__grid_coordinates_dont_overlap_image_grid_of_de
 
 def test__deflections_yx_2d_from__preload_grid_deflections_used_if_preload_grid_input():
 
-    deflections_y = ag.Array2D.without_mask(
-        array=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    deflections_y = ag.Array2D.no_mask(
+        values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
-    deflections_x = ag.Array2D.without_mask(
-        array=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    deflections_x = ag.Array2D.no_mask(
+        values=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
@@ -131,8 +131,8 @@ def test__deflections_yx_2d_from__preload_grid_deflections_used_if_preload_grid_
         pixel_scales=deflections_y.pixel_scales,
     )
 
-    grid = ag.Grid2D.without_mask(
-        grid=np.array(
+    grid = ag.Grid2D.no_mask(
+        values=np.array(
             [
                 [0.05, 0.03],
                 [0.02, 0.01],
@@ -165,13 +165,13 @@ def test__deflections_yx_2d_from__preload_grid_deflections_used_if_preload_grid_
 
 def test__deflections_yx_2d_from__input_grid_extends_beyond_image_plane_grid__raises_exception():
 
-    deflections_y = ag.Array2D.without_mask(
-        array=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    deflections_y = ag.Array2D.no_mask(
+        values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
-    deflections_x = ag.Array2D.without_mask(
-        array=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    deflections_x = ag.Array2D.no_mask(
+        values=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
@@ -187,8 +187,8 @@ def test__deflections_yx_2d_from__input_grid_extends_beyond_image_plane_grid__ra
         image_plane_grid=image_plane_grid,
     )
 
-    grid = ag.Grid2D.without_mask(
-        grid=np.array(
+    grid = ag.Grid2D.no_mask(
+        values=np.array(
             [
                 [0.0999, 0.0],
                 [0.0, 0.0],
@@ -206,8 +206,8 @@ def test__deflections_yx_2d_from__input_grid_extends_beyond_image_plane_grid__ra
     )
     input_deflections.deflections_yx_2d_from(grid=grid)
 
-    grid = ag.Grid2D.without_mask(
-        grid=np.array(
+    grid = ag.Grid2D.no_mask(
+        values=np.array(
             [
                 [0.0, 0.0999],
                 [0.0, 0.0],
@@ -226,8 +226,8 @@ def test__deflections_yx_2d_from__input_grid_extends_beyond_image_plane_grid__ra
     input_deflections.deflections_yx_2d_from(grid=grid)
 
     with pytest.raises(exc.ProfileException):
-        grid = ag.Grid2D.without_mask(
-            grid=np.array(
+        grid = ag.Grid2D.no_mask(
+            values=np.array(
                 [
                     [0.11, 0.0],
                     [0.0, 0.0],
@@ -246,8 +246,8 @@ def test__deflections_yx_2d_from__input_grid_extends_beyond_image_plane_grid__ra
         input_deflections.deflections_yx_2d_from(grid=grid)
 
     with pytest.raises(exc.ProfileException):
-        grid = ag.Grid2D.without_mask(
-            grid=np.array(
+        grid = ag.Grid2D.no_mask(
+            values=np.array(
                 [
                     [0.0, 0.11],
                     [0.0, 0.0],
@@ -268,13 +268,13 @@ def test__deflections_yx_2d_from__input_grid_extends_beyond_image_plane_grid__ra
 
 def test__convergence_2d_from_potential_2d_from():
 
-    deflections_y = ag.Array2D.without_mask(
-        array=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    deflections_y = ag.Array2D.no_mask(
+        values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
-    deflections_x = ag.Array2D.without_mask(
-        array=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    deflections_x = ag.Array2D.no_mask(
+        values=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )

--- a/test_autogalaxy/profiles/mass/sheets/test_input_deflections.py
+++ b/test_autogalaxy/profiles/mass/sheets/test_input_deflections.py
@@ -9,13 +9,13 @@ grid = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [2.0, 4.0]])
 
 def test__deflections_yx_2d_from__grid_coordinates_overlap_image_grid_of_deflections():
 
-    deflections_y = ag.Array2D.manual_native(
-        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    deflections_y = ag.Array2D.without_mask(
+        array=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
-    deflections_x = ag.Array2D.manual_native(
-        [[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    deflections_x = ag.Array2D.without_mask(
+        array=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
@@ -41,39 +41,39 @@ def test__deflections_yx_2d_from__grid_coordinates_overlap_image_grid_of_deflect
     assert deflections[:, 0] == pytest.approx(deflections_y, 1.0e-4)
     assert deflections[:, 1] == pytest.approx(deflections_x, 1.0e-4)
 
-    grid = ag.Grid2D.manual_slim(
-        grid=np.array([[0.1, 0.0], [0.0, 0.0], [-0.1, -0.1]]),
+    grid = ag.Grid2D.without_mask(
+        grid=np.array(
+            [
+                [0.1, 0.0],
+                [0.0, 0.0],
+                [-0.1, -0.1],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+            ]
+        ),
         shape_native=deflections_y.shape_native,
         pixel_scales=deflections_y.pixel_scales,
     )
 
     deflections = input_deflections.deflections_yx_2d_from(grid=grid)
 
-    assert deflections[:, 0] == pytest.approx([2.0, 5.0, 7.0], 1.0e-4)
-    assert deflections[:, 1] == pytest.approx([8.0, 5.0, 3.0], 1.0e-4)
-
-    # input_deflections = ag.mp.InputDeflections(
-    #     deflections_y=deflections_y,
-    #     deflections_x=deflections_x,
-    #     image_plane_grid=image_plane_grid,
-    #     normalization_scale=2.0,
-    # )
-    #
-    # deflections = input_deflections.deflections_yx_2d_from(grid=grid)
-    #
-    # assert deflections[:, 0] == pytest.approx([4.0, 10.0, 14.0], 1.0e-4)
-    # assert deflections[:, 1] == pytest.approx([16.0, 10.0, 6.0], 1.0e-4)
+    assert deflections[0:3, 0] == pytest.approx([2.0, 5.0, 7.0], 1.0e-4)
+    assert deflections[0:3, 1] == pytest.approx([8.0, 5.0, 3.0], 1.0e-4)
 
 
 def test__deflections_yx_2d_from__grid_coordinates_dont_overlap_image_grid_of_deflections__uses_interpolation():
 
-    deflections_y = ag.Array2D.manual_native(
-        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    deflections_y = ag.Array2D.without_mask(
+        array=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
-    deflections_x = ag.Array2D.manual_native(
-        [[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    deflections_x = ag.Array2D.without_mask(
+        array=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
@@ -89,27 +89,39 @@ def test__deflections_yx_2d_from__grid_coordinates_dont_overlap_image_grid_of_de
         image_plane_grid=image_plane_grid,
     )
 
-    grid = ag.Grid2D.manual_slim(
-        grid=np.array([[0.05, 0.03], [0.02, 0.01], [-0.08, -0.04]]),
+    grid = ag.Grid2D.without_mask(
+        grid=np.array(
+            [
+                [0.05, 0.03],
+                [0.02, 0.01],
+                [-0.08, -0.04],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+            ]
+        ),
         shape_native=deflections_y.shape_native,
         pixel_scales=deflections_y.pixel_scales,
     )
 
     deflections = input_deflections.deflections_yx_2d_from(grid=grid)
 
-    assert deflections[:, 0] == pytest.approx([3.8, 4.5, 7.0], 1.0e-4)
-    assert deflections[:, 1] == pytest.approx([6.2, 5.5, 3.0], 1.0e-4)
+    assert deflections[0:3, 0] == pytest.approx([3.8, 4.5, 7.0], 1.0e-4)
+    assert deflections[0:3, 1] == pytest.approx([6.2, 5.5, 3.0], 1.0e-4)
 
 
 def test__deflections_yx_2d_from__preload_grid_deflections_used_if_preload_grid_input():
 
-    deflections_y = ag.Array2D.manual_native(
-        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    deflections_y = ag.Array2D.without_mask(
+        array=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
-    deflections_x = ag.Array2D.manual_native(
-        [[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    deflections_x = ag.Array2D.without_mask(
+        array=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
@@ -119,8 +131,20 @@ def test__deflections_yx_2d_from__preload_grid_deflections_used_if_preload_grid_
         pixel_scales=deflections_y.pixel_scales,
     )
 
-    grid = ag.Grid2D.manual_slim(
-        grid=np.array([[0.05, 0.03], [0.02, 0.01], [-0.08, -0.04]]),
+    grid = ag.Grid2D.without_mask(
+        grid=np.array(
+            [
+                [0.05, 0.03],
+                [0.02, 0.01],
+                [-0.08, -0.04],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+            ]
+        ),
         shape_native=deflections_y.shape_native,
         pixel_scales=deflections_y.pixel_scales,
     )
@@ -138,30 +162,16 @@ def test__deflections_yx_2d_from__preload_grid_deflections_used_if_preload_grid_
 
     assert (deflections == input_deflections.preload_deflections).all()
 
-    # input_deflections = ag.mp.InputDeflections(
-    #     deflections_y=deflections_y,
-    #     deflections_x=deflections_x,
-    #     image_plane_grid=image_plane_grid,
-    #     preload_grid=grid,
-    #     normalization_scale=2.0,
-    # )
-    #
-    # input_deflections.preload_deflections[0, 0] = 1.0
-    #
-    # deflections = input_deflections.deflections_yx_2d_from(grid=grid)
-    #
-    # assert (deflections == 2.0 * input_deflections.preload_deflections).all()
-
 
 def test__deflections_yx_2d_from__input_grid_extends_beyond_image_plane_grid__raises_exception():
 
-    deflections_y = ag.Array2D.manual_native(
-        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    deflections_y = ag.Array2D.without_mask(
+        array=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
-    deflections_x = ag.Array2D.manual_native(
-        [[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    deflections_x = ag.Array2D.without_mask(
+        array=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
@@ -177,46 +187,94 @@ def test__deflections_yx_2d_from__input_grid_extends_beyond_image_plane_grid__ra
         image_plane_grid=image_plane_grid,
     )
 
-    grid = ag.Grid2D.manual_slim(
-        grid=np.array([[0.0999, 0.0]]),
+    grid = ag.Grid2D.without_mask(
+        grid=np.array(
+            [
+                [0.0999, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+            ]
+        ),
         shape_native=deflections_y.shape_native,
         pixel_scales=deflections_y.pixel_scales,
     )
     input_deflections.deflections_yx_2d_from(grid=grid)
 
-    grid = ag.Grid2D.manual_slim(
-        grid=np.array([[0.0, 0.0999]]),
+    grid = ag.Grid2D.without_mask(
+        grid=np.array(
+            [
+                [0.0, 0.0999],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+                [0.0, 0.0],
+            ]
+        ),
         shape_native=deflections_y.shape_native,
         pixel_scales=deflections_y.pixel_scales,
     )
     input_deflections.deflections_yx_2d_from(grid=grid)
 
     with pytest.raises(exc.ProfileException):
-        grid = ag.Grid2D.manual_slim(
-            grid=np.array([[0.11, 0.0]]),
+        grid = ag.Grid2D.without_mask(
+            grid=np.array(
+                [
+                    [0.11, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                ]
+            ),
             shape_native=deflections_y.shape_native,
             pixel_scales=deflections_y.pixel_scales,
         )
         input_deflections.deflections_yx_2d_from(grid=grid)
 
-        with pytest.raises(exc.ProfileException):
-            grid = ag.Grid2D.manual_slim(
-                grid=np.array([[0.0, 0.11]]),
-                shape_native=deflections_y.shape_native,
-                pixel_scales=deflections_y.pixel_scales,
-            )
-            input_deflections.deflections_yx_2d_from(grid=grid)
+    with pytest.raises(exc.ProfileException):
+        grid = ag.Grid2D.without_mask(
+            grid=np.array(
+                [
+                    [0.0, 0.11],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                    [0.0, 0.0],
+                ]
+            ),
+            shape_native=deflections_y.shape_native,
+            pixel_scales=deflections_y.pixel_scales,
+        )
+        input_deflections.deflections_yx_2d_from(grid=grid)
 
 
 def test__convergence_2d_from_potential_2d_from():
 
-    deflections_y = ag.Array2D.manual_native(
-        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+    deflections_y = ag.Array2D.without_mask(
+        array=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )
-    deflections_x = ag.Array2D.manual_native(
-        [[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
+    deflections_x = ag.Array2D.without_mask(
+        array=[[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]],
         pixel_scales=0.1,
         origin=(0.0, 0.0),
     )

--- a/test_autogalaxy/profiles/mass/sheets/test_mass_sheet.py
+++ b/test_autogalaxy/profiles/mass/sheets/test_mass_sheet.py
@@ -91,8 +91,8 @@ def test__deflections_yx_2d_from():
     mass_sheet = ag.mp.MassSheet(centre=(0.0, 0.0), kappa=1.0)
 
     deflections = mass_sheet.deflections_yx_2d_from(
-        grid=ag.Grid2D.manual_native(
-            [[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
+        grid=ag.Grid2D.without_mask(
+            grid=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
             sub_size=2,
             pixel_scales=(1.0, 1.0),
         )
@@ -142,8 +142,8 @@ def test__convergence_2d_from():
     mass_sheet = ag.mp.MassSheet(centre=(0.0, 0.0), kappa=1.0)
 
     convergence = mass_sheet.convergence_2d_from(
-        grid=ag.Grid2D.manual_native(
-            [[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
+        grid=ag.Grid2D.without_mask(
+            grid=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
             sub_size=2,
             pixel_scales=(1.0, 1.0),
         )
@@ -173,8 +173,8 @@ def test__potential_2d_from():
     mass_sheet = ag.mp.MassSheet(centre=(0.0, 0.0), kappa=1.0)
 
     potential = mass_sheet.potential_2d_from(
-        grid=ag.Grid2D.manual_native(
-            [[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
+        grid=ag.Grid2D.without_mask(
+            grid=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
             sub_size=2,
             pixel_scales=(1.0, 1.0),
         )

--- a/test_autogalaxy/profiles/mass/sheets/test_mass_sheet.py
+++ b/test_autogalaxy/profiles/mass/sheets/test_mass_sheet.py
@@ -91,8 +91,8 @@ def test__deflections_yx_2d_from():
     mass_sheet = ag.mp.MassSheet(centre=(0.0, 0.0), kappa=1.0)
 
     deflections = mass_sheet.deflections_yx_2d_from(
-        grid=ag.Grid2D.without_mask(
-            grid=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
+        grid=ag.Grid2D.no_mask(
+            values=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
             sub_size=2,
             pixel_scales=(1.0, 1.0),
         )
@@ -142,8 +142,8 @@ def test__convergence_2d_from():
     mass_sheet = ag.mp.MassSheet(centre=(0.0, 0.0), kappa=1.0)
 
     convergence = mass_sheet.convergence_2d_from(
-        grid=ag.Grid2D.without_mask(
-            grid=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
+        grid=ag.Grid2D.no_mask(
+            values=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
             sub_size=2,
             pixel_scales=(1.0, 1.0),
         )
@@ -173,8 +173,8 @@ def test__potential_2d_from():
     mass_sheet = ag.mp.MassSheet(centre=(0.0, 0.0), kappa=1.0)
 
     potential = mass_sheet.potential_2d_from(
-        grid=ag.Grid2D.without_mask(
-            grid=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
+        grid=ag.Grid2D.no_mask(
+            values=[[[1.0, 0.0], [1.0, 0.0]], [[1.0, 0.0], [1.0, 0.0]]],
             sub_size=2,
             pixel_scales=(1.0, 1.0),
         )

--- a/test_autogalaxy/profiles/test_radial_minima.py
+++ b/test_autogalaxy/profiles/test_radial_minima.py
@@ -1,10 +1,8 @@
 from __future__ import division, print_function
 
 from os import path
-from autoconf import conf
 import autogalaxy as ag
 
-import numpy as np
 import pytest
 
 directory = path.dirname(path.realpath(__file__))
@@ -12,8 +10,8 @@ directory = path.dirname(path.realpath(__file__))
 
 def test__grid_2d__moves_radial_coordinates__does_not_double_transform():
 
-    grid_2d = ag.Grid2D.manual_native(grid=[[[0.0, 0.0]]], pixel_scales=1.0)
-    grid_2d_offset = ag.Grid2D.manual_native(grid=[[0.0001, 0.0001]], pixel_scales=1)
+    grid_2d = ag.Grid2D.without_mask(grid=[[[0.0, 0.0]]], pixel_scales=1.0)
+    grid_2d_offset = ag.Grid2D.without_mask(grid=[[[0.0001, 0.0001]]], pixel_scales=1)
 
     isothermal = ag.mp.Isothermal(centre=(0.0, 0.0), einstein_radius=1.0)
 
@@ -22,8 +20,8 @@ def test__grid_2d__moves_radial_coordinates__does_not_double_transform():
 
     assert convergence_0 == pytest.approx(convergence_1, 1.0e-8)
 
-    grid_2d = ag.Grid2D.manual_native(grid=[[[0.5, 0.5]]], pixel_scales=1.0)
-    grid_2d_offset = ag.Grid2D.manual_native(grid=[[0.5001, 0.5001]], pixel_scales=1)
+    grid_2d = ag.Grid2D.without_mask(grid=[[[0.5, 0.5]]], pixel_scales=1.0)
+    grid_2d_offset = ag.Grid2D.without_mask(grid=[[[0.5001, 0.5001]]], pixel_scales=1)
 
     isothermal = ag.mp.Isothermal(centre=(0.0, 0.0), einstein_radius=1.0)
 

--- a/test_autogalaxy/profiles/test_radial_minima.py
+++ b/test_autogalaxy/profiles/test_radial_minima.py
@@ -10,8 +10,8 @@ directory = path.dirname(path.realpath(__file__))
 
 def test__grid_2d__moves_radial_coordinates__does_not_double_transform():
 
-    grid_2d = ag.Grid2D.without_mask(grid=[[[0.0, 0.0]]], pixel_scales=1.0)
-    grid_2d_offset = ag.Grid2D.without_mask(grid=[[[0.0001, 0.0001]]], pixel_scales=1)
+    grid_2d = ag.Grid2D.no_mask(values=[[[0.0, 0.0]]], pixel_scales=1.0)
+    grid_2d_offset = ag.Grid2D.no_mask(values=[[[0.0001, 0.0001]]], pixel_scales=1)
 
     isothermal = ag.mp.Isothermal(centre=(0.0, 0.0), einstein_radius=1.0)
 
@@ -20,8 +20,8 @@ def test__grid_2d__moves_radial_coordinates__does_not_double_transform():
 
     assert convergence_0 == pytest.approx(convergence_1, 1.0e-8)
 
-    grid_2d = ag.Grid2D.without_mask(grid=[[[0.5, 0.5]]], pixel_scales=1.0)
-    grid_2d_offset = ag.Grid2D.without_mask(grid=[[[0.5001, 0.5001]]], pixel_scales=1)
+    grid_2d = ag.Grid2D.no_mask(values=[[[0.5, 0.5]]], pixel_scales=1.0)
+    grid_2d_offset = ag.Grid2D.no_mask(values=[[[0.5001, 0.5001]]], pixel_scales=1)
 
     isothermal = ag.mp.Isothermal(centre=(0.0, 0.0), einstein_radius=1.0)
 
@@ -40,8 +40,8 @@ def test__grid_2d__moves_radial_coordinates__does_not_double_transform():
 
 def test__grid_2d_irrergular__moves_radial_coordinates__does_not_double_transform():
 
-    grid_2d_irregular = ag.Grid2DIrregular(grid=[[0.0, 0.0]])
-    grid_2d_irregular_offset = ag.Grid2DIrregular(grid=[[0.0001, 0.0001]])
+    grid_2d_irregular = ag.Grid2DIrregular(values=[[0.0, 0.0]])
+    grid_2d_irregular_offset = ag.Grid2DIrregular(values=[[0.0001, 0.0001]])
 
     isothermal = ag.mp.Isothermal(centre=(0.0, 0.0), einstein_radius=1.0)
 
@@ -50,8 +50,8 @@ def test__grid_2d_irrergular__moves_radial_coordinates__does_not_double_transfor
 
     assert convergence_0 == pytest.approx(convergence_1, 1.0e-8)
 
-    grid_2d_irregular = ag.Grid2DIrregular(grid=[[0.5, 0.5]])
-    grid_2d_irregular_offset = ag.Grid2DIrregular(grid=[[0.5001, 0.5001]])
+    grid_2d_irregular = ag.Grid2DIrregular(values=[[0.5, 0.5]])
+    grid_2d_irregular_offset = ag.Grid2DIrregular(values=[[0.5001, 0.5001]])
 
     isothermal = ag.mp.Isothermal(centre=(0.0, 0.0), einstein_radius=1.0)
 

--- a/test_autogalaxy/quantity/test_dataset_quantity.py
+++ b/test_autogalaxy/quantity/test_dataset_quantity.py
@@ -7,9 +7,9 @@ from autogalaxy import exc
 
 def test_via_signal_to_noise_map(dataset_quantity_7x7_array_2d, sub_mask_2d_7x7):
 
-    data = ag.Array2D.without_mask(array=[[1.0, 2.0], [3.0, 4.0]], pixel_scales=1.0)
-    signal_to_noise_map = ag.Array2D.without_mask(
-        array=[[1.0, 5.0], [15.0, 40.0]], pixel_scales=1.0
+    data = ag.Array2D.no_mask(values=[[1.0, 2.0], [3.0, 4.0]], pixel_scales=1.0)
+    signal_to_noise_map = ag.Array2D.no_mask(
+        values=[[1.0, 5.0], [15.0, 40.0]], pixel_scales=1.0
     )
 
     dataset_quantity = ag.DatasetQuantity.via_signal_to_noise_map(
@@ -23,11 +23,11 @@ def test_via_signal_to_noise_map(dataset_quantity_7x7_array_2d, sub_mask_2d_7x7)
         np.array([[1.0, 0.4], [0.2, 0.1]]), 1.0e-4
     )
 
-    data = ag.VectorYX2D._manual_native(
-        vectors=[[[1.0, 1.0], [2.0, 2.0]], [[3.0, 3.0], [4.0, 4.0]]], pixel_scales=1.0
+    data = ag.VectorYX2D.no_mask(
+        values=[[[1.0, 1.0], [2.0, 2.0]], [[3.0, 3.0], [4.0, 4.0]]], pixel_scales=1.0
     )
-    signal_to_noise_map = ag.Array2D.without_mask(
-        array=[[1.0, 5.0], [15.0, 40.0]], pixel_scales=1.0
+    signal_to_noise_map = ag.Array2D.no_mask(
+        values=[[1.0, 5.0], [15.0, 40.0]], pixel_scales=1.0
     )
 
     dataset_quantity = ag.DatasetQuantity.via_signal_to_noise_map(
@@ -97,14 +97,14 @@ def test__grid(
 
 def test__vector_data__y_x():
 
-    data = ag.VectorYX2D._manual_native(
-        vectors=[[[1.0, 5.0], [2.0, 6.0]], [[3.0, 7.0], [4.0, 8.0]]],
+    data = ag.VectorYX2D.no_mask(
+        values=[[[1.0, 5.0], [2.0, 6.0]], [[3.0, 7.0], [4.0, 8.0]]],
         pixel_scales=1.0,
         sub_size=1,
     )
 
-    noise_map = ag.VectorYX2D._manual_native(
-        vectors=[[[1.1, 5.1], [2.1, 6.1]], [[3.1, 7.1], [4.1, 8.1]]],
+    noise_map = ag.VectorYX2D.no_mask(
+        values=[[[1.1, 5.1], [2.1, 6.1]], [[3.1, 7.1], [4.1, 8.1]]],
         pixel_scales=1.0,
         sub_size=1,
     )

--- a/test_autogalaxy/quantity/test_dataset_quantity.py
+++ b/test_autogalaxy/quantity/test_dataset_quantity.py
@@ -7,8 +7,8 @@ from autogalaxy import exc
 
 def test_via_signal_to_noise_map(dataset_quantity_7x7_array_2d, sub_mask_2d_7x7):
 
-    data = ag.Array2D.manual_native(array=[[1.0, 2.0], [3.0, 4.0]], pixel_scales=1.0)
-    signal_to_noise_map = ag.Array2D.manual_native(
+    data = ag.Array2D.without_mask(array=[[1.0, 2.0], [3.0, 4.0]], pixel_scales=1.0)
+    signal_to_noise_map = ag.Array2D.without_mask(
         array=[[1.0, 5.0], [15.0, 40.0]], pixel_scales=1.0
     )
 
@@ -23,10 +23,10 @@ def test_via_signal_to_noise_map(dataset_quantity_7x7_array_2d, sub_mask_2d_7x7)
         np.array([[1.0, 0.4], [0.2, 0.1]]), 1.0e-4
     )
 
-    data = ag.VectorYX2D.manual_native(
+    data = ag.VectorYX2D._manual_native(
         vectors=[[[1.0, 1.0], [2.0, 2.0]], [[3.0, 3.0], [4.0, 4.0]]], pixel_scales=1.0
     )
-    signal_to_noise_map = ag.Array2D.manual_native(
+    signal_to_noise_map = ag.Array2D.without_mask(
         array=[[1.0, 5.0], [15.0, 40.0]], pixel_scales=1.0
     )
 
@@ -97,13 +97,13 @@ def test__grid(
 
 def test__vector_data__y_x():
 
-    data = ag.VectorYX2D.manual_native(
+    data = ag.VectorYX2D._manual_native(
         vectors=[[[1.0, 5.0], [2.0, 6.0]], [[3.0, 7.0], [4.0, 8.0]]],
         pixel_scales=1.0,
         sub_size=1,
     )
 
-    noise_map = ag.VectorYX2D.manual_native(
+    noise_map = ag.VectorYX2D._manual_native(
         vectors=[[[1.1, 5.1], [2.1, 6.1]], [[3.1, 7.1], [4.1, 8.1]]],
         pixel_scales=1.0,
         sub_size=1,

--- a/test_autogalaxy/util/test_plane_util.py
+++ b/test_autogalaxy/util/test_plane_util.py
@@ -26,7 +26,7 @@ class TestPlaneImageFromGrid:
             mask=np.full(shape=(3, 3), fill_value=False), pixel_scales=1.0, sub_size=1
         )
 
-        grid = ag.Grid2D.manual_mask(
+        grid = ag.Grid2D(
             grid=np.array(
                 [
                     [-1.0, -1.0],
@@ -71,7 +71,7 @@ class TestPlaneImageFromGrid:
             mask=np.full(shape=(3, 3), fill_value=False), pixel_scales=1.0, sub_size=1
         )
 
-        grid = ag.Grid2D.manual_mask(
+        grid = ag.Grid2D(
             grid=np.array(
                 [
                     [-1.0, -1.0],
@@ -105,7 +105,7 @@ class TestPlaneImageFromGrid:
             mask=np.full(shape=(2, 3), fill_value=False), pixel_scales=1.0, sub_size=1
         )
 
-        grid = ag.Grid2D.manual_mask(
+        grid = ag.Grid2D(
             grid=np.array(
                 [
                     [-0.75, -1.0],
@@ -136,7 +136,7 @@ class TestPlaneImageFromGrid:
             mask=np.full(shape=(3, 2), fill_value=False), pixel_scales=1.0, sub_size=1
         )
 
-        grid = ag.Grid2D.manual_mask(
+        grid = ag.Grid2D(
             grid=np.array(
                 [
                     [-1.0, -0.75],
@@ -167,7 +167,7 @@ class TestPlaneImageFromGrid:
             mask=np.full(shape=(3, 3), fill_value=False), pixel_scales=1.0, sub_size=1
         )
 
-        grid = ag.Grid2D.manual_mask(
+        grid = ag.Grid2D(
             grid=np.array(
                 [
                     [-1.0, -1.0],

--- a/test_autogalaxy/util/test_plane_util.py
+++ b/test_autogalaxy/util/test_plane_util.py
@@ -22,7 +22,7 @@ class TestPlaneImageFromGrid:
             shape=(3, 3), grid=grid, galaxies=[galaxy], buffer=0.0
         )
 
-        mask = ag.Mask2D.manual(
+        mask = ag.Mask2D(
             mask=np.full(shape=(3, 3), fill_value=False), pixel_scales=1.0, sub_size=1
         )
 
@@ -67,7 +67,7 @@ class TestPlaneImageFromGrid:
             shape=(3, 3), grid=grid, galaxies=[galaxy], buffer=0.0
         )
 
-        mask = ag.Mask2D.manual(
+        mask = ag.Mask2D(
             mask=np.full(shape=(3, 3), fill_value=False), pixel_scales=1.0, sub_size=1
         )
 
@@ -101,7 +101,7 @@ class TestPlaneImageFromGrid:
             shape=(2, 3), grid=grid, galaxies=[galaxy], buffer=0.0
         )
 
-        mask = ag.Mask2D.manual(
+        mask = ag.Mask2D(
             mask=np.full(shape=(2, 3), fill_value=False), pixel_scales=1.0, sub_size=1
         )
 
@@ -132,7 +132,7 @@ class TestPlaneImageFromGrid:
             shape=(3, 2), grid=grid, galaxies=[galaxy], buffer=0.0
         )
 
-        mask = ag.Mask2D.manual(
+        mask = ag.Mask2D(
             mask=np.full(shape=(3, 2), fill_value=False), pixel_scales=1.0, sub_size=1
         )
 
@@ -163,7 +163,7 @@ class TestPlaneImageFromGrid:
             shape=(3, 3), grid=grid_without_buffer, galaxies=[galaxy], buffer=0.02
         )
 
-        mask = ag.Mask2D.manual(
+        mask = ag.Mask2D(
             mask=np.full(shape=(3, 3), fill_value=False), pixel_scales=1.0, sub_size=1
         )
 

--- a/test_autogalaxy/util/test_plane_util.py
+++ b/test_autogalaxy/util/test_plane_util.py
@@ -27,7 +27,7 @@ class TestPlaneImageFromGrid:
         )
 
         grid = ag.Grid2D(
-            grid=np.array(
+            values=np.array(
                 [
                     [-1.0, -1.0],
                     [-1.0, 0.0],
@@ -72,7 +72,7 @@ class TestPlaneImageFromGrid:
         )
 
         grid = ag.Grid2D(
-            grid=np.array(
+            values=np.array(
                 [
                     [-1.0, -1.0],
                     [-1.0, 0.0],
@@ -106,7 +106,7 @@ class TestPlaneImageFromGrid:
         )
 
         grid = ag.Grid2D(
-            grid=np.array(
+            values=np.array(
                 [
                     [-0.75, -1.0],
                     [-0.75, 0.0],
@@ -137,7 +137,7 @@ class TestPlaneImageFromGrid:
         )
 
         grid = ag.Grid2D(
-            grid=np.array(
+            values=np.array(
                 [
                     [-1.0, -0.75],
                     [-1.0, 0.75],
@@ -168,7 +168,7 @@ class TestPlaneImageFromGrid:
         )
 
         grid = ag.Grid2D(
-            grid=np.array(
+            values=np.array(
                 [
                     [-1.0, -1.0],
                     [-1.0, 0.0],

--- a/test_autogalaxy/util/test_shear_field.py
+++ b/test_autogalaxy/util/test_shear_field.py
@@ -13,20 +13,20 @@ def test__elliptical_properties_and_patches():
         pixel_scales=1.0,
     )
 
-    assert isinstance(vectors.ellipticities, ag.ValuesIrregular)
+    assert isinstance(vectors.ellipticities, ag.ArrayIrregular)
     assert vectors.ellipticities.in_list == [1.0, 1.0, np.sqrt(2.0), 0.0]
 
-    assert isinstance(vectors.semi_major_axes, ag.ValuesIrregular)
+    assert isinstance(vectors.semi_major_axes, ag.ArrayIrregular)
     assert vectors.semi_major_axes.in_list == pytest.approx(
         [6.0, 6.0, 7.242640, 3.0], 1.0e-4
     )
 
-    assert isinstance(vectors.semi_minor_axes, ag.ValuesIrregular)
+    assert isinstance(vectors.semi_minor_axes, ag.ArrayIrregular)
     assert vectors.semi_minor_axes.in_list == pytest.approx(
         [0.0, 0.0, -1.242640, 3.0], 1.0e-4
     )
 
-    assert isinstance(vectors.phis, ag.ValuesIrregular)
+    assert isinstance(vectors.phis, ag.ArrayIrregular)
     assert vectors.phis.in_list == pytest.approx([0.0, 45.0, 22.5, 0.0], 1.0e-4)
 
     assert isinstance(vectors.elliptical_patches[0], Ellipse)
@@ -40,20 +40,20 @@ def test__elliptical_properties_and_patches():
         grid=[[1.0, -1.0], [1.0, 1.0], [0.0, 0.0]],
     )
 
-    assert isinstance(vectors.ellipticities, ag.ValuesIrregular)
+    assert isinstance(vectors.ellipticities, ag.ArrayIrregular)
     assert vectors.ellipticities.in_list == [1.0, 1.0, np.sqrt(2.0)]
 
-    assert isinstance(vectors.semi_major_axes, ag.ValuesIrregular)
+    assert isinstance(vectors.semi_major_axes, ag.ArrayIrregular)
     assert vectors.semi_major_axes.in_list == pytest.approx(
         [6.0, 6.0, 7.242640], 1.0e-4
     )
 
-    assert isinstance(vectors.semi_minor_axes, ag.ValuesIrregular)
+    assert isinstance(vectors.semi_minor_axes, ag.ArrayIrregular)
     assert vectors.semi_minor_axes.in_list == pytest.approx(
         [0.0, 0.0, -1.242640], 1.0e-4
     )
 
-    assert isinstance(vectors.phis, ag.ValuesIrregular)
+    assert isinstance(vectors.phis, ag.ArrayIrregular)
     assert vectors.phis.in_list == pytest.approx([0.0, 45.0, 22.5], 1.0e-4)
 
     assert isinstance(vectors.elliptical_patches[0], Ellipse)

--- a/test_autogalaxy/util/test_shear_field.py
+++ b/test_autogalaxy/util/test_shear_field.py
@@ -7,7 +7,7 @@ import autogalaxy as ag
 
 def test__elliptical_properties_and_patches():
 
-    vectors = ag.ShearYX2D.manual_slim(
+    vectors = ag.ShearYX2D._manual_slim(
         vectors=[(0.0, 1.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)],
         shape_native=(2, 2),
         pixel_scales=1.0,

--- a/test_autogalaxy/util/test_shear_field.py
+++ b/test_autogalaxy/util/test_shear_field.py
@@ -7,8 +7,8 @@ import autogalaxy as ag
 
 def test__elliptical_properties_and_patches():
 
-    vectors = ag.ShearYX2D._manual_slim(
-        vectors=[(0.0, 1.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)],
+    vectors = ag.ShearYX2D.no_mask(
+        values=[(0.0, 1.0), (1.0, 0.0), (1.0, 1.0), (0.0, 0.0)],
         shape_native=(2, 2),
         pixel_scales=1.0,
     )
@@ -36,7 +36,7 @@ def test__elliptical_properties_and_patches():
     assert vectors.elliptical_patches[1].angle == pytest.approx(45.0, 1.0e-4)
 
     vectors = ag.ShearYX2DIrregular(
-        vectors=[(0.0, 1.0), (1.0, 0.0), (1.0, 1.0)],
+        values=[(0.0, 1.0), (1.0, 0.0), (1.0, 1.0)],
         grid=[[1.0, -1.0], [1.0, 1.0], [0.0, 0.0]],
     )
 


### PR DESCRIPTION
Data strutures (e.g. Array2D, Grid2D) no longer use the manual_slim and manual_native API for composition, usingh methods with more concise / intuitive names.