### PR TITLE
Background Sky Modeling

### DIFF
--- a/autogalaxy/config/priors/light/standard/sky.yaml
+++ b/autogalaxy/config/priors/light/standard/sky.yaml
@@ -1,0 +1,11 @@
+Sky:
+  intensity:
+    type: Uniform
+    lower_limit: -10.0
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    gaussian_limits:
+      lower: 0.0
+      upper: inf

--- a/autogalaxy/profiles/light/linear/__init__.py
+++ b/autogalaxy/profiles/light/linear/__init__.py
@@ -9,3 +9,4 @@ from .exponential_core import ExponentialCore
 from .shapelets.polar import ShapeletPolarSph, ShapeletPolar
 from .shapelets.cartesian import ShapeletCartesianSph, ShapeletCartesian
 from .shapelets.exponential import ShapeletExponentialSph, ShapeletExponential
+from .sky import Sky

--- a/autogalaxy/profiles/light/linear/sky.py
+++ b/autogalaxy/profiles/light/linear/sky.py
@@ -1,0 +1,25 @@
+from autogalaxy.profiles.light.linear.abstract import LightProfileLinear
+
+from autogalaxy.profiles.light import standard as lp
+from autogalaxy.profiles import light_and_mass_profiles as lmp
+
+
+class Sky(lp.Sky, LightProfileLinear):
+    def __init__(
+        self,
+    ):
+        """
+        The linear sky light profile, representing the background sky emission as a constant sheet of values.
+        """
+
+        super().__init__(
+            intensity=1.0,
+        )
+
+    @property
+    def lp_cls(self):
+        return lp.Sky
+
+    @property
+    def lmp_cls(self):
+        return lmp.sky

--- a/autogalaxy/profiles/light/linear/sky.py
+++ b/autogalaxy/profiles/light/linear/sky.py
@@ -1,7 +1,4 @@
-from typing import List
-
 from autogalaxy.profiles.light.basis import Basis
-from autogalaxy.profiles.light.abstract import LightProfile
 from autogalaxy.profiles.light.linear.abstract import LightProfileLinear
 
 from autogalaxy.profiles.light import standard as lp

--- a/autogalaxy/profiles/light/linear/sky.py
+++ b/autogalaxy/profiles/light/linear/sky.py
@@ -1,17 +1,32 @@
+from typing import List
+
+from autogalaxy.profiles.light.basis import Basis
+from autogalaxy.profiles.light.abstract import LightProfile
 from autogalaxy.profiles.light.linear.abstract import LightProfileLinear
 
 from autogalaxy.profiles.light import standard as lp
-from autogalaxy.profiles import light_and_mass_profiles as lmp
 
 
-class Sky(lp.Sky, LightProfileLinear):
+class Sky(Basis):
     def __init__(
         self,
     ):
         """
         The linear sky light profile, representing the background sky emission as a constant sheet of values.
         """
+        super().__init__(
+            light_profile_list=[SkyPos(), SkyNeg()]
+        )
 
+
+
+class SkyPos(lp.Sky, LightProfileLinear):
+    def __init__(
+        self,
+    ):
+        """
+        The linear sky light profile, representing the background sky emission as a constant sheet of values.
+        """
         super().__init__(
             intensity=1.0,
         )
@@ -20,6 +35,18 @@ class Sky(lp.Sky, LightProfileLinear):
     def lp_cls(self):
         return lp.Sky
 
+
+class SkyNeg(lp.Sky, LightProfileLinear):
+    def __init__(
+        self,
+    ):
+        """
+        The linear sky light profile, representing the background sky emission as a constant sheet of values.
+        """
+        super().__init__(
+            intensity=-1.0,
+        )
+
     @property
-    def lmp_cls(self):
-        return lmp.sky
+    def lp_cls(self):
+        return lp.Sky

