### PR TITLE
Simplify Figure of Merit Sanity check and Disable by Default

### DIFF
--- a/autogalaxy/analysis/analysis.py
+++ b/autogalaxy/analysis/analysis.py
@@ -443,7 +443,7 @@ class AnalysisDataset(Analysis):
         if os.environ.get("PYAUTOFIT_TEST_MODE") == "1":
             return
 
-        if conf.instance["general"]["test"]["bypass_figure_of_merit_sanity"]:
+        if not conf.instance["general"]["test"]["check_figure_of_merit_sanity"]:
             return
 
         figure_of_merit = result.max_log_likelihood_fit.figure_of_merit
@@ -451,16 +451,15 @@ class AnalysisDataset(Analysis):
         try:
             figure_of_merit_sanity = paths.load_json(name="figure_of_merit_sanity")
 
-            if conf.instance["general"]["test"]["check_figure_of_merit_sanity"]:
-                if not np.isclose(figure_of_merit, figure_of_merit_sanity):
-                    raise exc.AnalysisException(
-                        "Figure of merit sanity check failed. "
-                        ""
-                        "This means that the existing results of a model fit used a different "
-                        "likelihood function compared to the one implemented now.\n\n"
-                        f"Old Figure of Merit = {figure_of_merit_sanity}\n"
-                        f"New Figure of Merit = {figure_of_merit}"
-                    )
+            if not np.isclose(figure_of_merit, figure_of_merit_sanity):
+                raise exc.AnalysisException(
+                    "Figure of merit sanity check failed. "
+                    ""
+                    "This means that the existing results of a model fit used a different "
+                    "likelihood function compared to the one implemented now.\n\n"
+                    f"Old Figure of Merit = {figure_of_merit_sanity}\n"
+                    f"New Figure of Merit = {figure_of_merit}"
+                )
 
         except (FileNotFoundError, KeyError):
             paths.save_json(

--- a/autogalaxy/config/general.yaml
+++ b/autogalaxy/config/general.yaml
@@ -10,8 +10,7 @@ adapt:
 inversion:
   relocate_pix_border: true          # If True, by default a pixelization's border is used to relocate all pixels outside its border to the border.
 test:
-  check_figure_of_merit_sanity: false
-  bypass_figure_of_merit_sanity: false
+  check_figure_of_merit_sanity: false # If True, a sanity check is performed when a model-fit is resumed, to ensure the figure of merit of the new fit computed via the likelihood function is consistent with the previous fit.
   check_preloads: false
   exception_override: false
   preloads_check_threshold: 1.0     # If the figure of merit of a fit with and without preloads is greater than this threshold, the check preload test fails and an exception raised for a model-fit. 


### PR DESCRIPTION
An in-built sanity check can be performed, which when a non-linear search restarts compares the output value of the likelihood function to a value saved during the previous run.

If the values are inconsistent, an exception is raised.

This catches fits where the likelihood function has changed or is numerically unstable.

This PR simplifies the code by having just one config entry to turn the feature on and off. It also disables it by default, as it slows down the code and should not be relevent for most end users who do not interact with the source code.