### PR TITLE
Feature/zeroth mesh edge

### DIFF
--- a/autogalaxy/config/notation.yaml
+++ b/autogalaxy/config/notation.yaml
@@ -51,6 +51,8 @@ label:
     truncation_radius: R_{\rm t}
     weight_floor: W_{\rm f}
     weight_power: W_{\rm p}
+    zeroth_coefficient: \lambda_{\rm 0}
+    zeroth_signal_scale: V
   superscript:
     ExternalShear: ext
     Mesh: mesh

--- a/autogalaxy/config/priors/regularization/adaptive_brightness_split_zeroth.yaml
+++ b/autogalaxy/config/priors/regularization/adaptive_brightness_split_zeroth.yaml
@@ -1,0 +1,51 @@
+AdaptiveBrightnessSplitZeroth:
+  zeroth_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    gaussian_limits:
+      lower: 0.0
+      upper: inf
+  zeroth_signal_scale:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    gaussian_limits:
+      lower: 0.0
+      upper: inf
+  inner_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    gaussian_limits:
+      lower: 0.0
+      upper: inf
+  outer_coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    gaussian_limits:
+      lower: 0.0
+      upper: inf
+  signal_scale:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    gaussian_limits:
+      lower: 0.0
+      upper: inf


### PR DESCRIPTION
An experimental regularization scheme which applies adaptive zeroth-order regularization to the exterior regions of a inversion mesh (e.g. the regions of the source-plane that dont contain the source).

If this works, we will want to adjust PyAutoFit to allow a galaxy object to have multiple regularization schemes, which each lead to the summation of their regularization matrices.