### PR TITLE
Output max likelihood plane in files as plane.json

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -109,4 +109,4 @@ from autoconf import conf
 
 conf.instance.register(__file__)
 
-__version__ = "2023.7.5.2"
+__version__ = "2023.9.18.4"

--- a/autogalaxy/analysis/analysis.py
+++ b/autogalaxy/analysis/analysis.py
@@ -500,6 +500,31 @@ class AnalysisDataset(Analysis):
                     prefix="adapt",
                 )
 
+    def save_results(self, paths: af.DirectoryPaths, result: ResultDataset):
+        """
+        At the end of a model-fit, this routine saves attributes of the `Analysis` object to the `files`
+        folder such that they can be loaded after the analysis using PyAutoFit's database and aggregator tools.
+
+        For this analysis it outputs the following:
+
+        - The maximum log likelihood plane of the fit.
+
+        Parameters
+        ----------
+        paths
+            The PyAutoFit paths object which manages all paths, e.g. where the non-linear search outputs are stored,
+            visualization and the pickled objects used by the aggregator output by this function.
+        result
+            The result of a model fit, including the non-linear search, samples and maximum likelihood tracer.
+        """
+        try:
+            output_to_json(
+                obj=result.max_log_likelihood_plane,
+                file_path=paths._files_path / "plane.json"
+            )
+        except AttributeError:
+            pass
+
     def check_and_replace_adapt_images(self, paths: af.DirectoryPaths):
         """
         Using a the result of a previous model-fit, a adapt-dataset can be set up which adapts aspects of the model

--- a/autogalaxy/analysis/mock/mock_result.py
+++ b/autogalaxy/analysis/mock/mock_result.py
@@ -18,6 +18,8 @@ class MockResult(af.m.MockResult):
         search: af.mock.MockSearch = None,
         adapt_galaxy_image_path_dict: Dict[ag.Galaxy, ag.Array2D] = None,
         adapt_model_image: ag.Array2D = None,
+        max_log_likelihood_plane: ag.Plane = None,
+        max_log_likelihood_tracer = None,
     ):
         super().__init__(
             samples=samples,
@@ -29,6 +31,8 @@ class MockResult(af.m.MockResult):
 
         self.adapt_galaxy_image_path_dict = adapt_galaxy_image_path_dict
         self.adapt_model_image = adapt_model_image
+        self.max_log_likelihood_plane = max_log_likelihood_plane
+        self.max_log_likelihood_tracer = max_log_likelihood_tracer
 
     @property
     def last(self):

--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -47,7 +47,7 @@ You may get warnings which state something like:
 
 .. code-block:: bash
 
-    ERROR: autoarray 2023.7.5.2 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
+    ERROR: autoarray 2023.9.18.4 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
     ERROR: numba 0.53.1 has requirement llvmlite<0.37,>=0.36.0rc1, but you'll have llvmlite 0.38.0 which is incompatible.
 
 If you see these messages, they do not mean that the installation has failed and the instructions below will

--- a/docs/installation/pip.rst
+++ b/docs/installation/pip.rst
@@ -27,7 +27,7 @@ You may get warnings which state something like:
 
 .. code-block:: bash
 
-    ERROR: autoarray 2023.7.5.2 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
+    ERROR: autoarray 2023.9.18.4 has requirement numpy<=1.22.1, but you'll have numpy 1.22.2 which is incompatible.
     ERROR: numba 0.53.1 has requirement llvmlite<0.37,>=0.36.0rc1, but you'll have llvmlite 0.38.0 which is incompatible.
 
 If you see these messages, they do not mean that the installation has failed and the instructions below will

--- a/test_autogalaxy/analysis/test_analysis.py
+++ b/test_autogalaxy/analysis/test_analysis.py
@@ -1,6 +1,9 @@
 import pytest
 import numpy as np
+import os
 from os import path
+
+from autoconf.dictable import from_json
 
 import autofit as af
 import autogalaxy as ag
@@ -87,3 +90,24 @@ def test__modify_before_fit__kmeans_pixelization_upper_limit_ajusted_based_on_ma
     assert model.galaxies.source.pixelization.mesh.pixels.upper_limit == pytest.approx(
         9, 1.0e-4
     )
+
+def test__save_results__plane_output_to_json(analysis_imaging_7x7):
+
+    galaxy = ag.Galaxy(redshift=0.5)
+
+    model = af.Collection(galaxies=af.Collection(galaxy=galaxy))
+
+    plane = ag.Plane(galaxies=[galaxy])
+
+    paths = af.DirectoryPaths()
+
+    analysis_imaging_7x7.save_results(
+        paths=paths,
+        result=ag.m.MockResult(max_log_likelihood_plane=plane, model=model)
+    )
+
+    plane = from_json(file_path=paths._files_path / "plane.json")
+
+    assert plane.galaxies[0].redshift == 0.5
+
+    os.remove(paths._files_path / "plane.json")

--- a/test_autogalaxy/config/general.yaml
+++ b/test_autogalaxy/config/general.yaml
@@ -36,7 +36,7 @@ output:
 pixelization:
   voronoi_nn_max_interpolation_neighbors: 100
 structures:
-  use_dataset_grids: true
+  native_binned_only: false           # If True, data structures are only stored in their native and binned format. This is used to reduce memory usage in autocti.
 test:
   check_figure_of_merit_sanity: false
   bypass_figure_of_merit_sanity: true

--- a/zenodo.json
+++ b/zenodo.json
@@ -2,7 +2,7 @@
     "description": "Release which is tied to the publication of PyAutoGalaxy in the Journal of Open Source software (JOSS).",
     "license": "other-open",
     "title": "PyAutoGalaxy: Open-Source Multiwavelength Galaxy Structure & Morphology",
-    "version": "2023.7.5.2",
+    "version": "2023.9.18.4",
     "upload_type": "software",
     "publication_date": "2023-01-19",
     "creators": [
@@ -63,7 +63,7 @@
     "related_identifiers": [
         {
             "scheme": "url",
-            "identifier": "https://github.com/Jammy2211/PyAutoGalaxy/tree/2023.7.5.2",
+            "identifier": "https://github.com/Jammy2211/PyAutoGalaxy/tree/2023.9.18.4",
             "relation": "isSupplementTo"
         },
         {


### PR DESCRIPTION
When a model-fit completes, the maximum likelihood plane is output to the `files` folder as a .json file.

