### PR TITLE
Feature/adaptive sub

### DIFF
--- a/autogalaxy/config/visualize/plots.yaml
+++ b/autogalaxy/config/visualize/plots.yaml
@@ -52,7 +52,8 @@ inversion:                                 # Settings for plots of inversions (e
   all_at_end_pdf: false                    # Plot all individual plots listed below as publication-quality .pdf (even if False)?
   data_subtracted: false                   # Plot individual plots of the data with the other inversion linear objects subtracted?
   errors: false                            # Plot image of the errors of every mesh-pixel reconstructed value?
-  mesh_pixels_per_image_pixels : false     # Plot the number of image-plane mesh pixels per masked data pixels?
+  sub_pixels_per_image_pixels: false      # Plot the number of sub pixels per masked data pixels?
+  mesh_pixels_per_image_pixels: false     # Plot the number of image-plane mesh pixels per masked data pixels?
   reconstructed_image: false               # Plot image of the reconstructed data (e.g. in the image-plane)?
   reconstruction: false                    # Plot the reconstructed inversion (e.g. the pixelization's mesh in the source-plane)?
   regularization_weights: false            # Plot the effective regularization weight of every inversion mesh pixel?

--- a/autogalaxy/galaxy/to_inversion.py
+++ b/autogalaxy/galaxy/to_inversion.py
@@ -249,6 +249,7 @@ class GalaxiesToInversion(AbstractToInversion):
         image_plane_mesh_grid: Optional[aa.Grid2DIrregular] = None,
     ) -> aa.AbstractMapper:
         mapper_grids = mesh.mapper_grids_from(
+            mask=self.dataset.mask,
             border_relocator=self.border_relocator,
             source_plane_data_grid=source_plane_data_grid,
             source_plane_mesh_grid=source_plane_mesh_grid,

--- a/autogalaxy/galaxy/to_inversion.py
+++ b/autogalaxy/galaxy/to_inversion.py
@@ -51,7 +51,6 @@ class AbstractToInversion:
         self.preloads = preloads
         self.run_time_dict = run_time_dict
 
-
     @property
     def convolver(self):
         try:

--- a/test_autogalaxy/interferometer/test_fit_interferometer.py
+++ b/test_autogalaxy/interferometer/test_fit_interferometer.py
@@ -186,6 +186,7 @@ def test___galaxy_model_image_dict(interferometer_7):
     )
 
     mapper_grids = pixelization.mesh.mapper_grids_from(
+        mask=interferometer_7.real_space_mask,
         source_plane_data_grid=interferometer_7.grid,
         border_relocator=interferometer_7.border_relocator,
         source_plane_mesh_grid=None,
@@ -312,6 +313,7 @@ def test___galaxy_model_visibilities_dict(interferometer_7):
     )
 
     mapper_grids = pixelization.mesh.mapper_grids_from(
+        mask=interferometer_7.real_space_mask,
         source_plane_data_grid=interferometer_7.grid,
         border_relocator=interferometer_7.border_relocator,
         source_plane_mesh_grid=None,


### PR DESCRIPTION
Adaptive sub-sampling now works for pixelizations.

This means that instead of a fixed `sub_size` being used for a pixelization, an array with the same dimensions as the mask can be input specifying the `sub_size` in each image pixel.

This means we can assign high `sub_size` values to a source galaxy's brightest regions and low values elsewhere, offering computational speed up.

Template SLaM pipelines using this functionality will be provided after testing.