### PR TITLE
Feature/profiling lh

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -109,4 +109,4 @@ from autoconf import conf
 
 conf.instance.register(__file__)
 
-__version__ = "2023.3.27.1"
+__version__ = "2023.7.7.1"

--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -109,4 +109,4 @@ from autoconf import conf
 
 conf.instance.register(__file__)
 
-__version__ = "2023.7.7.1"
+__version__ = "2023.7.7.2"

--- a/autogalaxy/analysis/analysis.py
+++ b/autogalaxy/analysis/analysis.py
@@ -66,6 +66,129 @@ class Analysis(af.Analysis):
             )
         return Plane(galaxies=instance.galaxies, profiling_dict=profiling_dict)
 
+    @property
+    def fit_func(self) -> Callable:
+        raise NotImplementedError
+
+    def profile_log_likelihood_function(
+        self, instance: af.ModelInstance, paths: Optional[af.DirectoryPaths] = None
+    ) -> Tuple[Dict, Dict]:
+        """
+        This function is optionally called throughout a model-fit to profile the log likelihood function.
+
+        All function calls inside the `log_likelihood_function` that are decorated with the `profile_func` are timed
+        with their times stored in a dictionary called the `profiling_dict`.
+
+        An `info_dict` is also created which stores information on aspects of the model and dataset that dictate
+        run times, so the profiled times can be interpreted with this context.
+
+        The results of this profiling are then output to hard-disk in the `preloads` folder of the model-fit results,
+        which they can be inspected to ensure run-times are as expected.
+
+        Parameters
+        ----------
+        instance
+            An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
+            via a non-linear search).
+        paths
+            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            visualization and the pickled objects used by the aggregator output by this function.
+
+        Returns
+        -------
+        Two dictionaries, the profiling dictionary and info dictionary, which contain the profiling times of the
+        `log_likelihood_function` and information on the model and dataset used to perform the profiling.
+        """
+        profiling_dict = {}
+        info_dict = {}
+
+        repeats = conf.instance["general"]["profiling"]["repeats"]
+        info_dict["repeats"] = repeats
+
+        fit = self.fit_func(instance=instance)
+        fit.figure_of_merit
+
+        start = time.time()
+
+        for i in range(repeats):
+            try:
+                fit = self.fit_func(instance=instance)
+                fit.figure_of_merit
+            except Exception:
+                logger.info(
+                    "Profiling failed. Returning without outputting information."
+                )
+                return
+
+        fit_time = (time.time() - start) / repeats
+
+        profiling_dict["fit_time"] = fit_time
+
+        fit = self.fit_func(instance=instance, profiling_dict=profiling_dict)
+        fit.figure_of_merit
+
+        try:
+            info_dict["image_pixels"] = self.dataset.grid.sub_shape_slim
+            info_dict["sub_size_light_profiles"] = self.dataset.grid.sub_size
+        except AttributeError:
+            pass
+
+        if fit.model_obj.has(cls=aa.Pixelization):
+            info_dict["use_w_tilde"] = fit.inversion.settings.use_w_tilde
+            info_dict["sub_size_pixelization"] = self.dataset.grid_pixelization.sub_size
+            info_dict[
+                "use_positive_only_solver"
+            ] = fit.inversion.settings.use_positive_only_solver
+            info_dict[
+                "force_edge_pixels_to_zeros"
+            ] = fit.inversion.settings.force_edge_pixels_to_zeros
+            info_dict["use_w_tilde_numpy"] = fit.inversion.settings.use_w_tilde_numpy
+            info_dict["source_pixels"] = len(fit.inversion.reconstruction)
+
+            if hasattr(fit.inversion, "w_tilde"):
+                info_dict[
+                    "w_tilde_curvature_preload_size"
+                ] = fit.inversion.w_tilde.curvature_preload.shape[0]
+
+        self.output_profiling_info(
+            paths=paths, profiling_dict=profiling_dict, info_dict=info_dict
+        )
+
+        return profiling_dict, info_dict
+
+    def output_profiling_info(
+        self, paths: Optional[af.DirectoryPaths], profiling_dict: Dict, info_dict: Dict
+    ):
+        """
+        Output the log likelihood function profiling information to hard-disk as a json file.
+
+        This function is separate from the `profile_log_likelihood_function` function above such that it can be
+        called by children `Analysis` classes that profile additional aspects of the model-fit and therefore add
+        extra information to the `profiling_dict` and `info_dict`.
+
+        Parameters
+        ----------
+        paths
+            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            visualization and the pickled objects used by the aggregator output by this function.
+        profiling_dict
+            A dictionary containing the profiling times of the functions called by the `log_likelihood_function`.
+        info_dict
+            A dictionary containing information on the model and dataset used to perform the profiling, where these
+            settings typically control the overall run-time.
+        """
+
+        if paths is None:
+            return
+
+        os.makedirs(paths.profile_path, exist_ok=True)
+
+        with open(path.join(paths.profile_path, "profiling_dict.json"), "w+") as f:
+            json.dump(profiling_dict, f, indent=4)
+
+        with open(path.join(paths.profile_path, "info_dict.json"), "w+") as f:
+            json.dump(info_dict, f, indent=4)
+
 
 class AnalysisDataset(Analysis):
     def __init__(
@@ -425,123 +548,3 @@ class AnalysisDataset(Analysis):
                         f"Old Figure of Merit = {figure_of_merit_sanity}\n"
                         f"New Figure of Merit = {figure_of_merit}"
                     )
-
-    @property
-    def fit_func(self) -> Callable:
-        raise NotImplementedError
-
-    def profile_log_likelihood_function(
-        self, instance: af.ModelInstance, paths: Optional[af.DirectoryPaths] = None
-    ) -> Tuple[Dict, Dict]:
-        """
-        This function is optionally called throughout a model-fit to profile the log likelihood function.
-
-        All function calls inside the `log_likelihood_function` that are decorated with the `profile_func` are timed
-        with their times stored in a dictionary called the `profiling_dict`.
-
-        An `info_dict` is also created which stores information on aspects of the model and dataset that dictate
-        run times, so the profiled times can be interpreted with this context.
-
-        The results of this profiling are then output to hard-disk in the `preloads` folder of the model-fit results,
-        which they can be inspected to ensure run-times are as expected.
-
-        Parameters
-        ----------
-        instance
-            An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
-            via a non-linear search).
-        paths
-            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
-            visualization and the pickled objects used by the aggregator output by this function.
-
-        Returns
-        -------
-        Two dictionaries, the profiling dictionary and info dictionary, which contain the profiling times of the
-        `log_likelihood_function` and information on the model and dataset used to perform the profiling.
-        """
-        profiling_dict = {}
-        info_dict = {}
-
-        repeats = conf.instance["general"]["profiling"]["repeats"]
-        info_dict["repeats"] = repeats
-
-        fit = self.fit_func(instance=instance)
-        fit.figure_of_merit
-
-        start = time.time()
-
-        for i in range(repeats):
-            try:
-                fit = self.fit_func(instance=instance)
-                fit.figure_of_merit
-            except Exception:
-                logger.info(
-                    "Profiling failed. Returning without outputting information."
-                )
-                return
-
-        fit_time = (time.time() - start) / repeats
-
-        profiling_dict["fit_time"] = fit_time
-
-        fit = self.fit_func(instance=instance, profiling_dict=profiling_dict)
-        fit.figure_of_merit
-
-        info_dict["image_pixels"] = self.dataset.grid.sub_shape_slim
-        info_dict["sub_size_light_profiles"] = self.dataset.grid.sub_size
-
-        if fit.model_obj.has(cls=aa.Pixelization):
-            info_dict["use_w_tilde"] = fit.inversion.settings.use_w_tilde
-            info_dict["sub_size_pixelization"] = self.dataset.grid_pixelization.sub_size
-            info_dict[
-                "use_positive_only_solver"
-            ] = fit.inversion.settings.use_positive_only_solver
-            info_dict[
-                "force_edge_pixels_to_zeros"
-            ] = fit.inversion.settings.force_edge_pixels_to_zeros
-            info_dict["use_w_tilde_numpy"] = fit.inversion.settings.use_w_tilde_numpy
-            info_dict["source_pixels"] = len(fit.inversion.reconstruction)
-
-            if hasattr(fit.inversion, "w_tilde"):
-                info_dict[
-                    "w_tilde_curvature_preload_size"
-                ] = fit.inversion.w_tilde.curvature_preload.shape[0]
-
-        self.output_profiling_info(
-            paths=paths, profiling_dict=profiling_dict, info_dict=info_dict
-        )
-
-        return profiling_dict, info_dict
-
-    def output_profiling_info(
-        self, paths: Optional[af.DirectoryPaths], profiling_dict: Dict, info_dict: Dict
-    ):
-        """
-        Output the log likelihood function profiling information to hard-disk as a json file.
-
-        This function is separate from the `profile_log_likelihood_function` function above such that it can be
-        called by children `Analysis` classes that profile additional aspects of the model-fit and therefore add
-        extra information to the `profiling_dict` and `info_dict`.
-
-        Parameters
-        ----------
-        paths
-            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
-            visualization and the pickled objects used by the aggregator output by this function.
-        profiling_dict
-            A dictionary containing the profiling times of the functions called by the `log_likelihood_function`.
-        info_dict
-            A dictionary containing information on the model and dataset used to perform the profiling, where these
-            settings typically control the overall run-time.
-        """
-
-        if paths is None:
-            return
-
-        os.makedirs(paths.profile_path, exist_ok=True)
-
-        with open(path.join(paths.profile_path, "profiling_dict.json"), "w+") as f:
-            json.dump(profiling_dict, f, indent=4)
-
-        with open(path.join(paths.profile_path, "info_dict.json"), "w+") as f:
-            json.dump(info_dict, f, indent=4)

