### PR TITLE
added MaternKernel prior

### DIFF
--- a/autogalaxy/config/priors/regularization/exponential_kernel.yaml
+++ b/autogalaxy/config/priors/regularization/exponential_kernel.yaml
@@ -1,0 +1,21 @@
+ExponentialKernel:
+  coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    gaussian_limits:
+      lower: 0.0
+      upper: inf
+  scale:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    gaussian_limits:
+      lower: 0.0
+      upper: inf

--- a/autogalaxy/config/priors/regularization/gaussian_kernel.yaml
+++ b/autogalaxy/config/priors/regularization/gaussian_kernel.yaml
@@ -1,0 +1,21 @@
+GaussianKernel:
+  coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    gaussian_limits:
+      lower: 0.0
+      upper: inf
+  scale:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    gaussian_limits:
+      lower: 0.0
+      upper: inf

--- a/autogalaxy/config/priors/regularization/matern_kernel.yaml
+++ b/autogalaxy/config/priors/regularization/matern_kernel.yaml
@@ -1,0 +1,31 @@
+MaternKernel:
+  coefficient:
+    type: LogUniform
+    lower_limit: 1.0e-06
+    upper_limit: 1000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    gaussian_limits:
+      lower: 0.0
+      upper: inf
+  scale:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    gaussian_limits:
+      lower: 0.0
+      upper: inf
+  nu:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 3.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    gaussian_limits:
+      lower: 0.0
+      upper: inf


### PR DESCRIPTION
Implements the Exponential / Gaussian smoothing kernels for regularization documented in Vernardos 2022:

https://arxiv.org/abs/2202.09378

Also implements a Matern kernel, which is an extension of the above methods which allows for more control other the derivative of smoothing.

Thank you @caoxiaoyue for the implementation and code!
