### PR TITLE
Feature/lmp linear

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -83,6 +83,7 @@ from .profiles import (
     point_sources as ps,
     mass as mp,
     light_and_mass_profiles as lmp,
+    light_linear_and_mass_profiles as lmp_linear,
     scaling_relations as sr,
 )
 from .profiles.light.abstract import LightProfile

--- a/autogalaxy/analysis/chaining_util.py
+++ b/autogalaxy/analysis/chaining_util.py
@@ -15,6 +15,7 @@ from autogalaxy.profiles.basis import Basis
 from autogalaxy.profiles.light import standard as lp
 from autogalaxy.profiles.light import linear as lp_linear
 from autogalaxy.profiles import light_and_mass_profiles as lmp
+from autogalaxy.profiles import light_linear_and_mass_profiles as lmp_linear
 
 
 def mass_from(mass, mass_result, unfix_mass_centre: bool = False) -> af.Model:
@@ -234,76 +235,7 @@ def clumps_from(
     return clumps
 
 
-def mass_light_dark_lmp_from(
-    light_result: Result, name : str, light_is_model : bool = False
-):
-    """
-    Returns a light and mass profile from a standard light profile (e.g. a Sersic) in the LIGHT PIPELINE result, for
-    the LIGHT DARK MASS PIPELINE.
-
-    For example, if the light pipeline fits a Sersic profile, this function will return a Sersic profile for the LIGHT
-    DARK MASS PIPELINE.
-
-    If a linear light profile is passed in, the function will return a light and mass profile where its `intensity` is
-    fixed to the solved for value of the maximum log likelihood linear fit.
-
-    The light and mass profiles can also be switched to variants which have a radial gradient in their mass-to-light
-    conversion, by setting the `include_mass_to_light_gradient` parameter to `True`.
-
-    Parameters
-    ----------
-    light_result
-        The result of the light pipeline, which determines the light and mass profiles used in the LIGHT DARK
-        MASS PIPELINE.
-    name
-        The name of the light profile in the light pipeline's galaxy model that the model is being created for
-    light_is_model
-        If `True`, the light profile is passed as a model component, else it is a fixed instance.
-
-    Returns
-    -------
-    The light and mass profile for a standard light profile whose priors are initialized from a previous result.
-    """
-
-    lp_instance = getattr(light_result.instance.galaxies.lens, name)
-    lp_model = getattr(light_result.model.galaxies.lens, name)
-
-    lp_to_lmp_dict = {
-        lp.Sersic : lmp.Sersic
-    }
-    lp_linear_to_lmp_dict = {
-        lp_linear.Sersic : lmp.Sersic
-    }
-
-    try:
-
-        is_linear = False
-
-        lmp_model = lp_to_lmp_dict[type(lp_instance)]
-
-    except KeyError:
-
-        is_linear = True
-        lmp_model = lp_linear_to_lmp_dict[type(lp_instance)]
-
-    lmp_model = af.Model(lmp_model)
-
-    if light_is_model:
-        lmp_model.take_attributes(source=lp_model)
-    else:
-        lmp_model.take_attributes(source=lp_instance)
-
-    if is_linear:
-
-        fit = light_result.max_log_likelihood_fit
-        lp_solved = getattr(fit.model_obj_linear_light_profiles_to_light_profiles.galaxies[0], name)
-
-        lmp_model.intensity = lp_solved.intensity
-
-    return lmp_model
-
-
-def basis_no_linear_from(light_result: Result, name : str) -> af.Model:
+def basis_no_linear_from(light_result: Result, name: str) -> af.Model:
     """
     Returns a basis containing standard light profiles from a basis (e.g. an MGE) in the LIGHT PIPELINE result,
     for the TOTAL MASS PIPELINE.
@@ -340,7 +272,12 @@ def basis_no_linear_from(light_result: Result, name : str) -> af.Model:
     """
 
     try:
-        lp_instance = getattr(light_result.max_log_likelihood_fit.model_obj_linear_light_profiles_to_light_profiles.galaxies[0], name)
+        lp_instance = getattr(
+            light_result.max_log_likelihood_fit.model_obj_linear_light_profiles_to_light_profiles.galaxies[
+                0
+            ],
+            name,
+        )
     except AttributeError:
         return None
 
@@ -352,26 +289,95 @@ def basis_no_linear_from(light_result: Result, name : str) -> af.Model:
     lp_model_list = []
 
     for i, light_profile in enumerate(profile_list):
+        lp_model = af.Model(lp.Gaussian)
 
-        if light_profile.intensity > 0.0:
+        lp_model.centre = light_profile.centre
+        lp_model.ell_comps = light_profile.ell_comps
+        lp_model.intensity = light_profile.intensity
+        lp_model.sigma = light_profile.sigma
 
-            lp_model = af.Model(lp.Gaussian)
+        lp_model_list += [lp_model]
 
-            lp_model.centre = light_profile.centre
-            lp_model.ell_comps = light_profile.ell_comps
-            lp_model.intensity = light_profile.intensity
-            lp_model.sigma = light_profile.sigma
+    return af.Model(Basis, profile_list=lp_model_list)
 
-            lp_model_list += [lp_model]
 
-    return af.Model(
-        Basis,
-        profile_list=lp_model_list
-    )
+def mass_light_dark_lmp_from(
+    light_result: Result,
+    name: str,
+    linear_lp_to_standard: bool = False,
+    light_is_model: bool = False,
+):
+    """
+    Returns a light and mass profile from a standard light profile (e.g. a Sersic) in the LIGHT PIPELINE result, for
+    the LIGHT DARK MASS PIPELINE.
+
+    For example, if the light pipeline fits a Sersic profile, this function will return a Sersic profile for the LIGHT
+    DARK MASS PIPELINE.
+
+    For the light profile, it will by default use a linear light and mass profile, which therefore continues to solve
+    for the intensity of the linear light profile via linear algebra. This means that during the fit the `intensity`
+    used to compute deflection angles is not the same as the `intensity` parameter solved for in the linear light
+    profile. If the input `linear_lp_to_standard` is `True`, the function will instead use a standard light profile.
+
+    The light and mass profiles can also be switched to variants which have a radial gradient in their mass-to-light
+    conversion, by setting the `include_mass_to_light_gradient` parameter to `True`.
+
+    Parameters
+    ----------
+    light_result
+        The result of the light pipeline, which determines the light and mass profiles used in the LIGHT DARK
+        MASS PIPELINE.
+    name
+        The name of the light profile in the light pipeline's galaxy model that the model is being created for
+    light_is_model
+        If `True`, the light profile is passed as a model component, else it is a fixed instance.
+
+    Returns
+    -------
+    The light and mass profile for a standard light profile whose priors are initialized from a previous result.
+    """
+
+    lp_instance = getattr(light_result.instance.galaxies.lens, name)
+    lp_model = getattr(light_result.model.galaxies.lens, name)
+
+    try:
+        is_linear = False
+
+        lp_to_lmp_dict = {lp.Sersic: lmp.Sersic}
+
+        lmp_model = lp_to_lmp_dict[type(lp_instance)]
+
+    except KeyError:
+        if not linear_lp_to_standard:
+            lp_linear_to_lmp_dict = {lp_linear.Sersic: lmp_linear.Sersic}
+        else:
+            lp_linear_to_lmp_dict = {lp_linear.Sersic: lmp.Sersic}
+
+        is_linear = True
+        lmp_model = lp_linear_to_lmp_dict[type(lp_instance)]
+
+    lmp_model = af.Model(lmp_model)
+
+    if light_is_model:
+        lmp_model.take_attributes(source=lp_model)
+    else:
+        lmp_model.take_attributes(source=lp_instance)
+
+    if is_linear:
+        fit = light_result.max_log_likelihood_fit
+        lp_solved = getattr(
+            fit.model_obj_linear_light_profiles_to_light_profiles.galaxies[0], name
+        )
+
+        lmp_model.intensity = lp_solved.intensity
+
+    return lmp_model
 
 
 def mass_light_dark_basis_from(
-    light_result: Result, name : str,
+    light_result: Result,
+    name: str,
+    linear_lp_to_standard: bool = False,
 ) -> af.Model:
     """
     Returns a basis containing light and mass profiles from a basis (e.g. an MGE) in the LIGHT PIPELINE result, for the
@@ -384,8 +390,10 @@ def mass_light_dark_basis_from(
     profiles, where their light profile parameters (e.g. their `centre`, `ell_comps`) are used to set up the parameters
     of the light and mass profile.
 
-    If a linear light profile is passed in, the function will return a light and mass profile where its `intensity` is
-    fixed to the solved for value of the maximum log likelihood linear fit.
+    For the light profile, it will by default use a linear light and mass profile, which therefore continues to solve
+    for the intensity of the linear light profile via linear algebra. This means that during the fit the `intensity`
+    used to compute deflection angles is not the same as the `intensity` parameter solved for in the linear light
+    profile. If the input `linear_lp_to_standard` is `True`, the function will instead use a standard light profile.
 
     The light and mass profiles can also be switched to variants which have a radial gradient in their mass-to-light
     conversion, by setting the `include_mass_to_light_gradient` parameter to `True`.
@@ -404,34 +412,40 @@ def mass_light_dark_basis_from(
     The light and mass profile for a basis (e.g. an MGE) whose priors are initialized from a previous result.
     """
 
-    lp_instance = getattr(light_result.max_log_likelihood_fit.model_obj_linear_light_profiles_to_light_profiles.galaxies[0], name)
+    lp_instance = getattr(
+        light_result.max_log_likelihood_fit.model_obj_linear_light_profiles_to_light_profiles.galaxies[
+            0
+        ],
+        name,
+    )
 
     profile_list = lp_instance.profile_list
 
     lmp_model_list = []
 
     for i, light_profile in enumerate(profile_list):
-
-        if light_profile.intensity > 0.0:
-
+        if not linear_lp_to_standard:
+            lmp_model = af.Model(lmp_linear.Gaussian)
+        else:
             lmp_model = af.Model(lmp.Gaussian)
 
-            lmp_model.centre = light_profile.centre
-            lmp_model.ell_comps = light_profile.ell_comps
-            lmp_model.intensity = light_profile.intensity
-            lmp_model.sigma = light_profile.sigma
+        lmp_model.centre = light_profile.centre
+        lmp_model.ell_comps = light_profile.ell_comps
+        lmp_model.intensity = light_profile.intensity
+        lmp_model.sigma = light_profile.sigma
 
-            lmp_model_list += [lmp_model]
+        lmp_model_list += [lmp_model]
 
-            lmp_model.mass_to_light_ratio = lmp_model_list[0].mass_to_light_ratio
+        lmp_model.mass_to_light_ratio = lmp_model_list[0].mass_to_light_ratio
 
-    return af.Model(
-        Basis,
-        profile_list=lmp_model_list
-    )
+    return af.Model(Basis, profile_list=lmp_model_list)
+
 
 def mass_light_dark_from(
-    light_result: Result, name : str, light_is_model : bool = False
+    light_result: Result,
+    name: str,
+    linear_lp_to_standard: bool = False,
+    light_is_model: bool = False,
 ) -> Optional[af.Model]:
     """
     Returns light and mass profiles from the LIGHT PIPELINE result, for the LIGHT DARK MASS PIPELINE.
@@ -443,8 +457,13 @@ def mass_light_dark_from(
     profiles, where their light profile parameters (e.g. their `centre`, `ell_comps`) are used to set up the parameters
     of the light and mass profile.
 
-    If a linear light profile is passed in, the function will return a light and mass profile where its `intensity` is
+    If a linear light profile is passed in, the function will return a mass profile where its `intensity` is
     fixed to the solved for value of the maximum log likelihood linear fit.
+
+    For the light profile, it will by default use a linear light and mass profile, which therefore continues to solve
+    for the intensity of the linear light profile via linear algebra. This means that during the fit the `intensity`
+    used to compute deflection angles is not the same as the `intensity` parameter solved for in the linear light
+    profile. If the input `linear_lp_to_standard` is `True`, the function will instead use a standard light profile.
 
     This function supports the input of a basis (e.g. an MGE), converting every individual standard light or
     linear light profile in the basis to a light and mass profile.
@@ -461,6 +480,9 @@ def mass_light_dark_from(
     name
         The name of the light profile in the light pipeline's galaxy model that the model is being created for
         (e.g. `bulge`).
+    linear_lp_to_standard
+        If `True`, the light profile is passed as a standard component, else it is a linear component. The
+        mass always uses the `interity` parameter of the linear light profile solved for in the previous pipeline.
     light_is_model
         If `True`, the light profile is passed as a model component, else it is a fixed instance. For a basis
         (e.g. an MGE) this feature is not used due to the large number of profiles in the basis.
@@ -476,5 +498,10 @@ def mass_light_dark_from(
         return None
 
     if not isinstance(lp_instance, Basis):
-        return mass_light_dark_lmp_from(light_result=light_result, name=name, light_is_model=light_is_model)
+        return mass_light_dark_lmp_from(
+            light_result=light_result,
+            name=name,
+            linear_lp_to_standard=linear_lp_to_standard,
+            light_is_model=light_is_model,
+        )
     return mass_light_dark_basis_from(light_result=light_result, name=name)

--- a/autogalaxy/profiles/light_linear_and_mass_profiles.py
+++ b/autogalaxy/profiles/light_linear_and_mass_profiles.py
@@ -1,0 +1,644 @@
+from typing import Tuple
+
+from autogalaxy.profiles.light import linear as lp_linear
+from autogalaxy.profiles import mass as mp
+
+
+class LightMassProfile:
+    """
+    Mass and light profiles describe both mass distributions and light distributions with a single set of parameters. This
+    means that the light and mass of these profiles are tied together. Galaxy instances interpret these
+    objects as being both mass and light profiles.
+    """
+
+    pass
+
+
+class Gaussian(lp_linear.Gaussian, mp.Gaussian, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        ell_comps: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        sigma: float = 1.0,
+        mass_to_light_ratio: float = 1.0,
+    ):
+        """
+        The elliptical Gaussian light and mass profile.
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The grid of The (y,x) arc-second coordinates of the profile centre.
+        ell_comps
+            The first and second ellipticity components of the elliptical coordinate system.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second).
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles.
+        """
+        lp_linear.Gaussian.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            sigma=sigma,
+        )
+        mp.Gaussian.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            intensity=intensity,
+            sigma=sigma,
+            mass_to_light_ratio=mass_to_light_ratio,
+        )
+
+
+class GaussianGradient(lp_linear.Gaussian, mp.GaussianGradient, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        ell_comps: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        sigma: float = 1.0,
+        mass_to_light_ratio_base: float = 1.0,
+        mass_to_light_gradient: float = 0.0,
+        mass_to_light_radius: float = 1.0,
+    ):
+        """
+        The elliptical Gaussian light profile with a gradient in its mass to light conversion.
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The grid of The (y,x) arc-second coordinates of the profile centre.
+        ell_comps
+            The first and second ellipticity components of the elliptical coordinate system.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second).
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio_base
+            The base mass-to-light ratio of the profile, which is the mass-to-light ratio of the Gaussian before it
+            is scaled by values that adjust its mass-to-light ratio based on the reference radius and gradient.
+        mass_to_light_gradient
+            The mass-to-light radial gradient of the profile, whereby positive values means there is more mass
+            per unit light within the reference radius.
+        mass_to_light_radius
+            The radius where the mass-to-light ratio is equal to the base mass-to-light ratio, such that there will be
+            more of less mass per unit light within this radius depending on the mass-to-light gradient.
+        """
+        lp_linear.Gaussian.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            sigma=sigma,
+        )
+        mp.GaussianGradient.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            intensity=intensity,
+            sigma=sigma,
+            mass_to_light_ratio_base=mass_to_light_ratio_base,
+            mass_to_light_gradient=mass_to_light_gradient,
+            mass_to_light_radius=mass_to_light_radius,
+        )
+
+
+class Sersic(lp_linear.Sersic, mp.Sersic, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        ell_comps: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        effective_radius: float = 0.6,
+        sersic_index: float = 0.6,
+        mass_to_light_ratio: float = 1.0,
+    ):
+        """
+        The elliptical Sersic light and mass profile.
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The grid of The (y,x) arc-second coordinates of the profile centre.
+        ell_comps
+            The first and second ellipticity components of the elliptical coordinate system.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second).
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles.
+        """
+        lp_linear.Sersic.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            effective_radius=effective_radius,
+            sersic_index=sersic_index,
+        )
+        mp.Sersic.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            intensity=intensity,
+            effective_radius=effective_radius,
+            sersic_index=sersic_index,
+            mass_to_light_ratio=mass_to_light_ratio,
+        )
+
+
+class SersicSph(Sersic, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        effective_radius: float = 0.6,
+        sersic_index: float = 0.6,
+        mass_to_light_ratio: float = 1.0,
+    ):
+        """
+        The spherical Sersic light and mass profile.
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The grid of The (y,x) arc-second coordinates of the profile centre..
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second).
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles.
+        """
+        Sersic.__init__(
+            self,
+            centre=centre,
+            ell_comps=(0.0, 0.0),
+            intensity=intensity,
+            effective_radius=effective_radius,
+            sersic_index=sersic_index,
+            mass_to_light_ratio=mass_to_light_ratio,
+        )
+
+
+class Exponential(Sersic, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        ell_comps: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        effective_radius: float = 0.6,
+        mass_to_light_ratio: float = 1.0,
+    ):
+        """
+        The elliptical Exponential light and mass profile.
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The grid of The (y,x) arc-second coordinates of the profile centre.
+        ell_comps
+            The first and second ellipticity components of the elliptical coordinate system.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second)
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles
+        """
+        Sersic.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            intensity=intensity,
+            effective_radius=effective_radius,
+            sersic_index=1.0,
+            mass_to_light_ratio=mass_to_light_ratio,
+        )
+
+
+class ExponentialSph(Exponential, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        effective_radius: float = 0.6,
+        mass_to_light_ratio: float = 1.0,
+    ):
+        """
+        The spherical Exponential light and mass profile.
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The grid of The (y,x) arc-second coordinates of the profile centre.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second)
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles
+        """
+        Exponential.__init__(
+            self,
+            centre=centre,
+            ell_comps=(0.0, 0.0),
+            intensity=intensity,
+            effective_radius=effective_radius,
+            mass_to_light_ratio=mass_to_light_ratio,
+        )
+
+
+class DevVaucouleurs(Sersic, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        ell_comps: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        effective_radius: float = 0.6,
+        mass_to_light_ratio: float = 1.0,
+    ):
+        """
+        The elliptical Dev Vaucouleurs light and mass profile.
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The grid of The (y,x) arc-second coordinates of the profile centre.
+        ell_comps
+            The first and second ellipticity components of the elliptical coordinate system.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second)
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles
+        """
+        super().__init__(
+            centre=centre,
+            ell_comps=ell_comps,
+            intensity=intensity,
+            effective_radius=effective_radius,
+            sersic_index=4.0,
+            mass_to_light_ratio=mass_to_light_ratio,
+        )
+
+
+class DevVaucouleursSph(DevVaucouleurs, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        effective_radius: float = 0.6,
+        mass_to_light_ratio: float = 1.0,
+    ):
+        """
+        The spherical Dev Vaucouleurs light and mass profile.
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The grid of The (y,x) arc-second coordinates of the profile centre.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second)
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles
+        """
+        DevVaucouleurs.__init__(
+            self,
+            centre=centre,
+            ell_comps=(0.0, 0.0),
+            intensity=intensity,
+            effective_radius=effective_radius,
+            mass_to_light_ratio=mass_to_light_ratio,
+        )
+
+
+class SersicGradient(lp_linear.Sersic, mp.SersicGradient, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        ell_comps: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        effective_radius: float = 0.6,
+        sersic_index: float = 0.6,
+        mass_to_light_ratio: float = 1.0,
+        mass_to_light_gradient: float = 0.0,
+    ):
+        """
+        The elliptical Sersic light and mass profile, with a radial gradient in the conversion of light to mass..
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The (y,x) arc-second coordinates of the profile centre..
+        ell_comps
+            The first and second ellipticity components of the elliptical coordinate system.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second)
+        effective_radius
+            The radius containing half the light of this light profile.
+        sersic_index
+            The concentration of the light profiles.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles.
+        mass_to_light_gradient
+            The mass-to-light radial gradient.
+        """
+        lp_linear.Sersic.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            effective_radius=effective_radius,
+            sersic_index=sersic_index,
+        )
+        mp.SersicGradient.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            intensity=intensity,
+            effective_radius=effective_radius,
+            sersic_index=sersic_index,
+            mass_to_light_ratio=mass_to_light_ratio,
+            mass_to_light_gradient=mass_to_light_gradient,
+        )
+
+
+class SersicGradientSph(SersicGradient, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        effective_radius: float = 0.6,
+        sersic_index: float = 0.6,
+        mass_to_light_ratio: float = 1.0,
+        mass_to_light_gradient: float = 0.0,
+    ):
+        """
+        The spherical Sersic light and mass profile, with a radial gradient in the conversion of light to mass..
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The (y,x) arc-second coordinates of the profile centre.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second)
+        effective_radius
+            The radius containing half the light of this light profile.
+        sersic_index
+            The concentration of the light profiles
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles
+        mass_to_light_gradient
+            The mass-to-light radial gradient.
+        """
+
+        SersicGradient.__init__(
+            self,
+            centre=centre,
+            ell_comps=(0.0, 0.0),
+            intensity=intensity,
+            effective_radius=effective_radius,
+            sersic_index=sersic_index,
+            mass_to_light_ratio=mass_to_light_ratio,
+            mass_to_light_gradient=mass_to_light_gradient,
+        )
+
+
+class ExponentialGradient(SersicGradient, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        ell_comps: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        effective_radius: float = 0.6,
+        mass_to_light_ratio: float = 1.0,
+        mass_to_light_gradient: float = 0.0,
+    ):
+        """
+        The elliptical Exponential light and mass profile, with a radial gradient in the conversion of light to mass..
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The (y,x) arc-second coordinates of the profile centre.
+        ell_comps
+            The first and second ellipticity components of the elliptical coordinate system.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second)
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles
+        mass_to_light_gradient
+            The mass-to-light radial gradient.
+        """
+
+        SersicGradient.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            intensity=intensity,
+            effective_radius=effective_radius,
+            sersic_index=1.0,
+            mass_to_light_ratio=mass_to_light_ratio,
+            mass_to_light_gradient=mass_to_light_gradient,
+        )
+
+
+class SphExponentialGradient(SersicGradientSph, LightMassProfile):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        intensity: float = 0.1,
+        effective_radius: float = 0.6,
+        mass_to_light_ratio: float = 1.0,
+        mass_to_light_gradient: float = 0.0,
+    ):
+        """
+        The spherical Exponential light and mass profile, with a radial gradient in the conversion of light to mass..
+
+        This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+        Parameters
+        ----------
+        centre
+            The (y,x) arc-second coordinates of the profile centre.
+        ell_comps
+            The first and second ellipticity components of the elliptical coordinate system.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second)
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles
+        mass_to_light_gradient
+            The mass-to-light radial gradient.
+        """
+
+        SersicGradientSph.__init__(
+            self,
+            centre=centre,
+            intensity=intensity,
+            effective_radius=effective_radius,
+            sersic_index=1.0,
+            mass_to_light_ratio=mass_to_light_ratio,
+            mass_to_light_gradient=mass_to_light_gradient,
+        )
+
+
+class SersicCore(lp_linear.SersicCore, mp.SersicCore, LightMassProfile):
+    """
+    The elliptical cored-Sersic light and mass profile.
+
+    This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+    Parameters
+    ----------
+    centre
+        The grid of The (y,x) arc-second coordinates of the profile centre.
+    ell_comps
+        The first and second ellipticity components of the elliptical coordinate system.
+    intensity
+        Overall flux intensity normalisation in the light profiles (electrons per second).
+    effective_radius
+        The radius containing half the light of this light profile.
+    radius_break
+        The break radius separating the inner power-law (with logarithmic slope gamma) and outer Sersic function.
+    gamma
+        The logarithmic power-law slope of the inner core profiles
+    alpha
+        Controls the sharpness of the transition between the inner core / outer Sersic profiles.
+    mass_to_light_ratio
+        The mass-to-light ratio of the light profiles.
+    """
+
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        ell_comps: Tuple[float, float] = (0.0, 0.0),
+        effective_radius: float = 0.6,
+        sersic_index: float = 4.0,
+        radius_break: float = 0.01,
+        intensity: float = 0.05,
+        gamma: float = 0.25,
+        alpha: float = 3.0,
+        mass_to_light_ratio: float = 1.0,
+    ):
+        lp_linear.SersicCore.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            effective_radius=effective_radius,
+            sersic_index=sersic_index,
+            radius_break=radius_break,
+            gamma=gamma,
+            alpha=alpha,
+        )
+        mp.SersicCore.__init__(
+            self,
+            centre=centre,
+            ell_comps=ell_comps,
+            effective_radius=effective_radius,
+            sersic_index=sersic_index,
+            radius_break=radius_break,
+            intensity=intensity,
+            gamma=gamma,
+            alpha=alpha,
+            mass_to_light_ratio=mass_to_light_ratio,
+        )
+
+
+class SersicCoreSph(SersicCore, LightMassProfile):
+    """
+    The spherical cored-Sersic light and mass profile.
+
+    This simultaneously represents the luminous emission and stellar mass of a galaxy.
+
+    Parameters
+    ----------
+    centre
+        The grid of The (y,x) arc-second coordinates of the profile centre.
+    ell_comps
+        The first and second ellipticity components of the elliptical coordinate system.
+    intensity
+        Overall flux intensity normalisation in the light profiles (electrons per second).
+    effective_radius
+        The radius containing half the light of this light profile.
+    radius_break
+        The break radius separating the inner power-law (with logarithmic slope gamma) and outer Sersic function.
+    gamma
+        The logarithmic power-law slope of the inner core profiles
+    alpha
+        Controls the sharpness of the transition between the inner core / outer Sersic profiles.
+    mass_to_light_ratio
+        The mass-to-light ratio of the light profiles.
+    """
+
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        effective_radius: float = 0.6,
+        sersic_index: float = 4.0,
+        radius_break: float = 0.01,
+        intensity: float = 0.05,
+        gamma: float = 0.25,
+        alpha: float = 3.0,
+        mass_to_light_ratio: float = 1.0,
+    ):
+        """
+        The SersicSph mass profile, the mass profiles of the light profiles that are used to fit_normal and
+        subtract the lens model_galaxy's light.
+
+        Parameters
+        ----------
+        centre
+            The grid of The (y,x) arc-second coordinates of the profile centre.
+        intensity
+            Overall flux intensity normalisation in the light profiles (electrons per second)
+        effective_radius
+            The radius containing half the light of this light profile.
+        mass_to_light_ratio
+            The mass-to-light ratio of the light profiles
+        """
+        SersicCore.__init__(
+            self,
+            centre=centre,
+            ell_comps=(0.0, 0.0),
+            effective_radius=effective_radius,
+            sersic_index=sersic_index,
+            radius_break=radius_break,
+            intensity=intensity,
+            gamma=gamma,
+            alpha=alpha,
+            mass_to_light_ratio=mass_to_light_ratio,
+        )
+

--- a/autogalaxy/profiles/light_linear_and_mass_profiles.py
+++ b/autogalaxy/profiles/light_linear_and_mass_profiles.py
@@ -641,4 +641,3 @@ class SersicCoreSph(SersicCore, LightMassProfile):
             alpha=alpha,
             mass_to_light_ratio=mass_to_light_ratio,
         )
-

--- a/autogalaxy/profiles/mass/stellar/gaussian.py
+++ b/autogalaxy/profiles/mass/stellar/gaussian.py
@@ -51,6 +51,10 @@ class Gaussian(MassProfile, StellarProfile):
             The grid of (y,x) arc-second coordinates the deflection angles are computed on.
 
         """
+
+        if self.intensity == 0.0:
+            return np.zeros((grid.shape[0], 2))
+
         return self.deflections_2d_via_analytic_from(grid=grid, **kwargs)
 
     @aa.grid_dec.to_vector_yx

--- a/autogalaxy/profiles/mass/stellar/sersic.py
+++ b/autogalaxy/profiles/mass/stellar/sersic.py
@@ -122,6 +122,9 @@ class AbstractSersic(MassProfile, MassProfileMGE, MassProfileCSE, StellarProfile
         self.sersic_index = sersic_index
 
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, **kwargs):
+        if self.intensity == 0.0:
+            return np.zeros((grid.shape[0], 2))
+
         return self.deflections_2d_via_cse_from(grid=grid, **kwargs)
 
     @aa.grid_dec.to_vector_yx


### PR DESCRIPTION
Add a `light_linear_and_mass_profile` package for light profiles which act as light and mass profiles, but solved for the linear light profile `intensity` values via linear algebra in the normal way.,