### PR TITLE
Feature/cse grid scale

### DIFF
--- a/autogalaxy/operate/deflections.py
+++ b/autogalaxy/operate/deflections.py
@@ -291,6 +291,7 @@ class OperateDeflections:
             The spacing in the y and x directions around each grid coordinate where deflection angles are computed and
             used to estimate the derivative.
         """
+
         hessian_yy, hessian_xy, hessian_yx, hessian_xx = self.hessian_from(
             grid=grid, buffer=buffer
         )

--- a/autogalaxy/profiles/mass/abstract/cse.py
+++ b/autogalaxy/profiles/mass/abstract/cse.py
@@ -41,9 +41,7 @@ class MassProfileCSE(ABC):
         Parameters
         ----------
         """
-        # phi = np.sqrt(q**2.0 * (s**2.0 + gridx2) + gridy2)
         phi = np.sqrt(axis_ratio_squared * core_radius**2.0 + term1)
-        # Psi = (phi + s)**2.0 + (1 - q * q) * gridx2
         Psi = (phi + core_radius) ** 2.0 + term2
         bottom = core_radius * phi * Psi
         defl_x = (term3 * (phi + axis_ratio_squared * core_radius)) / bottom
@@ -51,7 +49,7 @@ class MassProfileCSE(ABC):
         return np.vstack((defl_y, defl_x))
 
     @abstractmethod
-    def decompose_convergence_via_cse(self):
+    def decompose_convergence_via_cse(self, grid_radii : np.ndarray):
         pass
 
     def _decompose_convergence_via_cse_from(
@@ -133,7 +131,9 @@ class MassProfileCSE(ABC):
             The grid of 1D radial arc-second coordinates the convergence is computed on.
         """
 
-        amplitude_list, core_radius_list = self.decompose_convergence_via_cse()
+        amplitude_list, core_radius_list = self.decompose_convergence_via_cse(
+            grid_radii=grid_radii
+        )
 
         return sum(
             amplitude
@@ -157,7 +157,9 @@ class MassProfileCSE(ABC):
             The grid of 1D radial arc-second coordinates the convergence is computed on.
         """
 
-        amplitude_list, core_radius_list = self.decompose_convergence_via_cse()
+        amplitude_list, core_radius_list = self.decompose_convergence_via_cse(
+            grid_radii=self.radial_grid_from(grid=grid)
+        )
         q = self.axis_ratio
         q2 = q**2.0
         grid_y = grid[:, 0]

--- a/autogalaxy/profiles/mass/dark/nfw.py
+++ b/autogalaxy/profiles/mass/dark/nfw.py
@@ -230,7 +230,7 @@ class NFW(gNFW, MassProfileCSE):
             into.
         """
         radii_min = 0.005
-        radii_max = 7.5
+        radii_max = max(7.5, np.max(grid_radii))
 
         def nfw_2d(r):
             grid_radius = (1.0 / self.scale_radius) * r + 0j

--- a/autogalaxy/profiles/mass/dark/nfw.py
+++ b/autogalaxy/profiles/mass/dark/nfw.py
@@ -203,7 +203,7 @@ class NFW(gNFW, MassProfileCSE):
             / ((1 - (1 - axis_ratio**2) * u) ** 0.5)
         )
 
-    def decompose_convergence_via_cse(self, total_cses=30, sample_points=60):
+    def decompose_convergence_via_cse(self, grid_radii : np.ndarray, total_cses=30, sample_points=60):
         """
         Decompose the convergence of the elliptical NFW mass profile into cored steep elliptical (cse) profiles.
 

--- a/autogalaxy/profiles/mass/stellar/sersic.py
+++ b/autogalaxy/profiles/mass/stellar/sersic.py
@@ -259,6 +259,7 @@ class AbstractSersic(MassProfile, MassProfileMGE, MassProfileCSE, StellarProfile
 
     def decompose_convergence_via_cse(
         self,
+        grid_radii: np.ndarray
     ) -> Tuple[List, List]:
         """
         Decompose the convergence of the Sersic profile into cored steep elliptical (cse) profiles.

--- a/autogalaxy/profiles/mass/stellar/sersic_radial_gradient.py
+++ b/autogalaxy/profiles/mass/stellar/sersic_radial_gradient.py
@@ -169,7 +169,7 @@ class SersicRadialGradient(AbstractSersic):
             func=sersic_radial_gradient_2D, radii_min=radii_min, radii_max=radii_max
         )
 
-    def decompose_convergence_via_cse(self) -> Tuple[List, List]:
+    def decompose_convergence_via_cse(self, grid_radii : np.ndarray) -> Tuple[List, List]:
         """
         Decompose the convergence of the Sersic profile into singular isothermal elliptical (sie) profiles.
 

--- a/test_autogalaxy/profiles/mass/dark/test_nfw.py
+++ b/test_autogalaxy/profiles/mass/dark/test_nfw.py
@@ -110,6 +110,52 @@ def test__deflections_2d_via_cse_from():
     assert deflections_via_integral == pytest.approx(deflections_via_cse, 1.0e-4)
 
 
+def test__deflections_2d__numerical_precision_of_csv_compared_to_integral():
+
+    nfw = ag.mp.NFW(
+        centre=(0.3, 0.2),
+        ell_comps=(0.03669, 0.172614),
+        kappa_s=2.5,
+        scale_radius=4.0,
+    )
+
+    deflections_via_integral = nfw.deflections_2d_via_integral_from(
+        grid=np.array([[1.0, 2.0]])
+    )
+    deflections_via_cse = nfw.deflections_2d_via_cse_from(
+        grid=np.array([[1.0, 2.0]])
+    )
+
+    assert deflections_via_integral == pytest.approx(deflections_via_cse, 1.0e-4)
+
+    nfw = ag.mp.NFW(
+        centre=(0.3, 0.2),
+        ell_comps=(0.2, 0.3),
+        kappa_s=3.5,
+        scale_radius=40.0,
+    )
+
+    deflections_via_integral = nfw.deflections_2d_via_integral_from(
+        grid=np.array([[100.0, 200.0]])
+    )
+    deflections_via_cse = nfw.deflections_2d_via_cse_from(
+        grid=np.array([[100.0, 200.0]])
+    )
+
+    assert deflections_via_integral == pytest.approx(deflections_via_cse, 1.0e-4)
+
+
+    deflections_via_integral = nfw.deflections_2d_via_integral_from(
+        grid=np.array([[-1000.0, -2000.0]])
+    )
+    deflections_via_cse = nfw.deflections_2d_via_cse_from(
+        grid=np.array([[-1000.0, -2000.0]])
+    )
+
+    assert deflections_via_integral == pytest.approx(deflections_via_cse, 1.0e-4)
+
+
+
 def test__deflections_yx_2d_from():
     nfw = ag.mp.NFW(centre=(0.0, 0.0), kappa_s=1.0, scale_radius=1.0)
 


### PR DESCRIPTION
The CSE decomposition of certain mass profiles was hard-coded to only go to a certain radii (e.g. around 7.5"), because we wrote them for galaxy scale lenses. 

This branch updates the implementation to work over much larger scales, based on the input grid, for galaxy cluster / weak lensing science. 

The first PR push is only for the `NFW`, I will update all other profiles (including those using an MGE) before merging.