### PR TITLE
Feature/shear fix refactor

### DIFF
--- a/autogalaxy/exc.py
+++ b/autogalaxy/exc.py
@@ -84,7 +84,7 @@ def raise_linear_light_profile_in_unmasked():
 
 
 def raise_linear_light_profile_in_plot(
-        plotter_type: str,
+    plotter_type: str,
 ):
     raise ProfileException(
         f"""

--- a/autogalaxy/operate/deflections.py
+++ b/autogalaxy/operate/deflections.py
@@ -179,7 +179,7 @@ class OperateDeflections:
     def hessian_from(self, grid, buffer: float = 0.01, deflections_func=None) -> Tuple:
         """
         Returns the Hessian of the lensing object, where the Hessian is the second partial derivatives of the
-        potential (see equation 55 https://www.tau.ac.il/~lab3/MICROLENSING/JeruLect.pdf):
+        potential (see equation 55 https://inspirehep.net/literature/419263):
 
         `hessian_{i,j} = d^2 / dtheta_i dtheta_j`
 
@@ -237,7 +237,7 @@ class OperateDeflections:
     ) -> aa.ArrayIrregular:
         """
         Returns the convergence of the lensing object, which is computed from the 2D deflection angle map via the
-        Hessian using the expression (see equation 56 https://www.tau.ac.il/~lab3/MICROLENSING/JeruLect.pdf):
+        Hessian using the expression (see equation 56 https://inspirehep.net/literature/419263):
 
         `convergence = 0.5 * (hessian_{0,0} + hessian_{1,1}) = 0.5 * (hessian_xx + hessian_yy)`
 
@@ -266,7 +266,7 @@ class OperateDeflections:
     ) -> ShearYX2DIrregular:
         """
         Returns the 2D (y,x) shear vectors of the lensing object, which are computed from the 2D deflection angle map
-        via the Hessian using the expressions (see equation 57 https://www.tau.ac.il/~lab3/MICROLENSING/JeruLect.pdf):
+        via the Hessian using the expressions (see equation 57 https://inspirehep.net/literature/419263):
 
         `shear_y = hessian_{1,0} =  hessian_{0,1} = hessian_yx = hessian_xy`
         `shear_x = 0.5 * (hessian_{0,0} - hessian_{1,1}) = 0.5 * (hessian_xx - hessian_yy)`
@@ -276,6 +276,12 @@ class OperateDeflections:
 
         This calculation of the shear vectors is independent of analytic calculations defined within `MassProfile`
         objects and can therefore be used as a cross-check.
+
+        The result is returned as a `ShearYX2D` dats structure, which has shape [total_shear_vectors, 2], where
+        entries for [:,0] are the gamma_2 values and entries for [:,1] are the gamma_1 values.
+
+        Note therefore that this convention means the FIRST entries in the array are the gamma_2 values and the SECOND
+        entries are the gamma_1 values.
 
         Parameters
         ----------
@@ -289,9 +295,13 @@ class OperateDeflections:
             grid=grid, buffer=buffer
         )
 
+        gamma_1 = 0.5 * (hessian_xx - hessian_yy)
+        gamma_2 = hessian_xy
+
         shear_yx_2d = np.zeros(shape=(grid.sub_shape_slim, 2))
-        shear_yx_2d[:, 0] = hessian_xy
-        shear_yx_2d[:, 1] = 0.5 * (hessian_xx - hessian_yy)
+
+        shear_yx_2d[:, 0] = gamma_2
+        shear_yx_2d[:, 1] = gamma_1
 
         return ShearYX2DIrregular(values=shear_yx_2d, grid=grid)
 
@@ -300,7 +310,7 @@ class OperateDeflections:
     ) -> aa.ArrayIrregular:
         """
         Returns the 2D magnification map of lensing object, which is computed from the 2D deflection angle map
-        via the Hessian using the expressions (see equation 60 https://www.tau.ac.il/~lab3/MICROLENSING/JeruLect.pdf):
+        via the Hessian using the expressions (see equation 60 https://inspirehep.net/literature/419263):
 
         `magnification = 1.0 / det(Jacobian) = 1.0 / abs((1.0 - convergence)**2.0 - shear**2.0)`
         `magnification = (1.0 - hessian_{0,0}) * (1.0 - hessian_{1, 1)) - hessian_{0,1}*hessian_{1,0}`
@@ -782,7 +792,7 @@ class OperateDeflections:
     def convergence_2d_via_jacobian_from(self, grid, jacobian=None) -> aa.Array2D:
         """
         Returns the convergence of the lensing object, which is computed from the 2D deflection angle map via the
-        Jacobian using the expression (see equation 58 https://www.tau.ac.il/~lab3/MICROLENSING/JeruLect.pdf):
+        Jacobian using the expression (see equation 58 https://inspirehep.net/literature/419263):
 
         `convergence = 1.0 - 0.5 * (jacobian_{0,0} + jacobian_{1,1}) = 0.5 * (jacobian_xx + jacobian_yy)`
 
@@ -808,7 +818,7 @@ class OperateDeflections:
     ) -> Union[ShearYX2D, ShearYX2DIrregular]:
         """
         Returns the 2D (y,x) shear vectors of the lensing object, which are computed from the 2D deflection angle map
-        via the Jacobian using the expression (see equation 58 https://www.tau.ac.il/~lab3/MICROLENSING/JeruLect.pdf):
+        via the Jacobian using the expression (see equation 58 https://inspirehep.net/literature/419263):
 
         `shear_y = -0.5 * (jacobian_{0,1} + jacobian_{1,0} = -0.5 * (jacobian_yx + jacobian_xy)`
         `shear_x = 0.5 * (jacobian_{1,1} + jacobian_{0,0} = 0.5 * (jacobian_yy + jacobian_xx)`

--- a/autogalaxy/profiles/geometry_profiles.py
+++ b/autogalaxy/profiles/geometry_profiles.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Type
+from typing import Optional, Tuple, Type
 
 import numpy as np
 
@@ -262,7 +262,7 @@ class EllProfile(SphProfile):
         return np.cos(theta_coordinate_to_profile), np.sin(theta_coordinate_to_profile)
 
     @aa.grid_dec.grid_2d_to_structure
-    def rotated_grid_from_reference_frame_from(self, grid):
+    def rotated_grid_from_reference_frame_from(self, grid, angle : float = Optional[None]):
         """
         Rotate a grid of (y,x) coordinates which have been transformed to the elliptical reference frame of a profile
         back to the original unrotated coordinate grid reference frame.
@@ -277,9 +277,17 @@ class EllProfile(SphProfile):
         ----------
         grid
             The (y, x) coordinates in the reference frame of an elliptical profile.
+        angle
+            Manually input an angle which is used instead of the profile's `angle` attribute. This is used in
+            certain circumstances where the angle applied is different to the profile's `angle` attribute, for
+            example weak lensing rotations which are typically twice that profile's `angle` attribute.
         """
+
+        if angle is None:
+            angle = self.angle
+
         return aa.util.geometry.transform_grid_2d_from_reference_frame(
-            grid_2d=grid, centre=(0.0, 0.0), angle=self.angle
+            grid_2d=grid, centre=(0.0, 0.0), angle=angle
         )
 
     @aa.grid_dec.grid_2d_to_structure

--- a/autogalaxy/profiles/geometry_profiles.py
+++ b/autogalaxy/profiles/geometry_profiles.py
@@ -262,7 +262,7 @@ class EllProfile(SphProfile):
         return np.cos(theta_coordinate_to_profile), np.sin(theta_coordinate_to_profile)
 
     @aa.grid_dec.grid_2d_to_structure
-    def rotated_grid_from_reference_frame_from(self, grid, angle : float = Optional[None]):
+    def rotated_grid_from_reference_frame_from(self, grid, angle : Optional[float] = None):
         """
         Rotate a grid of (y,x) coordinates which have been transformed to the elliptical reference frame of a profile
         back to the original unrotated coordinate grid reference frame.

--- a/autogalaxy/profiles/geometry_profiles.py
+++ b/autogalaxy/profiles/geometry_profiles.py
@@ -262,7 +262,9 @@ class EllProfile(SphProfile):
         return np.cos(theta_coordinate_to_profile), np.sin(theta_coordinate_to_profile)
 
     @aa.grid_dec.grid_2d_to_structure
-    def rotated_grid_from_reference_frame_from(self, grid, angle : Optional[float] = None):
+    def rotated_grid_from_reference_frame_from(
+        self, grid, angle: Optional[float] = None
+    ):
         """
         Rotate a grid of (y,x) coordinates which have been transformed to the elliptical reference frame of a profile
         back to the original unrotated coordinate grid reference frame.

--- a/autogalaxy/profiles/mass/total/isothermal.py
+++ b/autogalaxy/profiles/mass/total/isothermal.py
@@ -116,26 +116,32 @@ class Isothermal(PowerLaw):
         """
         Calculate the (gamma_y, gamma_x) shear vector field on a grid of (y,x) arc-second coordinates.
 
+        The result is returned as a `ShearYX2D` dats structure, which has shape [total_shear_vectors, 2], where
+        entries for [:,0] are the gamma_2 values and entries for [:,1] are the gamma_1 values.
+
+        Note therefore that this convention means the FIRST entries in the array are the gamma_2 values and the SECOND
+        entries are the gamma_1 values.
+
         Parameters
         ----------
         grid
             The grid of (y,x) arc-second coordinates the deflection angles are computed on.
+
         """
 
         convergence = self.convergence_2d_from(grid=grid)
 
-        shear_y = (
+        gamma_2 = (
             -2
             * convergence
             * np.divide(grid[:, 1] * grid[:, 0], grid[:, 1] ** 2 + grid[:, 0] ** 2)
         )
-        shear_x = -convergence * np.divide(
+        gamma_1 = -convergence * np.divide(
             grid[:, 1] ** 2 - grid[:, 0] ** 2, grid[:, 1] ** 2 + grid[:, 0] ** 2
         )
 
         shear_field = self.rotated_grid_from_reference_frame_from(
-            grid=np.vstack((shear_y, shear_x)).T,
-            angle=self.angle*2
+            grid=np.vstack((gamma_2, gamma_1)).T, angle=self.angle * 2
         )
 
         return aa.VectorYX2DIrregular(values=shear_field, grid=grid)

--- a/autogalaxy/profiles/mass/total/isothermal.py
+++ b/autogalaxy/profiles/mass/total/isothermal.py
@@ -134,7 +134,8 @@ class Isothermal(PowerLaw):
         )
 
         shear_field = self.rotated_grid_from_reference_frame_from(
-            grid=np.vstack((shear_y, shear_x)).T
+            grid=np.vstack((shear_y, shear_x)).T,
+            angle=self.angle*2
         )
 
         return aa.VectorYX2DIrregular(values=shear_field, grid=grid)

--- a/autogalaxy/profiles/mass/total/isothermal.py
+++ b/autogalaxy/profiles/mass/total/isothermal.py
@@ -112,7 +112,7 @@ class Isothermal(PowerLaw):
     @aa.grid_dec.grid_2d_to_structure
     @aa.grid_dec.transform
     @aa.grid_dec.relocate_to_radial_minimum
-    def shear_2d_from(self, grid: aa.type.Grid2DLike):
+    def shear_yx_2d_from(self, grid: aa.type.Grid2DLike):
         """
         Calculate the (gamma_y, gamma_x) shear vector field on a grid of (y,x) arc-second coordinates.
 

--- a/autogalaxy/profiles/mass/total/power_law_core.py
+++ b/autogalaxy/profiles/mass/total/power_law_core.py
@@ -65,6 +65,8 @@ class PowerLawCore(MassProfile):
             The grid of (y,x) arc-second coordinates the convergence is computed on.
         """
 
+        print(grid)
+
         covnergence_grid = np.zeros(grid.shape[0])
 
         grid_eta = self.elliptical_radii_grid_from(grid)

--- a/autogalaxy/util/shear_field.py
+++ b/autogalaxy/util/shear_field.py
@@ -78,6 +78,12 @@ class ShearYX2D(aa.VectorYX2D, AbstractShearField):
     This class extends `VectorYX2D` to include methods that are specific to a shear field, typically
     used for weak lensing calculations.
 
+    This data structure is of shape [total_vectors, 2], where entries for [:,0] are the gamma_2 values and
+    entries for [:,1] are the gamma_1 values.
+
+    Note therefore that this convention means the FIRST entries in the array are the gamma_2 values and the SECOND
+    entries are the gamma_1 values.
+
     Parameters
     ----------
     vectors
@@ -98,6 +104,13 @@ class ShearYX2DIrregular(aa.VectorYX2DIrregular, AbstractShearField):
 
     This class extends `VectorYX2DIrregular` to include methods that are specific to a shear field, typically
     used for weak lensing calculations.
+
+
+    This data structure is of shape [total_vectors, 2], where entries for [:,0] are the gamma_2 values and
+    entries for [:,1] are the gamma_1 values.
+
+    Note therefore that this convention means the FIRST entries in the array are the gamma_2 values and the SECOND
+    entries are the gamma_1 values.
 
     Parameters
     ----------

--- a/test_autogalaxy/profiles/mass/total/test_isothermal.py
+++ b/test_autogalaxy/profiles/mass/total/test_isothermal.py
@@ -120,24 +120,24 @@ def test__potential_2d_from():
     )
 
 
-def test__shear_2d_from():
+def test__shear_yx_2d_from():
     isothermal = ag.mp.IsothermalSph(centre=(0.0, 0.0), einstein_radius=2.0)
 
     convergence = isothermal.convergence_2d_from(grid=np.array([[0.0, 1.0]]))
 
-    shear = isothermal.shear_2d_from(grid=np.array([[0.0, 1.0]]))
+    shear = isothermal.shear_yx_2d_from(grid=np.array([[0.0, 1.0]]))
 
     assert shear[0, 0] == pytest.approx(0.0, 1e-4)
     assert shear[0, 1] == pytest.approx(-convergence, 1e-4)
 
     convergence = isothermal.convergence_2d_from(grid=np.array([[2.0, 1.0]]))
-    shear = isothermal.shear_2d_from(grid=np.array([[2.0, 1.0]]))
+    shear = isothermal.shear_yx_2d_from(grid=np.array([[2.0, 1.0]]))
 
     assert shear[0, 0] == pytest.approx(-(4.0 / 5.0) * convergence, 1e-4)
     assert shear[0, 1] == pytest.approx((3.0 / 5.0) * convergence, 1e-4)
 
     convergence = isothermal.convergence_2d_from(grid=np.array([[3.0, 5.0]]))
-    shear = isothermal.shear_2d_from(grid=np.array([[3.0, 5.0]]))
+    shear = isothermal.shear_yx_2d_from(grid=np.array([[3.0, 5.0]]))
 
     assert shear[0, 0] == pytest.approx(-(30.0 / 34.0) * convergence, 1e-4)
     assert shear[0, 1] == pytest.approx(-(16.0 / 34.0) * convergence, 1e-4)
@@ -148,7 +148,7 @@ def test__shear_2d_from():
 
     convergence = isothermal.convergence_2d_from(grid=np.array([[0.0, 1.0]]))
 
-    shear = isothermal.shear_2d_from(grid=np.array([[0.0, 1.0]]))
+    shear = isothermal.shear_yx_2d_from(grid=np.array([[0.0, 1.0]]))
 
     assert shear[0, 0] == pytest.approx(0.0, 1e-4)
     assert shear[0, 1] == pytest.approx(-convergence, 1e-4)
@@ -157,7 +157,7 @@ def test__shear_2d_from():
         centre=(0.0, 0.0), ell_comps=(0.3, 0.4), einstein_radius=2.0
     )
 
-    shear = isothermal.shear_2d_from(grid=np.array([[0.0, 1.0]]))
+    shear = isothermal.shear_yx_2d_from(grid=np.array([[0.0, 1.0]]))
 
     assert shear[0, 0] == pytest.approx(0.0, 1e-4)
     assert shear[0, 1] == pytest.approx(-1.11803398874, 1e-4)

--- a/test_autogalaxy/profiles/mass/total/test_isothermal.py
+++ b/test_autogalaxy/profiles/mass/total/test_isothermal.py
@@ -159,8 +159,8 @@ def test__shear_2d_from():
 
     shear = isothermal.shear_2d_from(grid=np.array([[0.0, 1.0]]))
 
-    assert shear[0, 0] == pytest.approx(0.35355, 1e-4)
-    assert shear[0, 1] == pytest.approx(-1.06066, 1e-4)
+    assert shear[0, 0] == pytest.approx(0.0, 1e-4)
+    assert shear[0, 1] == pytest.approx(-1.11803398874, 1e-4)
 
 
 def test__compare_to_cored_power_law():


### PR DESCRIPTION
Fixes the analytic shear calculation of the `Isothermal` profile for elliptical profiles.

This was fixed because ly, a rotation of n degrees propagates by 2n in the WL plane...hence the identical appearance.