### PR TITLE
Jacks doc updates

### DIFF
--- a/autogalaxy/cosmology/lensing.py
+++ b/autogalaxy/cosmology/lensing.py
@@ -221,21 +221,26 @@ class LensingCosmology(cosmo.FLRW):
     ) -> float:
         """
         For strong lens systems with more than 2 planes, the deflection angles between different planes must be scaled
-        by the angular diameter distances between the planes in order to properly perform multi-plane ray-tracing.
+        by the angular diameter distances between the planes in order to properly perform multi-plane ray-tracing. This
+        function computes the factor to scale deflections between `redshift_0` and `reshift_final`, to deflections between
+        `redshift_0` and `redshift_1`.
+
+        The second redshift should be strictly larger than the first. The scaling factor is unity when `redshift_1`
+        is `redshift_final`, and 0 when `redshift_0` is equal to `redshift_1`.
 
         For a system with a first lens galaxy l0 at `redshift_0`, second lens galaxy l1 at `redshift_1` and final
         source galaxy at `redshift_final` this scaling factor is given by:
 
-        (D_l0l1 * D_s) / (D_l1* D_l1s)
+        (D_l0l1 * D_s) / (D_l1* D_l0s)
 
-        The critical surface density for lensing, often written as $\sigma_{cr}$, is given by:
+        The critical surface density for lensing, often written as $\\sigma_{cr}$, is given by:
 
         critical_surface_density = (c^2 * D_s) / (4 * pi * G * D_ls * D_l)
 
         D_l0l1 = Angular diameter distance of first lens redshift to second lens redshift.
         D_s = Angular diameter distance of source redshift to earth
         D_l1 = Angular diameter distance of second lens redshift to Earth.
-        D_l1s = Angular diameter distance of second lens redshift to source redshift
+        D_l0s = Angular diameter distance of first lens redshift to source redshift
 
         For systems with more planes this scaling factor is computed multiple times for the different redshift
         combinations and applied recursively when scaling the deflection angles.
@@ -263,7 +268,7 @@ class LensingCosmology(cosmo.FLRW):
             self.angular_diameter_distance(z=redshift_1).to("kpc").value
         )
 
-        angular_diameter_distance_between_redshift_1_and_final = (
+        angular_diameter_distance_between_redshift_0_and_final = (
             self.angular_diameter_distance_z1z2(z1=redshift_0, z2=redshift_final)
             .to("kpc")
             .value
@@ -274,7 +279,7 @@ class LensingCosmology(cosmo.FLRW):
             * angular_diameter_distance_to_redshift_final
         ) / (
             angular_diameter_distance_of_redshift_1_to_earth
-            * angular_diameter_distance_between_redshift_1_and_final
+            * angular_diameter_distance_between_redshift_0_and_final
         )
 
     def velocity_dispersion_from(

--- a/autogalaxy/profiles/mass/dark/abstract.py
+++ b/autogalaxy/profiles/mass/dark/abstract.py
@@ -45,8 +45,8 @@ class AbstractgNFW(MassProfile, DarkProfile, MassProfileMGE):
         inner_slope
             The inner slope of the dark matter halo
         scale_radius
-            The arc-second radius where the average density within this radius is 200 times the critical density of \
-            the Universe..
+            The NFW scale radius as an angle on the sky in arc-seconds. For a regular NFW halo, \
+            the scale radius is roughly where the log-slope of the profile changes from -1 to -3.
         """
 
         super().__init__(centre=centre, ell_comps=ell_comps)
@@ -264,6 +264,9 @@ class AbstractgNFW(MassProfile, DarkProfile, MassProfileMGE):
         redshift_of_cosmic_average_density="profile",
         cosmology: LensingCosmology = Planck15(),
     ):
+        '''
+        Computes the NFW halo concentration, `c_{200m}`
+        '''
         delta_concentration = self.delta_concentration(
             redshift_object=redshift_profile,
             redshift_source=redshift_source,
@@ -296,6 +299,9 @@ class AbstractgNFW(MassProfile, DarkProfile, MassProfileMGE):
         redshift_of_cosmic_average_density="profile",
         cosmology: LensingCosmology = Planck15(),
     ):