--- a/autogalaxy/profiles/light/linear/sky.py
+++ b/autogalaxy/profiles/light/linear/sky.py
@@ -10,12 +10,21 @@ class Sky(Basis):
     ):
         """
         The linear sky light profile, representing the background sky emission as a constant sheet of values.
+
+        For a positive only linear solver, a single sky profile cannot be used to solve for the sky background.
+        This is because the solution must be positive, meaning that if the sky background is positive, negative
+        solutions are not accessible and visa-versa.
+
+        To address this, the sky is represented by two profiles, one with a positive intensity and one with a negative
+        intensity. The positive linear solver then fits for the both the positive and negative sky values. The solution
+        will have one of these values as zero, and the other as the sky background value.
+
+        When a positive-negative solver is used, no loss of performance is incurred by using two profiles, even though
+        the two solutions are fully degenerate. The same API is therefore used for both solvers, for convenience.
         """
         super().__init__(
             light_profile_list=[SkyPos(), SkyNeg()]
         )
-
-
 
 class SkyPos(lp.Sky, LightProfileLinear):
     def __init__(

--- a/autogalaxy/profiles/light/standard/__init__.py
+++ b/autogalaxy/profiles/light/standard/__init__.py
@@ -16,3 +16,4 @@ from .eff import (
 from .shapelets.polar import ShapeletPolarSph, ShapeletPolar
 from .shapelets.cartesian import ShapeletCartesianSph, ShapeletCartesian
 from .shapelets.exponential import ShapeletExponentialSph, ShapeletExponential
+from .sky import Sky

--- a/autogalaxy/profiles/light/standard/sky.py
+++ b/autogalaxy/profiles/light/standard/sky.py
@@ -19,8 +19,13 @@ class Sky:
             Overall intensity normalisation of the light profile (units are dimensionless and derived from the data
             the light profile's image is compared too, which is expected to be electrons per second).
         """
+        self.centre = (0.0, 0.0)
+        self.ell_comps = (0.0, 0.0)
+
         self.intensity = intensity
 
     @aa.grid_dec.grid_2d_to_structure
     def image_2d_from(self, grid: aa.type.Grid2DLike):
         return np.full(shape=grid.shape[0], fill_value=self.intensity)
+
+

--- a/autogalaxy/profiles/light/standard/sky.py
+++ b/autogalaxy/profiles/light/standard/sky.py
@@ -1,12 +1,7 @@
 import numpy as np
-from typing import Optional, Tuple
 
 import autoarray as aa
 
-from autogalaxy.profiles.light.abstract import LightProfile
-from autogalaxy.profiles.light.decorators import (
-    check_operated_only,
-)
 
 
 class Sky:

--- a/autogalaxy/profiles/light/standard/sky.py
+++ b/autogalaxy/profiles/light/standard/sky.py
@@ -1,0 +1,31 @@
+import numpy as np
+from typing import Optional, Tuple
+
+import autoarray as aa
+
+from autogalaxy.profiles.light.abstract import LightProfile
+from autogalaxy.profiles.light.decorators import (
+    check_operated_only,
+)
+
+
+class Sky:
+
+    def __init__(
+        self,
+        intensity: float = 0.1,
+    ):
+        """
+        The sky light profile, representing the background sky emission as a constant sheet of values.
+
+        Parameters
+        ----------
+        intensity
+            Overall intensity normalisation of the light profile (units are dimensionless and derived from the data
+            the light profile's image is compared too, which is expected to be electrons per second).
+        """
+        self.intensity = intensity
+
+    @aa.grid_dec.grid_2d_to_structure
+    def image_2d_from(self, grid: aa.type.Grid2DLike):
+        return np.full(shape=grid.shape[0], fill_value=self.intensity)

--- a/autogalaxy/profiles/light/standard/sky.py
+++ b/autogalaxy/profiles/light/standard/sky.py
@@ -2,9 +2,9 @@ import numpy as np
 
 import autoarray as aa
 
+from autogalaxy.profiles.light.abstract import LightProfile
 
-
-class Sky:
+class Sky(LightProfile):
 
     def __init__(
         self,
@@ -13,14 +13,17 @@ class Sky:
         """
         The sky light profile, representing the background sky emission as a constant sheet of values.
 
+        To be consistent with other parts of the light profile API, the sky is passed a centre and elliptical
+        components, but these are not used. The sky is a constant value across the whole image and therefore
+        does not have an image which depends on these geometric parameters.
+
         Parameters
         ----------
         intensity
             Overall intensity normalisation of the light profile (units are dimensionless and derived from the data
             the light profile's image is compared too, which is expected to be electrons per second).
         """
-        self.centre = (0.0, 0.0)
-        self.ell_comps = (0.0, 0.0)
+        super().__init__(centre = (0.0, 0.0), ell_comps = (0.0, 0.0))
 
         self.intensity = intensity
 

--- a/autogalaxy/profiles/light/standard/sky.py
+++ b/autogalaxy/profiles/light/standard/sky.py
@@ -2,9 +2,7 @@ import numpy as np
 
 import autoarray as aa
 
-from autogalaxy.profiles.light.abstract import LightProfile
-
-class Sky(LightProfile):
+class Sky:
 
     def __init__(
         self,
@@ -23,7 +21,6 @@ class Sky(LightProfile):
             Overall intensity normalisation of the light profile (units are dimensionless and derived from the data
             the light profile's image is compared too, which is expected to be electrons per second).
         """
-        super().__init__(centre = (0.0, 0.0), ell_comps = (0.0, 0.0))
 
         self.intensity = intensity
 
@@ -32,3 +29,10 @@ class Sky(LightProfile):
         return np.full(shape=grid.shape[0], fill_value=self.intensity)
 
 
+    @property
+    def centre(self):
+        return (0.0, 0.0)
+
+    @property
+    def ell_comps(self):
+        return (0.0, 0.0)

--- a/test_autogalaxy/imaging/test_fit_imaging.py
+++ b/test_autogalaxy/imaging/test_fit_imaging.py
@@ -189,6 +189,24 @@ def test__fit_figure_of_merit(
     assert fit.figure_of_merit == pytest.approx(-23.146720, 1.0e-4)
 
 
+def test__fit__sky_linear_light_profile__handles_special_behaviour(masked_imaging_7x7):
+
+    g0_linear_light = ag.Galaxy(
+        redshift=0.5, bulge=ag.lp_linear.Sersic(sersic_index=1.0), sky=ag.lp_linear.Sky()
+    )
+
+    fit = ag.FitImaging(
+        dataset=masked_imaging_7x7, galaxies=[g0_linear_light]
+    )
+
+    assert fit.perform_inversion is True
+    assert fit.figure_of_merit == pytest.approx(-14.5087714, 1.0e-4)
+
+    galaxies = fit.galaxies_linear_light_profiles_to_light_profiles
+
+    assert galaxies[0].sky.light_profile_list[0].intensity == pytest.approx(0.5, 1.0e-4)
+    assert galaxies[0].sky.light_profile_list[1].intensity == pytest.approx(-0.5, 1.0e-4)
+
 def test__galaxy_model_image_dict(masked_imaging_7x7):
     # Normal Light Profiles Only
 

--- a/test_autogalaxy/profiles/light/standard/test_sky.py
+++ b/test_autogalaxy/profiles/light/standard/test_sky.py
@@ -1,0 +1,18 @@
+from __future__ import division, print_function
+import numpy as np
+import pytest
+
+import autogalaxy as ag
+
+grid = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [2.0, 4.0]])
+
+
+def test__image_2d_from():
+    lp = ag.lp.Sky(
+        intensity=3.0,
+    )
+
+    image = lp.image_2d_from(grid=np.array([[1.0, 0.0], [3.0, 0.0]]))
+
+    assert image[0] == pytest.approx(3.0, 1e-3)
+    assert image[1] == pytest.approx(3.0, 1e-3)


### PR DESCRIPTION
Implements a `Sky` light profile which when included in galaxies models the background sky surrounding them.

This includes a `lp_linear.Sky` which fits for the sky as a linear light profile.

The linear sky light profile, representing the background sky emission as a constant sheet of values.

For a positive only linear solver, a single sky profile cannot be used to solve for the sky background robustly.
This is because the solution must be positive, meaning that negative solutions are not accessible.

To address this, the sky is represented by two flat sky profiles, one with a positive intensity and one with a 
negative intensity. The positive linear solver then fits for the both the positive and negative sky values. 
The solution will have one of these values as zero, and the other as the sky background value.

When a positive-negative solver is used, no loss of performance is incurred by using two profiles, even though
the two solutions are fully degenerate. The same API is therefore used for both solvers, for convenience.