### PR TITLE
Feature/deflections evaluation grid fix

### DIFF
--- a/autogalaxy/config/general.yaml
+++ b/autogalaxy/config/general.yaml
@@ -2,6 +2,8 @@ analysis:
   preload_attempts: 250
 fits:
   flip_for_ds9: true
+grid:
+  max_evaluation_grid_size: 1000   # An evaluation grid whose shape is adaptive chosen is used to compute quantities like critical curves, this integer is the max size of the grid ensuring faster run times.
 adapt:
   adapt_minimum_percent: 0.01
   adapt_noise_limit: 100000000.0

--- a/autogalaxy/operate/deflections.py
+++ b/autogalaxy/operate/deflections.py
@@ -4,6 +4,8 @@ import numpy as np
 from skimage import measure
 from typing import List, Tuple, Union
 
+from autoconf import conf
+
 import autoarray as aa
 
 from autogalaxy.util.shear_field import ShearYX2D
@@ -65,13 +67,15 @@ def evaluation_grid(func):
             int(pixel_scale_ratio * zoom_shape_native[1]),
         )
 
+        max_evaluation_grid_size = conf.instance["general"]["grid"]["max_evaluation_grid_size"]
+
         # This is a hack to prevent the evaluation gird going beyond 1000 x 1000 pixels, which slows the code
         # down a lot. Need a better moe robust way to set this up for any general lens.
 
-        if shape_native[0] > 1000:
+        if shape_native[0] > max_evaluation_grid_size:
 
-            pixel_scale = pixel_scale_ratio / (shape_native[0] / 1000.0)
-            shape_native = (1000, 1000)
+            pixel_scale = pixel_scale_ratio / (shape_native[0] / float(max_evaluation_grid_size))
+            shape_native = (max_evaluation_grid_size, max_evaluation_grid_size)
 
         grid = aa.Grid2D.uniform(
             shape_native=shape_native,

--- a/autogalaxy/operate/deflections.py
+++ b/autogalaxy/operate/deflections.py
@@ -65,6 +65,14 @@ def evaluation_grid(func):
             int(pixel_scale_ratio * zoom_shape_native[1]),
         )
 
+        # This is a hack to prevent the evaluation gird going beyond 1000 x 1000 pixels, which slows the code
+        # down a lot. Need a better moe robust way to set this up for any general lens.
+
+        if shape_native[0] > 1000:
+
+            pixel_scale = pixel_scale_ratio / (shape_native[0] / 1000.0)
+            shape_native = (1000, 1000)
+
         grid = aa.Grid2D.uniform(
             shape_native=shape_native,
             pixel_scales=(pixel_scale, pixel_scale),


### PR DESCRIPTION
When computing a quantities like the criticial curves, they are evaluated using an `evaluation_grid` which is typically higher resolution than the data.

For example, for a 100 x 100 strong lens image cut-out, this grid will typically be higher resolution, going to 2000 x 2000 pixels.

For large images (e.g. galaxy clusters) this produces grids which increase in shape from ~1000 x 1000 pixels to ~20000 x 20000, which significantly slows the code down.

This PR puts a cap on the shape of the evaluation grid to ensure fast run times.