+        '''
+        Returns `r_{200m}` for this halo in **arcseconds**
+        '''
         concentration = self.concentration(
             redshift_profile=redshift_object,
             redshift_source=redshift_source,
@@ -312,6 +318,9 @@ class AbstractgNFW(MassProfile, DarkProfile, MassProfileMGE):
         redshift_of_cosmic_average_density="profile",
         cosmology: LensingCosmology = Planck15(),
     ):
+        '''
+        Returns `M_{200m}` of this NFW halo, in solar masses, at the given cosmology.
+        '''
         if redshift_of_cosmic_average_density == "profile":
             redshift_calc = redshift_object
         elif redshift_of_cosmic_average_density == "local":

--- a/autogalaxy/profiles/mass/dark/mcr_util.py
+++ b/autogalaxy/profiles/mass/dark/mcr_util.py
@@ -10,6 +10,8 @@ def kappa_s_and_scale_radius_for_duffy(mass_at_200, redshift_object, redshift_so
     '''
     Computes the AutoGalaxy NFW parameters (kappa_s, scale_radius) for an NFW halo of the given
     mass, enforcing the Duffy '08 mass-concentration relation.
+
+    Interprets mass as *`M_{200c}`*, not `M_{200m}`.
     '''
     cosmology = Planck15()
 
@@ -59,6 +61,8 @@ def kappa_s_and_scale_radius_for_ludlow(
     '''
     Computes the AutoGalaxy NFW parameters (kappa_s, scale_radius) for an NFW halo of the given
     mass, enforcing the Ludlow '16 mass-concentration relation.
+
+    Interprets mass as *`M_{200c}`*, not `M_{200m}`.
     '''
     from colossus.cosmology import cosmology as col_cosmology
     from colossus.halo.concentration import concentration as col_concentration

--- a/autogalaxy/profiles/mass/dark/mcr_util.py
+++ b/autogalaxy/profiles/mass/dark/mcr_util.py
@@ -7,6 +7,10 @@ from autogalaxy.cosmology.wrap import Planck15
 
 
 def kappa_s_and_scale_radius_for_duffy(mass_at_200, redshift_object, redshift_source):
+    '''
+    Computes the AutoGalaxy NFW parameters (kappa_s, scale_radius) for an NFW halo of the given
+    mass, enforcing the Duffy '08 mass-concentration relation.
+    '''
     cosmology = Planck15()
 
     cosmic_average_density = (
@@ -52,6 +56,10 @@ def kappa_s_and_scale_radius_for_duffy(mass_at_200, redshift_object, redshift_so
 def kappa_s_and_scale_radius_for_ludlow(
     mass_at_200, scatter_sigma, redshift_object, redshift_source
 ):
+    '''
+    Computes the AutoGalaxy NFW parameters (kappa_s, scale_radius) for an NFW halo of the given
+    mass, enforcing the Ludlow '16 mass-concentration relation.
+    '''
     from colossus.cosmology import cosmology as col_cosmology
     from colossus.halo.concentration import concentration as col_concentration
 

--- a/autogalaxy/profiles/mass/dark/nfw.py
+++ b/autogalaxy/profiles/mass/dark/nfw.py
@@ -29,8 +29,7 @@ class NFW(gNFW, MassProfileCSE):
             The overall normalization of the dark matter halo \
             (kappa_s = (rho_s * scale_radius)/lensing_critical_density)
         scale_radius
-            The arc-second radius where the average density within this radius is 200 times the critical density of \
-            the Universe..
+            The NFW scale radius `r_s`, as an angle on the sky in arcseconds.
         """
 
         super().__init__(


### PR DESCRIPTION
As discussed with @Jammy2211 and @qiuhan96 on slack , I am updating some minor things I noticed in the documentation. The first is the code to scale deflection angles between different planes.

I have also added some clarifying documentation to (g)NFW functions. Some of the docs were incorrect, the description of `scale_radius` seemed to be describing `r_{200c}` instead.

I think there is also a slight discrepancy between how different parts of the code are using NFW halo definitions. The functions on `AbstractGNFW` to convert to physical units (mass, concentration) were implicitly using the `M_{200m}` mass definition, and the functions in `mcr_util.py` were implicitly using `M_{200c}` instead.

This is not a big deal, it doesn't actually cause any problems, but could lead to some confusion. I am updating the docs in each to clarify what mass definition they are implicitly using.