### PR TITLE
Feature/remove settings pixelization

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -25,7 +25,6 @@ from autoarray.inversion.pixelization.mappers.mapper_grids import MapperGrids  #
 from autoarray.inversion.pixelization.mappers.factory import (
     mapper_from as Mapper,
 )  # noqa
-from autoarray.inversion.pixelization.settings import SettingsPixelization  # noqa
 from autoarray.mask.mask_1d import Mask1D  # noqa
 from autoarray.mask.mask_2d import Mask2D  # noqa
 from autoarray.operators.convolver import Convolver  # noqa

--- a/autogalaxy/aggregator/fit_imaging.py
+++ b/autogalaxy/aggregator/fit_imaging.py
@@ -20,7 +20,6 @@ def _fit_imaging_from(
     fit: af.Fit,
     galaxies: List[Galaxy],
     settings_dataset: aa.SettingsImaging = None,
-    settings_pixelization: aa.SettingsPixelization = None,
     settings_inversion: aa.SettingsInversion = None,
     use_preloaded_grid: bool = True,
 ) -> List[FitImaging]:
@@ -31,7 +30,6 @@ def _fit_imaging_from(
 
     - The imaging data, noise-map, PSF and settings as .fits files (e.g. `dataset/data.fits`).
     - The mask used to mask the `Imaging` data structure in the fit (`dataset/mask.fits`).
-    - The settings of pixelization used by the fit (`dataset/settings_pixelization.json`).
     - The settings of inversions used by the fit (`dataset/settings_inversion.json`).
 
     Each individual attribute can be loaded from the database via the `fit.value()` method.
@@ -54,8 +52,6 @@ def _fit_imaging_from(
         A list of galaxies corresponding to a sample of a non-linear search and model-fit.
     settings_dataset
         Optionally overwrite the `SettingsImaging` of the `Imaging` object that is created from the fit.
-    settings_pixelization
-        Optionally overwrite the `SettingsPixelization` of the `Pixelization` object that is created from the fit.
     settings_inversion
         Optionally overwrite the `SettingsInversion` of the `Inversion` object that is created from the fit.
     use_preloaded_grid
@@ -70,9 +66,6 @@ def _fit_imaging_from(
 
     plane_list = _plane_from(fit=fit, galaxies=galaxies)
 
-    settings_pixelization = settings_pixelization or fit.value(
-        name="settings_pixelization"
-    )
     settings_inversion = settings_inversion or fit.value(name="settings_inversion")
 
     mesh_grids_of_planes_list = agg_util.mesh_grids_of_planes_list_from(
@@ -95,7 +88,6 @@ def _fit_imaging_from(
             FitImaging(
                 dataset=dataset,
                 plane=plane,
-                settings_pixelization=settings_pixelization,
                 settings_inversion=settings_inversion,
                 preloads=preloads,
             )
@@ -109,7 +101,6 @@ class FitImagingAgg(AbstractAgg):
         self,
         aggregator: af.Aggregator,
         settings_dataset: Optional[aa.SettingsImaging] = None,
-        settings_pixelization: Optional[aa.SettingsPixelization] = None,
         settings_inversion: Optional[aa.SettingsInversion] = None,
         use_preloaded_grid: bool = True,
     ):
@@ -121,7 +112,6 @@ class FitImagingAgg(AbstractAgg):
 
         - The imaging data, noise-map, PSF and settings as .fits files (e.g. `dataset/data.fits`).
         - The mask used to mask the `Imaging` data structure in the fit (`dataset/mask.fits`).
-        - The settings of pixelization used by the fit (`dataset/settings_pixelization.json`).
         - The settings of inversions used by the fit (`dataset/settings_inversion.json`).
 
         The `aggregator` contains the path to each of these files, and they can be loaded individually. This class
@@ -146,8 +136,6 @@ class FitImagingAgg(AbstractAgg):
             A `PyAutoFit` aggregator object which can load the results of model-fits.
         settings_dataset
             Optionally overwrite the `SettingsImaging` of the `Imaging` object that is created from the fit.
-        settings_pixelization
-            Optionally overwrite the `SettingsPixelization` of the `Pixelization` object that is created from the fit.
         settings_inversion
             Optionally overwrite the `SettingsInversion` of the `Inversion` object that is created from the fit.
         use_preloaded_grid
@@ -158,7 +146,6 @@ class FitImagingAgg(AbstractAgg):
         super().__init__(aggregator=aggregator)
 
         self.settings_dataset = settings_dataset
-        self.settings_pixelization = settings_pixelization
         self.settings_inversion = settings_inversion
         self.use_preloaded_grid = use_preloaded_grid
 
@@ -179,7 +166,6 @@ class FitImagingAgg(AbstractAgg):
             fit=fit,
             galaxies=galaxies,
             settings_dataset=self.settings_dataset,
-            settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             use_preloaded_grid=self.use_preloaded_grid,
         )

--- a/autogalaxy/aggregator/fit_interferometer.py
+++ b/autogalaxy/aggregator/fit_interferometer.py
@@ -21,7 +21,6 @@ def _fit_interferometer_from(
     galaxies: List[Galaxy],
     real_space_mask: Optional[aa.Mask2D] = None,
     settings_dataset: aa.SettingsInterferometer = None,
-    settings_pixelization: aa.SettingsPixelization = None,
     settings_inversion: aa.SettingsInversion = None,
     use_preloaded_grid: bool = True,
 ) -> List[FitInterferometer]:
@@ -32,7 +31,6 @@ def _fit_interferometer_from(
 
     - The interferometer data, noise-map, uv-wavelengths and settings as .fits files (e.g. `dataset/data.fits`).
     - The real space mask defining the grid of the interferometer for the FFT (`dataset/real_space_mask.fits`).
-    - The settings of pixelization used by the fit (`dataset/settings_pixelization.json`).
     - The settings of inversions used by the fit (`dataset/settings_inversion.json`).
 
     Each individual attribute can be loaded from the database via the `fit.value()` method.
@@ -56,8 +54,6 @@ def _fit_interferometer_from(
         A list of galaxies corresponding to a sample of a non-linear search and model-fit.
     settings_dataset
         Optionally overwrite the `SettingsInterferometer` of the `Interferometer` object that is created from the fit.
-    settings_pixelization
-        Optionally overwrite the `SettingsPixelization` of the `Pixelization` object that is created from the fit.
     settings_inversion
         Optionally overwrite the `SettingsInversion` of the `Inversion` object that is created from the fit.
     use_preloaded_grid
@@ -74,9 +70,6 @@ def _fit_interferometer_from(
     )
     plane_list = _plane_from(fit=fit, galaxies=galaxies)
 
-    settings_pixelization = settings_pixelization or fit.value(
-        name="settings_pixelization"
-    )
     settings_inversion = settings_inversion or fit.value(name="settings_inversion")
 
     mesh_grids_of_planes_list = agg_util.mesh_grids_of_planes_list_from(
@@ -99,7 +92,6 @@ def _fit_interferometer_from(
             FitInterferometer(
                 dataset=dataset,
                 plane=plane,
-                settings_pixelization=settings_pixelization,
                 settings_inversion=settings_inversion,
                 preloads=preloads,
             )
@@ -113,7 +105,6 @@ class FitInterferometerAgg(AbstractAgg):
         self,
         aggregator: af.Aggregator,
         settings_dataset: Optional[aa.SettingsInterferometer] = None,
-        settings_pixelization: Optional[aa.SettingsPixelization] = None,
         settings_inversion: Optional[aa.SettingsInversion] = None,
         use_preloaded_grid: bool = True,
         real_space_mask: Optional[aa.Mask2D] = None,
@@ -126,7 +117,6 @@ class FitInterferometerAgg(AbstractAgg):
 
         - The interferometer data, noise-map, uv-wavelengths and settings as .fits files (e.g. `dataset/data.fits`).
         - The real space mask defining the grid of the interferometer for the FFT (`dataset/real_space_mask.fits`).
-        - The settings of pixelization used by the fit (`dataset/settings_pixelization.json`).
         - The settings of inversions used by the fit (`dataset/settings_inversion.json`).
 
         The `aggregator` contains the path to each of these files, and they can be loaded individually. This class
@@ -151,8 +141,6 @@ class FitInterferometerAgg(AbstractAgg):
             A `PyAutoFit` aggregator object which can load the results of model-fits.
         settings_dataset
             Optionally overwrite the `SettingsInterferometer` of the `Interferometer` object that is created from the fit.
-        settings_pixelization
-            Optionally overwrite the `SettingsPixelization` of the `Pixelization` object that is created from the fit.
         settings_inversion
             Optionally overwrite the `SettingsInversion` of the `Inversion` object that is created from the fit.
         use_preloaded_grid
@@ -163,7 +151,6 @@ class FitInterferometerAgg(AbstractAgg):
         super().__init__(aggregator=aggregator)
 
         self.settings_dataset = settings_dataset
-        self.settings_pixelization = settings_pixelization
         self.settings_inversion = settings_inversion
         self.use_preloaded_grid = use_preloaded_grid
         self.real_space_mask = real_space_mask
@@ -185,7 +172,6 @@ class FitInterferometerAgg(AbstractAgg):
             fit=fit,
             galaxies=galaxies,
             settings_dataset=self.settings_dataset,
-            settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             use_preloaded_grid=self.use_preloaded_grid,
         )

--- a/autogalaxy/analysis/analysis.py
+++ b/autogalaxy/analysis/analysis.py
@@ -203,7 +203,6 @@ class AnalysisDataset(Analysis):
         dataset: Union[aa.Imaging, aa.Interferometer],
         adapt_result: ResultDataset = None,
         cosmology: LensingCosmology = Planck15(),
-        settings_pixelization: aa.SettingsPixelization = None,
         settings_inversion: aa.SettingsInversion = None,
     ):
         """
@@ -223,9 +222,6 @@ class AnalysisDataset(Analysis):
             used by certain classes for adapting the analysis to the properties of the dataset.
         cosmology
             The Cosmology assumed for this analysis.
-        settings_pixelization
-            settings controlling how a pixelization is fitted during the model-fit, for example if a border is used
-            when creating the pixelization.
         settings_inversion
             Settings controlling how an inversion is fitted during the model-fit, for example which linear algebra
             formalism is used.
@@ -242,7 +238,6 @@ class AnalysisDataset(Analysis):
             self.adapt_galaxy_image_path_dict = None
             self.adapt_model_image = None
 
-        self.settings_pixelization = settings_pixelization or aa.SettingsPixelization()
         self.settings_inversion = settings_inversion or aa.SettingsInversion()
 
         self.preloads = self.preloads_cls()
@@ -465,10 +460,6 @@ class AnalysisDataset(Analysis):
         paths.save_json(
             name="settings_inversion",
             object_dict=to_dict(self.settings_inversion),
-        )
-        paths.save_json(
-            name="settings_pixelization",
-            object_dict=to_dict(self.settings_pixelization),
         )
         paths.save_json(
             name="cosmology",

--- a/autogalaxy/config/general.yaml
+++ b/autogalaxy/config/general.yaml
@@ -7,7 +7,6 @@ grid:
 adapt:
   adapt_minimum_percent: 0.01
   adapt_noise_limit: 100000000.0
-  stochastic_outputs: false
 test:
   check_figure_of_merit_sanity: false
   bypass_figure_of_merit_sanity: false

--- a/autogalaxy/config/general.yaml
+++ b/autogalaxy/config/general.yaml
@@ -7,6 +7,8 @@ grid:
 adapt:
   adapt_minimum_percent: 0.01
   adapt_noise_limit: 100000000.0
+inversion:
+  relocate_pix_border: true          # If True, by default a pixelization's border is used to relocate all pixels outside its border to the border.
 test:
   check_figure_of_merit_sanity: false
   bypass_figure_of_merit_sanity: false

--- a/autogalaxy/config/priors/image_mesh/hilbert.yaml
+++ b/autogalaxy/config/priors/image_mesh/hilbert.yaml
@@ -1,0 +1,31 @@
+Hilbert:
+  pixels:
+    type: Uniform
+    lower_limit: 50.0
+    upper_limit: 2500.0
+    width_modifier:
+      type: Absolute
+      value: 100.0
+    gaussian_limits:
+      lower: 50.0
+      upper: inf
+  weight_floor:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Absolute
+      value: 0.1
+    gaussian_limits:
+      lower: 0.0
+      upper: inf
+  weight_power:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 20.0
+    width_modifier:
+      type: Absolute
+      value: 5.0
+    gaussian_limits:
+      lower: 0.0
+      upper: inf

--- a/autogalaxy/config/visualize/plots.yaml
+++ b/autogalaxy/config/visualize/plots.yaml
@@ -76,8 +76,7 @@ fit_interferometer:                        # Settings for plots of fits to inter
   dirty_residual_map: false
   dirty_normalized_residual_map: false
   dirty_chi_squared_map: false
-other:                                     # Settings for other plotting quantities.
-  stochastic_histogram: false
+
 fit_quantity:                              # Settings for plots of fit quantities (e.g. FitQuantityPlotter).
   all_at_end_png: true                     # Plot all individual plots listed below as .png (even if False)?
   all_at_end_fits: true                    # Plot all individual plots listed below as .fits (even if False)?

--- a/autogalaxy/imaging/fit_imaging.py
+++ b/autogalaxy/imaging/fit_imaging.py
@@ -22,7 +22,6 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         self,
         dataset: aa.Imaging,
         plane: Plane,
-        settings_pixelization: aa.SettingsPixelization = aa.SettingsPixelization(),
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads: aa.Preloads = Preloads(),
         run_time_dict: Optional[Dict] = None,
@@ -57,9 +56,6 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             The imaging dataset which is fitted by the galaxies in the plane.
         plane
             The plane of galaxies whose light profile images are used to fit the imaging data.
-        settings_pixelization
-            Settings controlling how a pixelization is fitted for example if a border is used when creating the
-            pixelization.
         settings_inversion
             Settings controlling how an inversion is fitted for example which linear algebra formalism is used.
         preloads
@@ -81,7 +77,6 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             self=self, model_obj=plane, settings_inversion=settings_inversion
         )
 
-        self.settings_pixelization = settings_pixelization
         self.settings_inversion = settings_inversion
 
     @property
@@ -142,7 +137,6 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             data=self.profile_subtracted_image,
             noise_map=self.noise_map,
             w_tilde=self.w_tilde,
-            settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             preloads=self.preloads,
             run_time_dict=self.run_time_dict,
@@ -316,7 +310,6 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         return FitImaging(
             dataset=self.dataset,
             plane=self.plane,
-            settings_pixelization=self.settings_pixelization,
             settings_inversion=settings_inversion,
             preloads=preloads,
             run_time_dict=run_time_dict,

--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -25,7 +25,6 @@ class AnalysisImaging(AnalysisDataset):
         dataset: aa.Imaging,
         adapt_result: ResultImaging = None,
         cosmology: LensingCosmology = Planck15(),
-        settings_pixelization: aa.SettingsPixelization = None,
         settings_inversion: aa.SettingsInversion = None,
     ):
         """
@@ -53,9 +52,6 @@ class AnalysisImaging(AnalysisDataset):
             used by certain classes for adapting the analysis to the properties of the dataset.
         cosmology
             The Cosmology assumed for this analysis.
-        settings_pixelization
-            Settings controlling how a pixelization is fitted for example if a border is used when creating the
-            pixelization.
         settings_inversion
             Settings controlling how an inversion is fitted for example which linear algebra formalism is used.
         """
@@ -63,7 +59,6 @@ class AnalysisImaging(AnalysisDataset):
             dataset=dataset,
             adapt_result=adapt_result,
             cosmology=cosmology,
-            settings_pixelization=settings_pixelization,
             settings_inversion=settings_inversion,
         )
 
@@ -219,7 +214,6 @@ class AnalysisImaging(AnalysisDataset):
         return FitImaging(
             dataset=self.dataset,
             plane=plane,
-            settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             preloads=preloads,
             run_time_dict=run_time_dict,

--- a/autogalaxy/interferometer/fit_interferometer.py
+++ b/autogalaxy/interferometer/fit_interferometer.py
@@ -17,7 +17,6 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         self,
         dataset: aa.Interferometer,
         plane: Plane,
-        settings_pixelization: aa.SettingsPixelization = aa.SettingsPixelization(),
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads: aa.Preloads = Preloads(),
         run_time_dict: Optional[Dict] = None,
@@ -53,9 +52,6 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
             The interfometer dataset which is fitted by the galaxies in the plane.
         plane
             The plane of galaxies whose light profile images are used to fit the interferometer data.
-        settings_pixelization
-            Settings controlling how a pixelization is fitted for example if a border is used when creating the
-            pixelization.
         settings_inversion
             Settings controlling how an inversion is fitted for example which linear algebra formalism is used.
         preloads
@@ -80,7 +76,6 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
 
         self.plane = plane
 
-        self.settings_pixelization = settings_pixelization
         self.settings_inversion = settings_inversion
 
         self.preloads = preloads
@@ -111,7 +106,6 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
             data=self.profile_subtracted_visibilities,
             noise_map=self.noise_map,
             w_tilde=self.w_tilde,
-            settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             preloads=self.preloads,
         )
@@ -252,7 +246,6 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         return FitInterferometer(
             dataset=self.interferometer,
             plane=self.plane,
-            settings_pixelization=self.settings_pixelization,
             settings_inversion=settings_inversion,
             preloads=preloads,
             run_time_dict=run_time_dict,

--- a/autogalaxy/interferometer/model/analysis.py
+++ b/autogalaxy/interferometer/model/analysis.py
@@ -29,7 +29,6 @@ class AnalysisInterferometer(AnalysisDataset):
         dataset: aa.Interferometer,
         adapt_result: ResultInterferometer = None,
         cosmology: LensingCosmology = Planck15(),
-        settings_pixelization: aa.SettingsPixelization = None,
         settings_inversion: aa.SettingsInversion = None,
     ):
         """
@@ -57,9 +56,6 @@ class AnalysisInterferometer(AnalysisDataset):
             used by certain classes for adapting the analysis to the properties of the dataset.
         cosmology
             The Cosmology assumed for this analysis.
-        settings_pixelization
-            settings controlling how a pixelization is fitted for example if a border is used when creating the
-            pixelization.
         settings_inversion
             Settings controlling how an inversion is fitted, for example which linear algebra formalism is used.
         """
@@ -67,7 +63,6 @@ class AnalysisInterferometer(AnalysisDataset):
             dataset=dataset,
             adapt_result=adapt_result,
             cosmology=cosmology,
-            settings_pixelization=settings_pixelization,
             settings_inversion=settings_inversion,
         )
 
@@ -221,7 +216,6 @@ class AnalysisInterferometer(AnalysisDataset):
         return FitInterferometer(
             dataset=self.dataset,
             plane=plane,
-            settings_pixelization=self.settings_pixelization,
             settings_inversion=self.settings_inversion,
             preloads=preloads,
             run_time_dict=run_time_dict,

--- a/autogalaxy/plane/to_inversion.py
+++ b/autogalaxy/plane/to_inversion.py
@@ -26,7 +26,6 @@ class AbstractToInversion:
         data: Optional[Union[aa.Array2D, aa.Visibilities]] = None,
         noise_map: Optional[Union[aa.Array2D, aa.VisibilitiesNoiseMap]] = None,
         w_tilde: Optional[Union[aa.WTildeImaging, aa.WTildeInterferometer]] = None,
-        settings_pixelization=aa.SettingsPixelization(),
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads=Preloads(),
         run_time_dict: Optional[Dict] = None,
@@ -48,7 +47,6 @@ class AbstractToInversion:
         self.noise_map = noise_map
         self.w_tilde = w_tilde
 
-        self.settings_pixelization = settings_pixelization
         self.settings_inversion = settings_inversion
 
         self.preloads = preloads
@@ -99,7 +97,6 @@ class PlaneToInversion(AbstractToInversion):
         grid: Optional[aa.type.Grid2DLike] = None,
         blurring_grid: Optional[aa.type.Grid2DLike] = None,
         grid_pixelization: Optional[aa.type.Grid2DLike] = None,
-        settings_pixelization=aa.SettingsPixelization(),
         settings_inversion: aa.SettingsInversion = aa.SettingsInversion(),
         preloads=aa.Preloads(),
         run_time_dict: Optional[Dict] = None,
@@ -111,7 +108,6 @@ class PlaneToInversion(AbstractToInversion):
             data=data,
             noise_map=noise_map,
             w_tilde=w_tilde,
-            settings_pixelization=settings_pixelization,
             settings_inversion=settings_inversion,
             preloads=preloads,
             run_time_dict=run_time_dict,
@@ -222,7 +218,6 @@ class PlaneToInversion(AbstractToInversion):
             source_plane_mesh_grid=source_plane_mesh_grid,
             image_plane_mesh_grid=image_plane_mesh_grid,
             adapt_data=adapt_galaxy_image,
-            settings=self.settings_pixelization,
             preloads=self.preloads,
             run_time_dict=self.plane.run_time_dict,
         )

--- a/autogalaxy/plane/to_inversion.py
+++ b/autogalaxy/plane/to_inversion.py
@@ -217,6 +217,7 @@ class PlaneToInversion(AbstractToInversion):
             source_plane_data_grid=self.grid_pixelization,
             source_plane_mesh_grid=source_plane_mesh_grid,
             image_plane_mesh_grid=image_plane_mesh_grid,
+            relocate_pix_border=self.settings_inversion.relocate_pix_border,
             adapt_data=adapt_galaxy_image,
             preloads=self.preloads,
             run_time_dict=self.plane.run_time_dict,

--- a/test_autogalaxy/config/general.yaml
+++ b/test_autogalaxy/config/general.yaml
@@ -10,6 +10,7 @@ inversion:
   use_positive_only_solver: false    # If True, inversion's use a positive-only linear algebra solver by default, which is slower but prevents unphysical negative values in the reconstructed solutuion.
   no_regularization_add_to_curvature_diag_value: 1.0e-8 # The default value added to the curvature matrix's diagonal when regularization is not applied to a linear object, which prevents inversion's failing due to the matrix being singular.
   positive_only_uses_p_initial: false  # If True, the positive-only solver of an inversion's uses an initial guess of the reconstructed data's values as which values should be positive, speeding up the solver.
+  relocate_pix_border: false          # If True, by default a pixelization's border is used to relocate all pixels outside its border to the border.
 hpc:
   hpc_mode: false
   iterations_per_update: 5000

--- a/test_autogalaxy/config/general.yaml
+++ b/test_autogalaxy/config/general.yaml
@@ -16,7 +16,6 @@ hpc:
 adapt:
   adapt_minimum_percent: 0.01
   adapt_noise_limit: 100000000.0
-  stochastic_outputs: false
 model:
   ignore_prior_limits: true
 numba:

--- a/test_autogalaxy/interferometer/test_simulate_and_fit_interferometer.py
+++ b/test_autogalaxy/interferometer/test_simulate_and_fit_interferometer.py
@@ -70,7 +70,6 @@ def test__perfect_fit__chi_squared_0():
     fit = ag.FitInterferometer(
         dataset=dataset,
         plane=plane,
-        settings_pixelization=ag.SettingsPixelization(use_border=False),
         settings_inversion=ag.SettingsInversion(use_w_tilde=False),
     )
 
@@ -92,7 +91,6 @@ def test__perfect_fit__chi_squared_0():
     fit = ag.FitInterferometer(
         dataset=dataset,
         plane=plane,
-        settings_pixelization=ag.SettingsPixelization(use_border=False),
         settings_inversion=ag.SettingsInversion(use_w_tilde=False),
     )
     assert abs(fit.chi_squared) < 1.0e-4
@@ -183,7 +181,6 @@ def test__linear_light_profiles_agree_with_standard_light_profiles():
     fit = ag.FitInterferometer(
         dataset=dataset,
         plane=plane,
-        settings_pixelization=ag.SettingsPixelization(use_border=False),
         settings_inversion=ag.SettingsInversion(use_w_tilde=False),
     )
 
@@ -198,7 +195,6 @@ def test__linear_light_profiles_agree_with_standard_light_profiles():
     fit_linear = ag.FitInterferometer(
         dataset=dataset,
         plane=plane_linear,
-        settings_pixelization=ag.SettingsPixelization(use_border=False),
         settings_inversion=ag.SettingsInversion(
             use_w_tilde=False, no_regularization_add_to_curvature_diag_value=False
         ),

--- a/test_autogalaxy/plane/test_to_inversion.py
+++ b/test_autogalaxy/plane/test_to_inversion.py
@@ -212,7 +212,6 @@ def test__inversion_imaging_from(sub_grid_2d_7x7, masked_imaging_7x7):
         data=masked_imaging_7x7.data,
         noise_map=masked_imaging_7x7.noise_map,
         w_tilde=masked_imaging_7x7.w_tilde,
-        settings_pixelization=ag.SettingsPixelization(use_border=False),
         settings_inversion=ag.SettingsInversion(use_w_tilde=False),
     )
 
@@ -235,7 +234,6 @@ def test__inversion_imaging_from(sub_grid_2d_7x7, masked_imaging_7x7):
         data=masked_imaging_7x7.data,
         noise_map=masked_imaging_7x7.noise_map,
         w_tilde=masked_imaging_7x7.w_tilde,
-        settings_pixelization=ag.SettingsPixelization(use_border=False),
         settings_inversion=ag.SettingsInversion(use_w_tilde=False),
     )
 
@@ -257,7 +255,6 @@ def test__inversion_interferometer_from(sub_grid_2d_7x7, interferometer_7):
         data=interferometer_7.visibilities,
         noise_map=interferometer_7.noise_map,
         w_tilde=None,
-        settings_pixelization=ag.SettingsPixelization(use_border=False),
         settings_inversion=ag.SettingsInversion(
             use_w_tilde=False, use_linear_operators=False
         ),
@@ -284,7 +281,6 @@ def test__inversion_interferometer_from(sub_grid_2d_7x7, interferometer_7):
         data=interferometer_7.visibilities,
         noise_map=interferometer_7.noise_map,
         w_tilde=None,
-        settings_pixelization=ag.SettingsPixelization(use_border=False),
         settings_inversion=ag.SettingsInversion(
             use_w_tilde=False, use_linear_operators=False
         ),


### PR DESCRIPTION
Removes the `SettingsPixelization` object and moves its only input, `use_border`, to the `SettingsInversion` object.