--- a/autogalaxy/analysis/analysis.py
+++ b/autogalaxy/analysis/analysis.py
@@ -1,9 +1,10 @@
 import json
 import logging
 import numpy as np
-from typing import Optional, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 from os import path
 import os
+import time
 
 from autoconf import conf
 import autofit as af
@@ -42,7 +43,7 @@ class Analysis(af.Analysis):
         """
         self.cosmology = cosmology
 
-    def plane_via_instance_from(self, instance: af.ModelInstance) -> Plane:
+    def plane_via_instance_from(self, instance: af.ModelInstance, profiling_dict: Optional[Dict] = None) -> Plane:
         """
         Create a `Plane` from the galaxies contained in a model instance.
 
@@ -57,8 +58,8 @@ class Analysis(af.Analysis):
         An instance of the Plane class that is used to then fit the dataset.
         """
         if hasattr(instance, "clumps"):
-            return Plane(galaxies=instance.galaxies + instance.clumps)
-        return Plane(galaxies=instance.galaxies)
+            return Plane(galaxies=instance.galaxies + instance.clumps, profiling_dict=profiling_dict)
+        return Plane(galaxies=instance.galaxies, profiling_dict=profiling_dict)
 
 
 class AnalysisDataset(Analysis):
@@ -421,5 +422,121 @@ class AnalysisDataset(Analysis):
                     )
 
     @property
-    def fit_func(self):
+    def fit_func(self) -> Callable:
         raise NotImplementedError
+
+    def profile_log_likelihood_function(
+        self, instance: af.ModelInstance, paths: Optional[af.DirectoryPaths] = None
+    ) -> Tuple[Dict, Dict]:
+        """
+        This function is optionally called throughout a model-fit to profile the log likelihood function.
+
+        All function calls inside the `log_likelihood_function` that are decorated with the `profile_func` are timed
+        with their times stored in a dictionary called the `profiling_dict`.
+
+        An `info_dict` is also created which stores information on aspects of the model and dataset that dictate
+        run times, so the profiled times can be interpreted with this context.
+
+        The results of this profiling are then output to hard-disk in the `preloads` folder of the model-fit results,
+        which they can be inspected to ensure run-times are as expected.
+
+        Parameters
+        ----------
+        instance
+            An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
+            via a non-linear search).
+        paths
+            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            visualization and the pickled objects used by the aggregator output by this function.
+
+        Returns
+        -------
+        Two dictionaries, the profiling dictionary and info dictionary, which contain the profiling times of the
+        `log_likelihood_function` and information on the model and dataset used to perform the profiling.
+        """
+        profiling_dict = {}
+        info_dict = {}
+
+        repeats = conf.instance["general"]["profiling"]["repeats"]
+        info_dict["repeats"] = repeats
+
+        fit = self.fit_func(instance=instance)
+        fit.figure_of_merit
+
+        start = time.time()
+
+        for i in range(repeats):
+            try:
+                fit = self.fit_func(instance=instance)
+                fit.figure_of_merit
+            except Exception:
+                logger.info(
+                    "Profiling failed. Returning without outputting information."
+                )
+                return
+
+        fit_time = (time.time() - start) / repeats
+
+        info_dict["fit_time"] = fit_time
+
+        fit = self.fit_func(instance=instance, profiling_dict=profiling_dict)
+        fit.figure_of_merit
+
+        info_dict["image_pixels"] = self.dataset.grid.sub_shape_slim
+        info_dict["sub_size_light_profiles"] = self.dataset.grid.sub_size
+
+        if fit.model_obj.has(cls=aa.Pixelization):
+            info_dict["use_w_tilde"] = fit.inversion.settings.use_w_tilde
+            info_dict["sub_size_pixelization"] = self.dataset.grid_pixelization.sub_size
+            info_dict[
+                "use_positive_only_solver"
+            ] = fit.inversion.settings.use_positive_only_solver
+            info_dict[
+                "force_edge_pixels_to_zeros"
+            ] = fit.inversion.settings.force_edge_pixels_to_zeros
+            info_dict["use_w_tilde_numpy"] = fit.inversion.settings.use_w_tilde_numpy
+            info_dict["source_pixels"] = len(fit.inversion.reconstruction)
+
+            if hasattr(fit.inversion, "w_tilde"):
+                info_dict[
+                    "w_tilde_curvature_preload_size"
+                ] = fit.inversion.w_tilde.curvature_preload.shape[0]
+
+        self.output_profiling_info(
+            paths=paths, profiling_dict=profiling_dict, info_dict=info_dict
+        )
+
+        return profiling_dict, info_dict
+
+    def output_profiling_info(
+        self, paths: Optional[af.DirectoryPaths], profiling_dict: Dict, info_dict: Dict
+    ):
+        """
+        Output the log likelihood function profiling information to hard-disk as a json file.
+
+        This function is separate from the `profile_log_likelihood_function` function above such that it can be
+        called by children `Analysis` classes that profile additional aspects of the model-fit and therefore add
+        extra information to the `profiling_dict` and `info_dict`.
+
+        Parameters
+        ----------
+        paths
+            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            visualization and the pickled objects used by the aggregator output by this function.
+        profiling_dict
+            A dictionary containing the profiling times of the functions called by the `log_likelihood_function`.
+        info_dict
+            A dictionary containing information on the model and dataset used to perform the profiling, where these
+            settings typically control the overall run-time.
+        """
+
+        if paths is None:
+            return
+
+        os.makedirs(paths.profile_path, exist_ok=True)
+
+        with open(path.join(paths.profile_path, "profiling_dict.json"), "w+") as f:
+            json.dump(profiling_dict, f, indent=4)
+
+        with open(path.join(paths.profile_path, "info_dict.json"), "w+") as f:
+            json.dump(info_dict, f, indent=4)

--- a/autogalaxy/analysis/analysis.py
+++ b/autogalaxy/analysis/analysis.py
@@ -482,7 +482,7 @@ class AnalysisDataset(Analysis):
 
         fit_time = (time.time() - start) / repeats
 
-        info_dict["fit_time"] = fit_time
+        profiling_dict["fit_time"] = fit_time
 
         fit = self.fit_func(instance=instance, profiling_dict=profiling_dict)
         fit.figure_of_merit

--- a/autogalaxy/analysis/analysis.py
+++ b/autogalaxy/analysis/analysis.py
@@ -43,7 +43,9 @@ class Analysis(af.Analysis):
         """
         self.cosmology = cosmology
 
