### PR TITLE
build serve supports python311

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     steps:
     - name: Checkout PyAutoConf
       uses: actions/checkout@v2


### PR DESCRIPTION
Update requirements to support Python 3.11 libraries (e.g. numpy, scipy) and small source code edits to fix unit tests.