-    def plane_via_instance_from(self, instance: af.ModelInstance, profiling_dict: Optional[Dict] = None) -> Plane:
+    def plane_via_instance_from(
+        self, instance: af.ModelInstance, profiling_dict: Optional[Dict] = None
+    ) -> Plane:
         """
         Create a `Plane` from the galaxies contained in a model instance.
 
@@ -58,7 +60,10 @@ class Analysis(af.Analysis):
         An instance of the Plane class that is used to then fit the dataset.
         """
         if hasattr(instance, "clumps"):
-            return Plane(galaxies=instance.galaxies + instance.clumps, profiling_dict=profiling_dict)
+            return Plane(
+                galaxies=instance.galaxies + instance.clumps,
+                profiling_dict=profiling_dict,
+            )
         return Plane(galaxies=instance.galaxies, profiling_dict=profiling_dict)
 
 

--- a/autogalaxy/config/general.yaml
+++ b/autogalaxy/config/general.yaml
@@ -11,4 +11,4 @@ test:
   bypass_figure_of_merit_sanity: false
   check_preloads: false
   exception_override: false
-  preloads_check_threshold: 0.1     # If the figure of merit of a fit with and without preloads is greater than this threshold, the check preload test fails and an exception raised for a model-fit. 
+  preloads_check_threshold: 1.0     # If the figure of merit of a fit with and without preloads is greater than this threshold, the check preload test fails and an exception raised for a model-fit. 

--- a/autogalaxy/imaging/fit_imaging.py
+++ b/autogalaxy/imaging/fit_imaging.py
@@ -136,7 +136,6 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
 
     @property
     def plane_to_inversion(self) -> PlaneToInversion:
-
         return PlaneToInversion(
             plane=self.plane,
             dataset=self.dataset,
@@ -146,7 +145,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             preloads=self.preloads,
-            profiling_dict=self.profiling_dict
+            profiling_dict=self.profiling_dict,
         )
 
     @cached_property

--- a/autogalaxy/imaging/fit_imaging.py
+++ b/autogalaxy/imaging/fit_imaging.py
@@ -25,7 +25,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         settings_pixelization: aa.SettingsPixelization = aa.SettingsPixelization(),
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads: aa.Preloads = Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         Fits an imaging dataset using a `Plane` object.
@@ -65,7 +65,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         preloads
             Contains preloaded calculations (e.g. linear algebra matrices) which can skip certain calculations in
             the fit.
-        profiling_dict
+        run_time_dict
             A dictionary which if passed to the fit records how long fucntion calls which have the `profile_func`
             decorator take to run.
         """
@@ -75,7 +75,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
 
         super().__init__(
             dataset=dataset,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
         AbstractFitInversion.__init__(
             self=self, model_obj=plane, settings_inversion=settings_inversion
@@ -145,7 +145,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             preloads=self.preloads,
-            profiling_dict=self.profiling_dict,
+            run_time_dict=self.run_time_dict,
         )
 
     @cached_property
@@ -305,7 +305,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         -------
         A new fit which has used new preloads input into this function but the same dataset, plane and other settings.
         """
-        profiling_dict = {} if self.profiling_dict is not None else None
+        run_time_dict = {} if self.run_time_dict is not None else None
 
         settings_inversion = (
             self.settings_inversion
@@ -319,5 +319,5 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             settings_pixelization=self.settings_pixelization,
             settings_inversion=settings_inversion,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )

--- a/autogalaxy/imaging/fit_imaging.py
+++ b/autogalaxy/imaging/fit_imaging.py
@@ -136,6 +136,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
 
     @property
     def plane_to_inversion(self) -> PlaneToInversion:
+
         return PlaneToInversion(
             plane=self.plane,
             dataset=self.dataset,
@@ -145,6 +146,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             preloads=self.preloads,
+            profiling_dict=self.profiling_dict
         )
 
     @cached_property

--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -176,7 +176,9 @@ class AnalysisImaging(AnalysisDataset):
         """
         instance = self.instance_with_associated_adapt_images_from(instance=instance)
 
-        plane = self.plane_via_instance_from(instance=instance, profiling_dict=profiling_dict)
+        plane = self.plane_via_instance_from(
+            instance=instance, profiling_dict=profiling_dict
+        )
 
         return self.fit_imaging_via_plane_from(
             plane=plane,
@@ -436,6 +438,8 @@ class AnalysisImaging(AnalysisDataset):
 
         info_dict["psf_shape_2d"] = self.dataset.psf.shape_native
 
-        self.output_profiling_info(paths=paths, profiling_dict=profiling_dict, info_dict=info_dict)
+        self.output_profiling_info(
+            paths=paths, profiling_dict=profiling_dict, info_dict=info_dict
+        )
 
         return profiling_dict, info_dict

--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -151,7 +151,7 @@ class AnalysisImaging(AnalysisDataset):
         self,
         instance: af.ModelInstance,
         preload_overwrite: Optional[Preloads] = None,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ) -> FitImaging:
         """
         Given a model instance create a `FitImaging` object.
@@ -166,7 +166,7 @@ class AnalysisImaging(AnalysisDataset):
             via a non-linear search).
         preload_overwrite
             If a `Preload` object is input this is used instead of the preloads stored as an attribute in the analysis.
-        profiling_dict
+        run_time_dict
             A dictionary which times functions called to fit the model to data, for profiling.
 
         Returns
@@ -177,20 +177,20 @@ class AnalysisImaging(AnalysisDataset):
         instance = self.instance_with_associated_adapt_images_from(instance=instance)
 
         plane = self.plane_via_instance_from(
-            instance=instance, profiling_dict=profiling_dict
+            instance=instance, run_time_dict=run_time_dict
         )
 
         return self.fit_imaging_via_plane_from(
             plane=plane,
             preload_overwrite=preload_overwrite,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     def fit_imaging_via_plane_from(
         self,
         plane: Plane,
         preload_overwrite: Optional[Preloads] = None,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ) -> FitImaging:
         """
         Given a `Plane`, which the analysis constructs from a model instance, create a `FitImaging` object.
@@ -204,7 +204,7 @@ class AnalysisImaging(AnalysisDataset):
             The plane of galaxies whose model images are used to fit the imaging data.
         preload_overwrite
             If a `Preload` object is input this is used instead of the preloads stored as an attribute in the analysis.
-        profiling_dict
+        run_time_dict
             A dictionary which times functions called to fit the model to data, for profiling.
 
         Returns
@@ -221,7 +221,7 @@ class AnalysisImaging(AnalysisDataset):
             settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     @property
@@ -410,7 +410,7 @@ class AnalysisImaging(AnalysisDataset):
         This function is optionally called throughout a model-fit to profile the log likelihood function.
 
         All function calls inside the `log_likelihood_function` that are decorated with the `profile_func` are timed
-        with their times stored in a dictionary called the `profiling_dict`.
+        with their times stored in a dictionary called the `run_time_dict`.
 
         An `info_dict` is also created which stores information on aspects of the model and dataset that dictate
         run times, so the profiled times can be interpreted with this context.
@@ -432,14 +432,14 @@ class AnalysisImaging(AnalysisDataset):
         Two dictionaries, the profiling dictionary and info dictionary, which contain the profiling times of the
         `log_likelihood_function` and information on the model and dataset used to perform the profiling.
         """
-        profiling_dict, info_dict = super().profile_log_likelihood_function(
+        run_time_dict, info_dict = super().profile_log_likelihood_function(
             instance=instance,
         )
 
         info_dict["psf_shape_2d"] = self.dataset.psf.shape_native
 
         self.output_profiling_info(
-            paths=paths, profiling_dict=profiling_dict, info_dict=info_dict
+            paths=paths, run_time_dict=run_time_dict, info_dict=info_dict
         )
 
-        return profiling_dict, info_dict
+        return run_time_dict, info_dict

--- a/autogalaxy/interferometer/fit_interferometer.py
+++ b/autogalaxy/interferometer/fit_interferometer.py
@@ -20,7 +20,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         settings_pixelization: aa.SettingsPixelization = aa.SettingsPixelization(),
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads: aa.Preloads = Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         Fits an interferometer dataset using a `Plane` object.
@@ -61,7 +61,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         preloads
             Contains preloaded calculations (e.g. linear algebra matrices) which can skip certain calculations in
             the fit.
-        profiling_dict
+        run_time_dict
             A dictionary which if passed to the fit records how long fucntion calls which have the `profile_func`
             decorator take to run.
         """
@@ -72,7 +72,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
             settings_inversion.use_w_tilde = False
 
         super().__init__(
-            dataset=dataset, use_mask_in_fit=False, profiling_dict=profiling_dict
+            dataset=dataset, use_mask_in_fit=False, run_time_dict=run_time_dict
         )
         AbstractFitInversion.__init__(
             self=self, model_obj=plane, settings_inversion=settings_inversion
@@ -241,10 +241,10 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         -------
         A new fit which has used new preloads input into this function but the same dataset, plane and other settings.
         """
-        if self.profiling_dict is not None:
-            profiling_dict = {}
+        if self.run_time_dict is not None:
+            run_time_dict = {}
         else:
-            profiling_dict = None
+            run_time_dict = None
 
         if settings_inversion is None:
             settings_inversion = self.settings_inversion
@@ -255,5 +255,5 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
             settings_pixelization=self.settings_pixelization,
             settings_inversion=settings_inversion,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )

--- a/autogalaxy/interferometer/model/analysis.py
+++ b/autogalaxy/interferometer/model/analysis.py
@@ -1,7 +1,6 @@
 import logging
 import numpy as np
-import os
-from typing import Optional
+from typing import Dict, Optional, Tuple
 
 import autofit as af
 import autoarray as aa
@@ -15,7 +14,6 @@ from autogalaxy.cosmology.wrap import Planck15
 from autogalaxy.interferometer.model.result import ResultInterferometer
 from autogalaxy.interferometer.model.visualizer import VisualizerInterferometer
 from autogalaxy.interferometer.fit_interferometer import FitInterferometer
-from autogalaxy.galaxy.galaxy import Galaxy
 from autogalaxy.plane.plane import Plane
 
 from autogalaxy import exc
@@ -161,7 +159,7 @@ class AnalysisInterferometer(AnalysisDataset):
     def fit_interferometer_via_instance_from(
         self,
         instance: af.ModelInstance,
-        preload_overwrite: Optional[Preloads] = None,
+        profiling_dict: Optional[Dict] = None,
     ) -> FitInterferometer:
         """
         Given a model instance create a `FitInterferometer` object.
@@ -186,16 +184,19 @@ class AnalysisInterferometer(AnalysisDataset):
         """
         instance = self.instance_with_associated_adapt_images_from(instance=instance)
 
-        plane = self.plane_via_instance_from(instance=instance)
+        plane = self.plane_via_instance_from(
+            instance=instance, profiling_dict=profiling_dict
+        )
 
         return self.fit_interferometer_via_plane_from(
-            plane=plane,
+            plane=plane, profiling_dict=profiling_dict
         )
 
     def fit_interferometer_via_plane_from(
         self,
         plane: Plane,
         preload_overwrite: Optional[Preloads] = None,
+        profiling_dict: Optional[Dict] = None,
     ) -> FitInterferometer:
         """
         Given a `Plane`, which the analysis constructs from a model instance, create a `FitInterferometer` object.
@@ -222,6 +223,7 @@ class AnalysisInterferometer(AnalysisDataset):
             settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             preloads=preloads,
+            profiling_dict=profiling_dict,
         )
 
     @property
@@ -407,3 +409,45 @@ class AnalysisInterferometer(AnalysisDataset):
 
         paths.save_object("uv_wavelengths", self.dataset.uv_wavelengths)
         paths.save_object("real_space_mask", self.dataset.real_space_mask)
+
+    def profile_log_likelihood_function(
+        self, instance: af.ModelInstance, paths: Optional[af.DirectoryPaths] = None
+    ) -> Tuple[Dict, Dict]:
+        """
+        This function is optionally called throughout a model-fit to profile the log likelihood function.
+
+        All function calls inside the `log_likelihood_function` that are decorated with the `profile_func` are timed
+        with their times stored in a dictionary called the `profiling_dict`.
+
+        An `info_dict` is also created which stores information on aspects of the model and dataset that dictate
+        run times, so the profiled times can be interpreted with this context.
+
+        The results of this profiling are then output to hard-disk in the `preloads` folder of the model-fit results,
+        which they can be inspected to ensure run-times are as expected.
+
+        Parameters
+        ----------
+        instance
+            An instance of the model that is being fitted to the data by this analysis (whose parameters have been set
+            via a non-linear search).
+        paths
+            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            visualization and the pickled objects used by the aggregator output by this function.
+
+        Returns
+        -------
+        Two dictionaries, the profiling dictionary and info dictionary, which contain the profiling times of the
+        `log_likelihood_function` and information on the model and dataset used to perform the profiling.
+        """
+        profiling_dict, info_dict = super().profile_log_likelihood_function(
+            instance=instance,
+        )
+
+        info_dict["number_of_visibilities"] = self.dataset.visibilities.shape[0]
+        info_dict["transformer_cls"] = self.dataset.transformer.__class__.__name__
+
+        self.output_profiling_info(
+            paths=paths, profiling_dict=profiling_dict, info_dict=info_dict
+        )
+
+        return profiling_dict, info_dict

--- a/autogalaxy/interferometer/model/analysis.py
+++ b/autogalaxy/interferometer/model/analysis.py
@@ -159,7 +159,7 @@ class AnalysisInterferometer(AnalysisDataset):
     def fit_interferometer_via_instance_from(
         self,
         instance: af.ModelInstance,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ) -> FitInterferometer:
         """
         Given a model instance create a `FitInterferometer` object.
@@ -174,7 +174,7 @@ class AnalysisInterferometer(AnalysisDataset):
             via a non-linear search).
         preload_overwrite
             If a `Preload` object is input this is used instead of the preloads stored as an attribute in the analysis.
-        profiling_dict
+        run_time_dict
             A dictionary which times functions called to fit the model to data, for profiling.
 
         Returns
@@ -185,18 +185,18 @@ class AnalysisInterferometer(AnalysisDataset):
         instance = self.instance_with_associated_adapt_images_from(instance=instance)
 
         plane = self.plane_via_instance_from(
-            instance=instance, profiling_dict=profiling_dict
+            instance=instance, run_time_dict=run_time_dict
         )
 
         return self.fit_interferometer_via_plane_from(
-            plane=plane, profiling_dict=profiling_dict
+            plane=plane, run_time_dict=run_time_dict
         )
 
     def fit_interferometer_via_plane_from(
         self,
         plane: Plane,
         preload_overwrite: Optional[Preloads] = None,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ) -> FitInterferometer:
         """
         Given a `Plane`, which the analysis constructs from a model instance, create a `FitInterferometer` object.
@@ -223,7 +223,7 @@ class AnalysisInterferometer(AnalysisDataset):
             settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
     @property
@@ -417,7 +417,7 @@ class AnalysisInterferometer(AnalysisDataset):
         This function is optionally called throughout a model-fit to profile the log likelihood function.
 
         All function calls inside the `log_likelihood_function` that are decorated with the `profile_func` are timed
-        with their times stored in a dictionary called the `profiling_dict`.
+        with their times stored in a dictionary called the `run_time_dict`.
 
         An `info_dict` is also created which stores information on aspects of the model and dataset that dictate
         run times, so the profiled times can be interpreted with this context.
@@ -439,7 +439,7 @@ class AnalysisInterferometer(AnalysisDataset):
         Two dictionaries, the profiling dictionary and info dictionary, which contain the profiling times of the
         `log_likelihood_function` and information on the model and dataset used to perform the profiling.
         """
-        profiling_dict, info_dict = super().profile_log_likelihood_function(
+        run_time_dict, info_dict = super().profile_log_likelihood_function(
             instance=instance,
         )
 
@@ -447,7 +447,7 @@ class AnalysisInterferometer(AnalysisDataset):
         info_dict["transformer_cls"] = self.dataset.transformer.__class__.__name__
 
         self.output_profiling_info(
-            paths=paths, profiling_dict=profiling_dict, info_dict=info_dict
+            paths=paths, run_time_dict=run_time_dict, info_dict=info_dict
         )
 
-        return profiling_dict, info_dict
+        return run_time_dict, info_dict

--- a/autogalaxy/interferometer/plot/fit_interferometer_plotters.py
+++ b/autogalaxy/interferometer/plot/fit_interferometer_plotters.py
@@ -1,3 +1,4 @@
+import autoarray as aa
 import autoarray.plot as aplt
 
 from autoarray.fit.plot.fit_interferometer_plotters import FitInterferometerPlotterMeta
@@ -184,14 +185,14 @@ class FitInterferometerPlotter(Plotter):
         Depending on whether `LightProfile`'s or an `Inversion` are used to represent galaxies in the `Plane`, different
         methods are called to create these real-space images.
         """
-        if self.fit.inversion is None:
+        if not self.plane.has(cls=aa.Pixelization):
             plane_plotter = self.plane_plotter_from(plane=self.plane)
 
             plane_plotter.subplot(
                 image=True, plane_image=True, auto_filename="subplot_fit_real_space"
             )
 
-        elif self.fit.inversion is not None:
+        elif self.plane.has(cls=aa.Pixelization):
             self.open_subplot_figure(number_subplots=6)
 
             mapper_index = 0

--- a/autogalaxy/operate/image.py
+++ b/autogalaxy/operate/image.py
@@ -29,6 +29,7 @@ class OperateImage:
     def has(self, cls) -> bool:
         raise NotImplementedError
 
+    @aa.profile_func
     def _blurred_image_2d_from(
         self,
         image_2d: aa.Array2D,
@@ -168,6 +169,7 @@ class OperateImage:
 
         return padded_image_2d + padded_image_2d_operated.binned
 
+    @aa.profile_func
     def visibilities_from(
         self, grid: aa.Grid2D, transformer: aa.type.Transformer
     ) -> aa.Visibilities:

--- a/autogalaxy/plane/plane.py
+++ b/autogalaxy/plane/plane.py
@@ -1,6 +1,6 @@
 import json
 import numpy as np
-from typing import Dict, List, Optional, Tuple, Type
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 import autoarray as aa
 
@@ -67,7 +67,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
     def galaxy_redshifts(self) -> List[float]:
         return [galaxy.redshift for galaxy in self.galaxies]
 
-    def has(self, cls: Tuple[Type]) -> bool:
+    def has(self, cls: Union[Type, Tuple[Type]]) -> bool:
         if self.galaxies is not None:
             return any(list(map(lambda galaxy: galaxy.has(cls=cls), self.galaxies)))
         return False

--- a/autogalaxy/plane/plane.py
+++ b/autogalaxy/plane/plane.py
@@ -23,7 +23,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
         self,
         galaxies,
         redshift: Optional[float] = None,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         """
         A plane of galaxies where all galaxies are at the same redshift.
@@ -52,7 +52,7 @@ class Plane(OperateImageGalaxies, OperateDeflections, Dictable):
         self.redshift = redshift
         self.galaxies = galaxies
 
-        self.profiling_dict = profiling_dict
+        self.run_time_dict = run_time_dict
 
     def dict(self) -> Dict:
         plane_dict = super().dict()

--- a/autogalaxy/plane/plane_util.py
+++ b/autogalaxy/plane/plane_util.py
@@ -209,7 +209,7 @@ def galaxies_in_redshift_ordered_planes_from(galaxies, plane_redshifts):
     return galaxies_in_redshift_ordered_planes
 
 
-def planes_via_galaxies_from(galaxies, profiling_dict=None, plane_cls=Plane):
+def planes_via_galaxies_from(galaxies, run_time_dict=None, plane_cls=Plane):
     plane_redshifts = ordered_plane_redshifts_from(galaxies=galaxies)
 
     galaxies_in_planes = galaxies_in_redshift_ordered_planes_from(
@@ -221,7 +221,7 @@ def planes_via_galaxies_from(galaxies, profiling_dict=None, plane_cls=Plane):
     for plane_index in range(0, len(plane_redshifts)):
         planes.append(
             plane_cls(
-                galaxies=galaxies_in_planes[plane_index], profiling_dict=profiling_dict
+                galaxies=galaxies_in_planes[plane_index], run_time_dict=run_time_dict
             )
         )
 

--- a/autogalaxy/plane/plot/plane_plotters.py
+++ b/autogalaxy/plane/plot/plane_plotters.py
@@ -133,7 +133,7 @@ class PlanePlotter(Plotter):
         zoom_to_brightest: bool = True,
         title_suffix: str = "",
         filename_suffix: str = "",
-        source_plane_title : bool = False,
+        source_plane_title: bool = False,
     ):
         """
         Plots the individual attributes of the plotter's `Plane` object in 2D, which are computed via the plotter's 2D
@@ -180,7 +180,6 @@ class PlanePlotter(Plotter):
             )
 
         if plane_image:
-
             if source_plane_title:
                 title = "Source Plane Image"
             else:
@@ -198,7 +197,6 @@ class PlanePlotter(Plotter):
             )
 
         if plane_grid:
-
             if source_plane_title:
                 title = "Source Plane Grid"
             else:

--- a/autogalaxy/plane/plot/plane_plotters.py
+++ b/autogalaxy/plane/plot/plane_plotters.py
@@ -133,6 +133,7 @@ class PlanePlotter(Plotter):
         zoom_to_brightest: bool = True,
         title_suffix: str = "",
         filename_suffix: str = "",
+        source_plane_title : bool = False,
     ):
         """
         Plots the individual attributes of the plotter's `Plane` object in 2D, which are computed via the plotter's 2D
@@ -166,6 +167,8 @@ class PlanePlotter(Plotter):
             Add a suffix to the end of the matplotlib title label.
         filename_suffix
             Add a suffix to the end of the filename the plot is saved to hard-disk using.
+        source_plane_title
+            If `True`, the title of the plot is overwritten to read "source-plane image".
         """
         if image:
             self.mat_plot_2d.plot_array(
@@ -177,18 +180,11 @@ class PlanePlotter(Plotter):
             )
 
         if plane_image:
-            import numpy as np
 
-            # print(self.plane.galaxies[0].bulge)
-            # print(self.plane.galaxies[0].bulge.intensity)
-            #
-            # print(self.plane.plane_image_2d_from(
-            #         grid=self.grid, zoom_to_brightest=zoom_to_brightest
-            #     ))
-            # print(np.max(self.plane.plane_image_2d_from(
-            #         grid=self.grid, zoom_to_brightest=zoom_to_brightest
-            #     )))
-            # www
+            if source_plane_title:
+                title = "Source Plane Image"
+            else:
+                title = f"Plane Image{title_suffix}"
 
             self.mat_plot_2d.plot_array(
                 array=self.plane.plane_image_2d_from(
@@ -196,17 +192,23 @@ class PlanePlotter(Plotter):
                 ),
                 visuals_2d=self.get_visuals_2d(),
                 auto_labels=aplt.AutoLabels(
-                    title=f"Plane Image{title_suffix}",
+                    title=title,
                     filename=f"plane_image{filename_suffix}",
                 ),
             )
 
         if plane_grid:
+
+            if source_plane_title:
+                title = "Source Plane Grid"
+            else:
+                title = f"Plane Grid{title_suffix}"
+
             self.mat_plot_2d.plot_grid(
                 grid=self.grid,
                 visuals_2d=self.get_visuals_2d(),
                 auto_labels=aplt.AutoLabels(
-                    title=f"Plane Grid2D{title_suffix}",
+                    title=title,
                     filename=f"plane_grid{filename_suffix}",
                 ),
             )

--- a/autogalaxy/plane/to_inversion.py
+++ b/autogalaxy/plane/to_inversion.py
@@ -29,7 +29,7 @@ class AbstractToInversion:
         settings_pixelization=aa.SettingsPixelization(),
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads=Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         if dataset is not None:
             if dataset.noise_covariance_matrix is not None:
@@ -52,7 +52,7 @@ class AbstractToInversion:
         self.settings_inversion = settings_inversion
 
         self.preloads = preloads
-        self.profiling_dict = profiling_dict
+        self.run_time_dict = run_time_dict
 
     def cls_light_profile_func_list_galaxy_dict_from(
         self, cls: Type
@@ -102,7 +102,7 @@ class PlaneToInversion(AbstractToInversion):
         settings_pixelization=aa.SettingsPixelization(),
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads=aa.Preloads(),
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         self.plane = plane
 
@@ -114,7 +114,7 @@ class PlaneToInversion(AbstractToInversion):
             settings_pixelization=settings_pixelization,
             settings_inversion=settings_inversion,
             preloads=preloads,
-            profiling_dict=profiling_dict,
+            run_time_dict=run_time_dict,
         )
 
         if grid is not None:
@@ -223,7 +223,7 @@ class PlaneToInversion(AbstractToInversion):
             adapt_data=adapt_galaxy_image,
             settings=self.settings_pixelization,
             preloads=self.preloads,
-            profiling_dict=self.plane.profiling_dict,
+            run_time_dict=self.plane.run_time_dict,
         )
 
         return mapper_from(mapper_grids=mapper_grids, regularization=regularization)
@@ -268,7 +268,7 @@ class PlaneToInversion(AbstractToInversion):
             linear_obj_list=self.linear_obj_list,
             settings=self.settings_inversion,
             preloads=self.preloads,
-            profiling_dict=self.plane.profiling_dict,
+            run_time_dict=self.plane.run_time_dict,
         )
 
         inversion.linear_obj_galaxy_dict = self.linear_obj_galaxy_dict

--- a/autogalaxy/plane/to_inversion.py
+++ b/autogalaxy/plane/to_inversion.py
@@ -260,6 +260,7 @@ class PlaneToInversion(AbstractToInversion):
 
     @property
     def inversion(self) -> aa.AbstractInversion:
+
         inversion = inversion_unpacked_from(
             dataset=self.dataset,
             data=self.data,

--- a/autogalaxy/plane/to_inversion.py
+++ b/autogalaxy/plane/to_inversion.py
@@ -260,7 +260,6 @@ class PlaneToInversion(AbstractToInversion):
 
     @property
     def inversion(self) -> aa.AbstractInversion:
-
         inversion = inversion_unpacked_from(
             dataset=self.dataset,
             data=self.data,

--- a/autogalaxy/plot/mass_plotter.py
+++ b/autogalaxy/plot/mass_plotter.py
@@ -108,7 +108,7 @@ class MassPlotter(Plotter):
                 array=deflections_x,
                 visuals_2d=self.get_visuals_2d(),
                 auto_labels=aplt.AutoLabels(
-                    title=f"deflections X{title_suffix}",
+                    title=f"Deflections X{title_suffix}",
                     filename=f"deflections_x_2d{filename_suffix}",
                 ),
             )

--- a/autogalaxy/profiles/light/linear/abstract.py
+++ b/autogalaxy/profiles/light/linear/abstract.py
@@ -107,7 +107,7 @@ class LightProfileLinearObjFuncList(aa.AbstractLinearObjFuncList):
         convolver: Optional[aa.Convolver],
         light_profile_list: List[LightProfileLinear],
         regularization=aa.reg.Regularization,
-        profiling_dict: Optional[Dict] = None,
+        run_time_dict: Optional[Dict] = None,
     ):
         for light_profile in light_profile_list:
             if not isinstance(light_profile, LightProfileLinear):
@@ -121,7 +121,7 @@ class LightProfileLinearObjFuncList(aa.AbstractLinearObjFuncList):
                 )
 
         super().__init__(
-            grid=grid, regularization=regularization, profiling_dict=profiling_dict
+            grid=grid, regularization=regularization, run_time_dict=run_time_dict
         )
 
         self.blurring_grid = blurring_grid

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ irregulars. Today, by analysing millions of galaxies with advanced image process
 expanded on this picture and revealed the rich diversity of galaxy morphology both in the nearby and distant
 Universe.
 
-``PyAutoGalaxy`` is an open-source Python 3.8+ package for analysing the morphologies and structures of large
+``PyAutoGalaxy`` is an open-source Python 3.8 - 3.10 package for analysing the morphologies and structures of large
 multi-wavelength galaxy samples. **PyAutoGalaxy** makes it simple to model galaxies, for example this Hubble Space
 Telescope imaging of a spiral galaxy:
 

--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -47,7 +47,7 @@ You may get warnings which state something like:
 
 .. code-block:: bash
 
-    ERROR: autoarray 2022.2.14.1 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
+    ERROR: autoarray 2023.7.7.2 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
     ERROR: numba 0.53.1 has requirement llvmlite<0.37,>=0.36.0rc1, but you'll have llvmlite 0.38.0 which is incompatible.
 
 If you see these messages, they do not mean that the installation has failed and the instructions below will

--- a/docs/installation/overview.rst
+++ b/docs/installation/overview.rst
@@ -3,7 +3,7 @@
 Overview
 ========
 
-**PyAutoGalaxy** requires Python 3.8+ and support the Linux, MacOS and Windows operating systems.
+**PyAutoGalaxy** requires Python 3.8 - 3.10 and support the Linux, MacOS and Windows operating systems.
 
 **PyAutoGalaxy** can be installed via the Python distribution `Anaconda <https://www.anaconda.com/>`_ or using
 `PyPI <https://pypi.org/>`_ to ``pip install`` **PyAutoGalaxy** into your Python distribution.

--- a/docs/installation/pip.rst
+++ b/docs/installation/pip.rst
@@ -27,7 +27,7 @@ You may get warnings which state something like:
 
 .. code-block:: bash
 
-    ERROR: autoarray 2022.2.14.1 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
+    ERROR: autoarray 2023.7.7.2 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
     ERROR: numba 0.53.1 has requirement llvmlite<0.37,>=0.36.0rc1, but you'll have llvmlite 0.38.0 which is incompatible.
 
 If you see these messages, they do not mean that the installation has failed and the instructions below will

--- a/docs/installation/troubleshooting.rst
+++ b/docs/installation/troubleshooting.rst
@@ -14,42 +14,6 @@ the latest version of pip.
     pip install --upgrade pip
     pip3 install --upgrade pip
 
-NumPy / numba
--------------
-
-The libraries ``numpy`` and ``numba`` can be installed with incompatible versions.
-
-An error message like the one below occurs when importing **PyAutoGalaxy**:
-
-.. code-block:: bash
-
-    Traceback (most recent call last):
-      File "<stdin>", line 1, in <module>
-      File "/home/jammy/venvs/PyAutoMay2/lib/python3.8/site-packages/autolens/__init__.py", line 1, in <module>
-        from autoarray import preprocess
-      File "/home/jammy/venvs/PyAutoMay2/lib/python3.8/site-packages/autoarray/__init__.py", line 2, in <module>
-        from . import type
-      File "/home/jammy/venvs/PyAutoMay2/lib/python3.8/site-packages/autoarray/type.py", line 7, in <module>
-        from autoarray.mask.mask_1d import Mask1D
-      File "/home/jammy/venvs/PyAutoMay2/lib/python3.8/site-packages/autoarray/mask/mask_1d.py", line 8, in <module>
-        from autoarray.structures.arrays import array_1d_util
-      File "/home/jammy/venvs/PyAutoMay2/lib/python3.8/site-packages/autoarray/structures/arrays/array_1d_util.py", line 5, in <module>
-        from autoarray import numba_util
-      File "/home/jammy/venvs/PyAutoMay2/lib/python3.8/site-packages/autoarray/numba_util.py", line 2, in <module>
-        import numba
-      File "/home/jammy/venvs/PyAutoMay2/lib/python3.8/site-packages/numba/__init__.py", line 200, in <module>
-        _ensure_critical_deps()
-      File "/home/jammy/venvs/PyAutoMay2/lib/python3.8/site-packages/numba/__init__.py", line 140, in _ensure_critical_deps
-        raise ImportError("Numba needs NumPy 1.21 or less")
-    ImportError: Numba needs NumPy 1.21 or less
-
-This can be fixed by reinstalling numpy with the version requested by the error message, in the example
-numpy 1.21 (you should replace the ``==1.21.0`` with a different version if requested).
-
-.. code-block:: bash
-
-    pip install numpy==1.21.0
-
 Pip / Conda
 -----------
 
@@ -91,15 +55,15 @@ Matplotlib uses the default backend on your computer, as set in the config file:
 
 .. code-block:: bash
 
-    autogalaxy_workspace/config/visualize/generaltrue
+    autogalaxy_workspace/config/visualize/general.yaml
 
 If unchanged, the backend is set to 'default', meaning it will use the backend automatically set up for Python on
 your system.
 
 .. code-block:: bash
 
-    [general]
-    backend = default
+    general:
+      backend: default
 
 There have been reports that using the default backend causes crashes when running the test script below (either the
 code crashes without a error or your computer restarts). If this happens, change the config's backend until the test
@@ -107,5 +71,5 @@ works (TKAgg has worked on Linux machines, Qt5Agg has worked on new MACs). For e
 
 .. code-block:: bash
 
-    [general]
-    backend = TKAgg
+    general:
+      backend: TKAgg

--- a/docs/overview/overview_2_fitting.rst
+++ b/docs/overview/overview_2_fitting.rst
@@ -26,7 +26,7 @@ demonstrate fitting.
     )
 
     dataset_plotter = aplt.ImagingPlotter(dataset=dataset)
-    dataset_plotter.figures_2d(image=True, noise_map=True, psf=True)
+    dataset_plotter.figures_2d(data=True, noise_map=True, psf=True)
 
 Here's what our ``image``, ``noise_map`` and ``psf`` (point-spread function) look like:
 
@@ -58,7 +58,7 @@ To do this we can use a ``Mask2D`` object, which for this example we'll create a
     dataset = dataset.apply_mask(mask=mask)
 
     dataset_plotter = aplt.ImagingPlotter(dataset=dataset)
-    dataset_plotter.figures_2d(image=True)
+    dataset_plotter.figures_2d(data=True)
 
 Here is what our image looks like with the mask applied, where **PyAutoGalaxy** has automatically zoomed around the
 ``Mask2D`` to make the lensed source appear bigger:

--- a/docs/overview/overview_3_modeling.rst
+++ b/docs/overview/overview_3_modeling.rst
@@ -140,7 +140,7 @@ which returns two dictionaries containing the run-times and information about th
 
 .. code-block:: python
 
-    profiling_dict, info_dict = analysis.profile_log_likelihood_function(
+    run_time_dict, info_dict = analysis.profile_log_likelihood_function(
         instance=model.random_instance()
     )
 
@@ -150,13 +150,13 @@ For this example, it is ~0.01 seconds, which is extremely fast for modeling. Mor
 modeling features (e.g. shapelets, multi Gaussian expansions, pixelizations) have slower log likelihood evaluation
 times (1-3 seconds), and you should be wary of this when using these features.
 
-The ``profiling_dict`` has a break-down of the run-time of every individual function call in the log likelihood
+The ``run_time_dict`` has a break-down of the run-time of every individual function call in the log likelihood
 function, whereas the ``info_dict`` stores information about the data which drives the run-time (e.g. number of
 image-pixels in the mask, the shape of the PSF, etc.).
 
 .. code-block:: python
 
-    print(f"Log Likelihood Evaluation Time (second) = {profiling_dict['fit_time']}")
+    print(f"Log Likelihood Evaluation Time (second) = {run_time_dict['fit_time']}")
 
 This gives an output of ~0.01 seconds.
 
@@ -177,7 +177,7 @@ does not scale linearly with the number of cores.
 
     print(
         "Estimated Run Time Upper Limit (seconds) = ",
-        (profiling_dict["fit_time"] * model.total_free_parameters * 10000)
+        (run_time_dict["fit_time"] * model.total_free_parameters * 10000)
         / search.number_of_cores,
     )
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -66,7 +66,7 @@ bibliography: paper.bib
 Nearly a century ago, Edwin Hubble famously classified galaxies into three distinct groups: ellipticals, spirals and 
 irregulars [@Hubble1926]. Today, by analysing millions of galaxies with advanced image processing techniques Astronomers have 
 expanded on this picture and revealed the rich diversity of galaxy morphology in both the nearby and distant 
-Universe [@Kormendy2015a; @Vulcani2014; @VanDerWel2012]. `PyAutoGalaxy` is an open-source Python 3.8+ package 
+Universe [@Kormendy2015a; @Vulcani2014; @VanDerWel2012]. `PyAutoGalaxy` is an open-source Python 3.8 - 3.10 package 
 for analysing the morphologies and structures of large multiwavelength galaxy samples, with core features including 
 fully automated Bayesian model-fitting of galaxy two-dimensional surface brightness profiles, support for dataset and 
 interferometer datasets and comprehensive tools for simulating galaxy images. The software places a focus 
@@ -161,7 +161,7 @@ taken without a local `PyAutoGalaxy` installation.
 
 # Software Citations
 
-`PyAutoGalaxy` is written in Python 3.8+ and uses the following software packages:
+`PyAutoGalaxy` is written in Python 3.8 - 3.10 and uses the following software packages:
 
 - `Astropy` [@astropy1; @astropy2]
 - `COLOSSUS` [@colossus]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(join(this_dir, "README.rst"), encoding="utf-8") as file:
 with open(join(this_dir, "requirements.txt")) as f:
     requirements = f.read().split("\n")
 
-version = environ.get("VERSION", "2023.7.7.1")
+version = environ.get("VERSION", "1.0.dev0")
 requirements.extend(
     [f"autoconf=={version}", f"autoarray=={version}", f"autofit=={version}"]
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(join(this_dir, "README.rst"), encoding="utf-8") as file:
 with open(join(this_dir, "requirements.txt")) as f:
     requirements = f.read().split("\n")
 
-version = environ.get("VERSION", "1.0.dev0")
+version = environ.get("VERSION", "2023.7.7.1")
 requirements.extend(
     [f"autoconf=={version}", f"autoarray=={version}", f"autofit=={version}"]
 )

--- a/test_autogalaxy/config/general.yaml
+++ b/test_autogalaxy/config/general.yaml
@@ -42,4 +42,4 @@ test:
   bypass_figure_of_merit_sanity: false
   check_preloads: false
   exception_override: false
-  preloads_check_threshold: 0.1     # If the figure of merit of a fit with and without preloads is greater than this threshold, the check preload test fails and an exception raised for a model-fit. 
+  preloads_check_threshold: 1.0     # If the figure of merit of a fit with and without preloads is greater than this threshold, the check preload test fails and an exception raised for a model-fit. 

--- a/test_autogalaxy/imaging/model/test_analysis_imaging.py
+++ b/test_autogalaxy/imaging/model/test_analysis_imaging.py
@@ -53,9 +53,9 @@ def test__profile_log_likelihood_function(masked_imaging_7x7):
 
     analysis = ag.AnalysisImaging(dataset=masked_imaging_7x7)
 
-    profiling_dict, info_dict = analysis.profile_log_likelihood_function(
+    run_time_dict, info_dict = analysis.profile_log_likelihood_function(
         instance=instance
     )
 
-    assert "regularization_term_0" in profiling_dict
-    assert "log_det_regularization_matrix_term_0" in profiling_dict
+    assert "regularization_term_0" in run_time_dict
+    assert "log_det_regularization_matrix_term_0" in run_time_dict

--- a/test_autogalaxy/imaging/model/test_analysis_imaging.py
+++ b/test_autogalaxy/imaging/model/test_analysis_imaging.py
@@ -37,3 +37,23 @@ def test__figure_of_merit__matches_correct_fit_given_galaxy_profiles(
     fit = ag.FitImaging(dataset=masked_imaging_7x7, plane=plane)
 
     assert fit.log_likelihood == fit_figure_of_merit
+
+def test__profile_log_likelihood_function(masked_imaging_7x7):
+
+    pixelization = ag.Pixelization(
+        mesh=ag.mesh.Rectangular(shape=(3, 3)),
+        regularization=ag.reg.Constant(coefficient=1.0),
+    )
+
+    galaxy = ag.Galaxy(redshift=0.5,pixelization=pixelization)
+
+    model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+    instance = model.instance_from_unit_vector([])
+
+    analysis = ag.AnalysisImaging(dataset=masked_imaging_7x7)
+
+    profiling_dict, info_dict = analysis.profile_log_likelihood_function(instance=instance)
+
+    assert "regularization_term_0" in profiling_dict
+    assert "log_det_regularization_matrix_term_0" in profiling_dict

--- a/test_autogalaxy/imaging/model/test_analysis_imaging.py
+++ b/test_autogalaxy/imaging/model/test_analysis_imaging.py
@@ -38,14 +38,14 @@ def test__figure_of_merit__matches_correct_fit_given_galaxy_profiles(
 
     assert fit.log_likelihood == fit_figure_of_merit
 
-def test__profile_log_likelihood_function(masked_imaging_7x7):
 
+def test__profile_log_likelihood_function(masked_imaging_7x7):
     pixelization = ag.Pixelization(
         mesh=ag.mesh.Rectangular(shape=(3, 3)),
         regularization=ag.reg.Constant(coefficient=1.0),
     )
 
-    galaxy = ag.Galaxy(redshift=0.5,pixelization=pixelization)
+    galaxy = ag.Galaxy(redshift=0.5, pixelization=pixelization)
 
     model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
 
@@ -53,7 +53,9 @@ def test__profile_log_likelihood_function(masked_imaging_7x7):
 
     analysis = ag.AnalysisImaging(dataset=masked_imaging_7x7)
 
-    profiling_dict, info_dict = analysis.profile_log_likelihood_function(instance=instance)
+    profiling_dict, info_dict = analysis.profile_log_likelihood_function(
+        instance=instance
+    )
 
     assert "regularization_term_0" in profiling_dict
     assert "log_det_regularization_matrix_term_0" in profiling_dict

--- a/test_autogalaxy/interferometer/model/test_analysis_interferometer.py
+++ b/test_autogalaxy/interferometer/model/test_analysis_interferometer.py
@@ -38,3 +38,25 @@ def test__fit_figure_of_merit__matches_correct_fit_given_galaxy_profiles(
     fit = ag.FitInterferometer(dataset=interferometer_7, plane=plane)
 
     assert fit.log_likelihood == fit_figure_of_merit
+
+
+def test__profile_log_likelihood_function(interferometer_7):
+    pixelization = ag.Pixelization(
+        mesh=ag.mesh.Rectangular(shape=(3, 3)),
+        regularization=ag.reg.Constant(coefficient=1.0),
+    )
+
+    galaxy = ag.Galaxy(redshift=0.5, pixelization=pixelization)
+
+    model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+    instance = model.instance_from_unit_vector([])
+
+    analysis = ag.AnalysisInterferometer(dataset=interferometer_7)
+
+    profiling_dict, info_dict = analysis.profile_log_likelihood_function(
+        instance=instance
+    )
+
+    assert "regularization_term_0" in profiling_dict
+    assert "log_det_regularization_matrix_term_0" in profiling_dict

--- a/test_autogalaxy/interferometer/model/test_analysis_interferometer.py
+++ b/test_autogalaxy/interferometer/model/test_analysis_interferometer.py
@@ -54,9 +54,9 @@ def test__profile_log_likelihood_function(interferometer_7):
 
     analysis = ag.AnalysisInterferometer(dataset=interferometer_7)
 
-    profiling_dict, info_dict = analysis.profile_log_likelihood_function(
+    run_time_dict, info_dict = analysis.profile_log_likelihood_function(
         instance=instance
     )
 
-    assert "regularization_term_0" in profiling_dict
-    assert "log_det_regularization_matrix_term_0" in profiling_dict
+    assert "regularization_term_0" in run_time_dict
+    assert "log_det_regularization_matrix_term_0" in run_time_dict

--- a/zenodo.json
+++ b/zenodo.json
@@ -2,7 +2,7 @@
     "description": "Release which is tied to the publication of PyAutoGalaxy in the Journal of Open Source software (JOSS).",
     "license": "other-open",
     "title": "PyAutoGalaxy: Open-Source Multiwavelength Galaxy Structure & Morphology",
-    "version": "2023.3.27.1",
+    "version": "2023.7.7.1",
     "upload_type": "software",
     "publication_date": "2023-01-19",
     "creators": [
@@ -63,7 +63,7 @@
     "related_identifiers": [
         {
             "scheme": "url",
-            "identifier": "https://github.com/Jammy2211/PyAutoGalaxy/tree/2023.3.27.1",
+            "identifier": "https://github.com/Jammy2211/PyAutoGalaxy/tree/2023.7.7.1",
             "relation": "isSupplementTo"
         },
         {

--- a/zenodo.json
+++ b/zenodo.json
@@ -2,7 +2,7 @@
     "description": "Release which is tied to the publication of PyAutoGalaxy in the Journal of Open Source software (JOSS).",
     "license": "other-open",
     "title": "PyAutoGalaxy: Open-Source Multiwavelength Galaxy Structure & Morphology",
-    "version": "2023.7.7.1",
+    "version": "2023.7.7.2",
     "upload_type": "software",
     "publication_date": "2023-01-19",
     "creators": [
@@ -63,7 +63,7 @@
     "related_identifiers": [
         {
             "scheme": "url",
-            "identifier": "https://github.com/Jammy2211/PyAutoGalaxy/tree/2023.7.7.1",
+            "identifier": "https://github.com/Jammy2211/PyAutoGalaxy/tree/2023.7.7.2",
             "relation": "isSupplementTo"
         },
         {


### PR DESCRIPTION
Improve tools for profiling the likelihood funciton of an analysis class, including making profiling work on interferometer datasets.

All example scripts now on the workspace include the following run-times section (or text which is much shorter):

```
"""
__Run Times__

modeling can be a computationally expensive process. When fitting complex models to high resolution datasets 
run times can be of order hours, days, weeks or even months.

Run times are dictated by two factors:

 - The log likelihood evaluation time: the time it takes for a single `instance` of the model to be fitted to 
   the dataset such that a log likelihood is returned.

 - The number of iterations (e.g. log likelihood evaluations) performed by the non-linear search: more complex lens
   models require more iterations to converge to a solution.

The log likelihood evaluation time can be estimated before a fit using the `profile_log_likelihood_function` method,
which returns two dictionaries containing the run-times and information about the fit.
"""
run_time_dict, info_dict = analysis.profile_log_likelihood_function(
    instance=model.random_instance()
)

"""
The overall log likelihood evaluation time is given by the `fit_time` key.

For this example, it is ~0.01 seconds, which is extremely fast for modeling. More advanced lens
modeling features (e.g. shapelets, multi Gaussian expansions, pixelizations) have slower log likelihood evaluation
times (1-3 seconds), and you should be wary of this when using these features.

Feel free to go ahead a print the full `run_time_dict` and `info_dict` to see the other information they contain. The
former has a break-down of the run-time of every individual function call in the log likelihood function, whereas the 
latter stores information about the data which drives the run-time (e.g. number of image-pixels in the mask, the
shape of the PSF, etc.).
"""
print(f"Log Likelihood Evaluation Time (second) = {run_time_dict['fit_time']}")

"""
To estimate the expected overall run time of the model-fit we multiply the log likelihood evaluation time by an 
estimate of the number of iterations the non-linear search will perform. 

Estimating this quantity is more tricky, as it varies depending on the model complexity (e.g. number of parameters)
and the properties of the dataset and model being fitted.

For this example, we conservatively estimate that the non-linear search will perform ~10000 iterations per free 
parameter in the model. This is an upper limit, with models typically converging in far fewer iterations.

If you perform the fit over multiple CPUs, you can divide the run time by the number of cores to get an estimate of
the time it will take to fit the model. However, above ~6 cores the speed-up from parallelization is less efficient and
does not scale linearly with the number of cores.
"""
print(
    "Estimated Run Time Upper Limit (seconds) = ",
    (run_time_dict["fit_time"] * model.total_free_parameters * 10000)
    / search.number_of_cores,
)
```