### PR TITLE
Feature/over sample non uniform

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -3,6 +3,7 @@ from autoarray.dataset import preprocess  # noqa
 from autoarray.dataset.imaging.dataset import Imaging  # noqa
 from autoarray.dataset.interferometer.dataset import Interferometer  # noqa
 from autoarray.dataset.dataset_model import DatasetModel
+from autoarray.dataset.over_sampling import OverSamplingDataset
 from autoarray.inversion.pixelization import mesh  # noqa
 from autoarray.inversion import regularization as reg  # noqa
 from autoarray.inversion.pixelization import image_mesh

--- a/autogalaxy/aggregator/imaging.py
+++ b/autogalaxy/aggregator/imaging.py
@@ -46,18 +46,12 @@ def _imaging_from(
         psf = aa.Kernel2D.from_primary_hdu(primary_hdu=fit.value(name="dataset.psf"))
 
         over_sampling = fit.value(name="dataset.over_sampling")
-        over_sampling_non_uniform = fit.value(name="dataset.over_sampling_non_uniform")
-        over_sampling_pixelization = fit.value(
-            name="dataset.over_sampling_pixelization"
-        )
 
         dataset = aa.Imaging(
             data=data,
             noise_map=noise_map,
             psf=psf,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
-            over_sampling_pixelization=over_sampling_pixelization,
             check_noise_map=False,
         )
 

--- a/autogalaxy/aggregator/interferometer.py
+++ b/autogalaxy/aggregator/interferometer.py
@@ -57,10 +57,6 @@ def _interferometer_from(
         )
 
         over_sampling = fit.value(name="dataset.over_sampling")
-        over_sampling_non_uniform = fit.value(name="dataset.over_sampling_non_uniform")
-        over_sampling_pixelization = fit.value(
-            name="dataset.over_sampling_pixelization"
-        )
         transformer_class = fit.value(name="dataset.transformer_class")
 
         dataset = aa.Interferometer(
@@ -69,8 +65,6 @@ def _interferometer_from(
             uv_wavelengths=uv_wavelengths,
             real_space_mask=real_space_mask,
             over_sampling=over_sampling,
-            over_sampling_non_uniform=over_sampling_non_uniform,
-            over_sampling_pixelization=over_sampling_pixelization,
             transformer_class=transformer_class,
         )
 

--- a/autogalaxy/analysis/analysis/analysis.py
+++ b/autogalaxy/analysis/analysis/analysis.py
@@ -193,10 +193,10 @@ class Analysis(af.Analysis):
         fit.figure_of_merit
 
         try:
-            info_dict["image_pixels"] = self.dataset.grid.shape_slim
+            info_dict["image_pixels"] = self.dataset.grids.uniform.shape_slim
             info_dict[
                 "sub_total_light_profiles"
-            ] = self.dataset.grid.over_sampler.sub_total
+            ] = self.dataset.grids.uniform.over_sampler.sub_total
         except AttributeError:
             pass
 
@@ -205,7 +205,7 @@ class Analysis(af.Analysis):
             try:
                 info_dict[
                     "sub_total_pixelization"
-                ] = self.dataset.grid_pixelization.over_sampler.sub_total
+                ] = self.dataset.grids.pixelization.over_sampler.sub_total
             except AttributeError:
                 pass
             info_dict[

--- a/autogalaxy/analysis/analysis/dataset.py
+++ b/autogalaxy/analysis/analysis/dataset.py
@@ -178,16 +178,6 @@ class AnalysisDataset(Analysis):
             prefix="dataset",
         )
         paths.save_json(
-            name="over_sampling_non_uniform",
-            object_dict=to_dict(self.dataset.over_sampling_non_uniform),
-            prefix="dataset",
-        )
-        paths.save_json(
-            name="over_sampling_pixelization",
-            object_dict=to_dict(self.dataset.over_sampling_pixelization),
-            prefix="dataset",
-        )
-        paths.save_json(
             name="settings_inversion",
             object_dict=to_dict(self.settings_inversion),
         )

--- a/autogalaxy/analysis/result.py
+++ b/autogalaxy/analysis/result.py
@@ -54,11 +54,11 @@ class ResultDataset(Result):
         return self.analysis.dataset.mask
 
     @property
-    def grid(self) -> aa.Grid2D:
+    def grids(self) -> aa.Grid2D:
         """
         The masked 2D grid used by the dataset in the model-fit.
         """
-        return self.analysis.dataset.grid
+        return self.analysis.dataset.grids
 
     @property
     def dataset(self) -> Union[aa.Imaging, aa.Interferometer]:

--- a/autogalaxy/config/visualize/plots.yaml
+++ b/autogalaxy/config/visualize/plots.yaml
@@ -8,8 +8,9 @@ dataset:                                   # Settings for plots of all datasets 
   data: false                              # Plot the individual data of every dataset?
   noise_map: false                         # Plot the individual noise-map of every dataset?
   signal_to_noise_map: false               # Plot the individual signal-to-noise-map of every dataset?
-  over_sampling_sub_size: false            # Plot the over-sampling sub-size, used to evaluate light profiles, of every dataset?
-  over_sampling_sub_size_pixelization: false  # Plot the over-sampling sub-size, used to evaluate pixelizations, of every dataset?
+  over_sampling: false            # Plot the over-sampling sub-size, used to evaluate light profiles, of every dataset?
+  over_sampling_non_uniform: false  # Plot the over-sampling sub-size, used to evaluate non uniform grids, of every dataset?
+  over_sampling_pixelization: false  # Plot the over-sampling sub-size, used to evaluate pixelizations, of every dataset?
 imaging:                                   # Settings for plots of imaging datasets (e.g. ImagingPlotter).
   psf: false
 fit:                                       # Settings for plots of all fits (e.g. FitImagingPlotter, FitInterferometerPlotter).

--- a/autogalaxy/galaxy/to_inversion.py
+++ b/autogalaxy/galaxy/to_inversion.py
@@ -66,7 +66,7 @@ class AbstractToInversion:
     @property
     def border_relocator(self):
         if self.settings_inversion.use_border_relocator:
-            return self.dataset.border_relocator
+            return self.dataset.grids.border_relocator
 
     def cls_light_profile_func_list_galaxy_dict_from(
         self, cls: Type
@@ -150,8 +150,8 @@ class GalaxiesToInversion(AbstractToInversion):
 
                     if len(light_profile_list) > 0:
                         lp_linear_func = LightProfileLinearObjFuncList(
-                            grid=self.dataset.grid,
-                            blurring_grid=self.dataset.blurring_grid,
+                            grid=self.dataset.grids.uniform,
+                            blurring_grid=self.dataset.grids.blurring,
                             convolver=self.dataset.convolver,
                             light_profile_list=light_profile_list,
                             regularization=light_profile.regularization,
@@ -244,7 +244,7 @@ class GalaxiesToInversion(AbstractToInversion):
 
         return mapper_from(
             mapper_grids=mapper_grids,
-            over_sampler=self.dataset.grid_pixelization.over_sampling.over_sampler_from(
+            over_sampler=self.dataset.grids.pixelization.over_sampling.over_sampler_from(
                 mask=self.dataset.mask
             ),
             regularization=regularization,
@@ -280,7 +280,7 @@ class GalaxiesToInversion(AbstractToInversion):
             mapper = self.mapper_from(
                 mesh=pixelization_list[mapper_index].mesh,
                 regularization=pixelization_list[mapper_index].regularization,
-                source_plane_data_grid=self.dataset.grid_pixelization.over_sampler.over_sampled_grid,
+                source_plane_data_grid=self.dataset.grids.pixelization.over_sampler.over_sampled_grid,
                 source_plane_mesh_grid=mesh_grid_list[mapper_index],
                 adapt_galaxy_image=adapt_galaxy_image,
                 image_plane_mesh_grid=mesh_grid_list[mapper_index],

--- a/autogalaxy/imaging/fit_imaging.py
+++ b/autogalaxy/imaging/fit_imaging.py
@@ -104,13 +104,13 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             self.galaxies.cls_list_from(cls=LightProfileOperated)
         ):
             return self.galaxies.image_2d_from(
-                grid=self.grid,
+                grid=self.grids.uniform,
             )
 
         return self.galaxies.blurred_image_2d_from(
-            grid=self.grid,
+            grid=self.grids.uniform,
             convolver=self.dataset.convolver,
-            blurring_grid=self.blurring_grid,
+            blurring_grid=self.grids.blurring,
         )
 
     @property
@@ -125,12 +125,9 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         dataset = aa.DatasetInterface(
             data=self.profile_subtracted_image,
             noise_map=self.noise_map,
+            grids=self.grids,
             convolver=self.dataset.convolver,
             w_tilde=self.w_tilde,
-            grid=self.grid,
-            grid_pixelization=self.grid_pixelization,
-            blurring_grid=self.blurring_grid,
-            border_relocator=self.dataset.border_relocator,
         )
 
         return GalaxiesToInversion(
@@ -188,9 +185,9 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
         """
 
         galaxy_blurred_image_2d_dict = self.galaxies.galaxy_blurred_image_2d_dict_from(
-            grid=self.grid,
+            grid=self.grids.uniform,
             convolver=self.dataset.convolver,
-            blurring_grid=self.blurring_grid,
+            blurring_grid=self.grids.blurring,
         )
 
         galaxy_linear_obj_image_dict = self.galaxy_linear_obj_data_dict_from(
@@ -260,7 +257,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             exc.raise_linear_light_profile_in_unmasked()
 
         return self.galaxies.unmasked_blurred_image_2d_from(
-            grid=self.grid, psf=self.dataset.psf
+            grid=self.grids.uniform, psf=self.dataset.psf
         )
 
     @property
@@ -275,7 +272,7 @@ class FitImaging(aa.FitImaging, AbstractFitInversion):
             exc.raise_linear_light_profile_in_unmasked()
 
         return self.galaxies.unmasked_blurred_image_2d_list_from(
-            grid=self.grid, psf=self.dataset.psf
+            grid=self.grids.uniform, psf=self.dataset.psf
         )
 
     @property

--- a/autogalaxy/imaging/model/plotter_interface.py
+++ b/autogalaxy/imaging/model/plotter_interface.py
@@ -44,10 +44,9 @@ class PlotterInterfaceImaging(PlotterInterface):
             noise_map=should_plot("noise_map"),
             psf=should_plot("psf"),
             signal_to_noise_map=should_plot("signal_to_noise_map"),
-            over_sampling_sub_size=should_plot("over_sampling_sub_size"),
-            over_sampling_sub_size_pixelization=should_plot(
-                "over_sampling_sub_size_pixelization"
-            ),
+            over_sampling=should_plot("over_sampling"),
+            over_sampling_non_uniform=should_plot("over_sampling_non_uniform"),
+            over_sampling_pixelization=should_plot("over_sampling_pixelization"),
         )
 
         mat_plot_2d = self.mat_plot_2d_from(subfolders="")

--- a/autogalaxy/imaging/model/visualizer.py
+++ b/autogalaxy/imaging/model/visualizer.py
@@ -83,10 +83,10 @@ class VisualizerImaging(af.Visualizer):
         galaxies = fit.galaxies_linear_light_profiles_to_light_profiles
 
         plotter.galaxies(
-            galaxies=galaxies, grid=fit.grid, during_analysis=during_analysis
+            galaxies=galaxies, grid=fit.grids.uniform, during_analysis=during_analysis
         )
         plotter.galaxies_1d(
-            galaxies=galaxies, grid=fit.grid, during_analysis=during_analysis
+            galaxies=galaxies, grid=fit.grids.uniform, during_analysis=during_analysis
         )
         if fit.inversion is not None:
             plotter.inversion(inversion=fit.inversion, during_analysis=during_analysis)

--- a/autogalaxy/interferometer/fit_interferometer.py
+++ b/autogalaxy/interferometer/fit_interferometer.py
@@ -101,7 +101,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         a Fourier transform to the sum of light profile images.
         """
         return self.galaxies.visibilities_from(
-            grid=self.grid, transformer=self.dataset.transformer
+            grid=self.grids.uniform, transformer=self.dataset.transformer
         )
 
     @property
@@ -116,11 +116,9 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         dataset = aa.DatasetInterface(
             data=self.profile_subtracted_visibilities,
             noise_map=self.noise_map,
+            grids=self.grids,
             transformer=self.dataset.transformer,
             w_tilde=self.w_tilde,
-            grid=self.grid,
-            grid_pixelization=self.grid_pixelization,
-            border_relocator=self.dataset.border_relocator,
         )
 
         return GalaxiesToInversion(
@@ -175,7 +173,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         data being fitted.
         """
         galaxy_model_image_dict = self.galaxies.galaxy_image_2d_dict_from(
-            grid=self.grid
+            grid=self.grids.uniform
         )
 
         galaxy_linear_obj_image_dict = self.galaxy_linear_obj_data_dict_from(
@@ -199,7 +197,7 @@ class FitInterferometer(aa.FitInterferometer, AbstractFitInversion):
         data being fitted.
         """
         galaxy_model_visibilities_dict = self.galaxies.galaxy_visibilities_dict_from(
-            grid=self.grid, transformer=self.dataset.transformer
+            grid=self.grids.uniform, transformer=self.dataset.transformer
         )
 
         galaxy_linear_obj_data_dict = self.galaxy_linear_obj_data_dict_from(

--- a/autogalaxy/interferometer/model/visualizer.py
+++ b/autogalaxy/interferometer/model/visualizer.py
@@ -82,10 +82,10 @@ class VisualizerInterferometer(af.Visualizer):
         galaxies = fit.galaxies_linear_light_profiles_to_light_profiles
 
         PlotterInterface.galaxies(
-            galaxies=galaxies, grid=fit.grid, during_analysis=during_analysis
+            galaxies=galaxies, grid=fit.grids.uniform, during_analysis=during_analysis
         )
         PlotterInterface.galaxies_1d(
-            galaxies=galaxies, grid=fit.grid, during_analysis=during_analysis
+            galaxies=galaxies, grid=fit.grids.uniform, during_analysis=during_analysis
         )
 
         try:

--- a/autogalaxy/interferometer/plot/fit_interferometer_plotters.py
+++ b/autogalaxy/interferometer/plot/fit_interferometer_plotters.py
@@ -111,7 +111,7 @@ class FitInterferometerPlotter(Plotter):
         """
         return GalaxiesPlotter(
             galaxies=galaxies,
-            grid=self.fit.grid,
+            grid=self.fit.grids.uniform,
             mat_plot_2d=self.mat_plot_2d,
             visuals_2d=self.get_visuals_2d_real_space(),
             include_2d=self.include_2d,

--- a/autogalaxy/plot/get_visuals/two_d.py
+++ b/autogalaxy/plot/get_visuals/two_d.py
@@ -280,7 +280,7 @@ class GetVisuals2D(aplt.GetVisuals2D):
         visuals_2d_via_fit = super().via_fit_imaging_from(fit=fit)
 
         visuals_2d_via_light_mass_obj = self.via_light_mass_obj_from(
-            light_mass_obj=fit.galaxies, grid=fit.grid
+            light_mass_obj=fit.galaxies, grid=fit.grids.uniform
         )
 
         return visuals_2d_via_fit + visuals_2d_via_light_mass_obj

--- a/autogalaxy/quantity/dataset_quantity.py
+++ b/autogalaxy/quantity/dataset_quantity.py
@@ -38,7 +38,7 @@ class DatasetQuantity(AbstractDataset):
         - `grid`: A grids of (y,x) coordinates which align with the image pixels, whereby each coordinate corresponds to
         the centre of an image pixel. This may be used in fits to calculate the model image of the imaging data.
 
-        - `grid_pixelization`: A grid of (y,x) coordinates which align with the pixels of a pixelization. This grid
+        - `grids.pixelization`: A grid of (y,x) coordinates which align with the pixels of a pixelization. This grid
         is specifically used for pixelizations computed via the `invserion` module, which often use different
         oversampling and sub-size values to the grid above.
 
@@ -60,7 +60,7 @@ class DatasetQuantity(AbstractDataset):
         over_sampling
             The over sampling schemes which divide the grids into sub grids of smaller pixels within their host image
             pixels when using the grid to evaluate a function (e.g. images) to better approximate the 2D line integral
-            This class controls over sampling for all the different grids (e.g. `grid`, `grid_pixelization).
+            This class controls over sampling for all the different grids (e.g. `grid`, `grids.pixelization).
         """
         if data.shape != noise_map.shape:
             if data.shape[0:-1] == noise_map.shape[0:]:

--- a/autogalaxy/quantity/dataset_quantity.py
+++ b/autogalaxy/quantity/dataset_quantity.py
@@ -14,7 +14,7 @@ class DatasetQuantity(AbstractDataset):
         self,
         data: Union[aa.Array2D, aa.VectorYX2D],
         noise_map: Union[aa.Array2D, aa.VectorYX2D],
-        over_sampling: Optional[aa.OverSamplingIterate] = None,
+        over_sampling: Optional[aa.OverSamplingDataset] = aa.OverSamplingDataset(),
     ):
         """
         A quantity dataset, which represents a derived quantity of a light profile, mass profile, galaxy or galaxies
@@ -58,11 +58,9 @@ class DatasetQuantity(AbstractDataset):
             chi-squared in a fit, which is often chosen in an arbitrary way for a quantity dataset given the quantities
             are not observed using real astronomical instruments.
         over_sampling
-            How over sampling is performed for the grid which performs calculations not associated with a pixelization.
-            In PyAutoGalaxy and PyAutoLens this is light profile calculations.
-        over_sampling_pixelization
-            How over sampling is performed for the grid which is associated with a pixelization, which is therefore
-            passed into the calculations performed in the `inversion` module.
+            The over sampling schemes which divide the grids into sub grids of smaller pixels within their host image
+            pixels when using the grid to evaluate a function (e.g. images) to better approximate the 2D line integral
+            This class controls over sampling for all the different grids (e.g. `grid`, `grid_pixelization).
         """
         if data.shape != noise_map.shape:
             if data.shape[0:-1] == noise_map.shape[0:]:

--- a/autogalaxy/quantity/fit_quantity.py
+++ b/autogalaxy/quantity/fit_quantity.py
@@ -56,7 +56,7 @@ class FitQuantity(aa.FitImaging):
     def model_data(self):
         if self.model_data_manual is None:
             func = getattr(self.light_mass_obj, self.func_str)
-            return func(grid=self.grid)
+            return func(grid=self.grids.uniform)
 
         return self.model_data_manual
 

--- a/test_autogalaxy/aggregator/test_aggregator_imaging.py
+++ b/test_autogalaxy/aggregator/test_aggregator_imaging.py
@@ -14,7 +14,7 @@ def test__dataset_generator_from_aggregator__analysis_has_single_dataset(
         noise_map=noise_map_7x7,
         over_sampling=ag.OverSamplingDataset(
             uniform=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
-            pixelization=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
+            pixelization=ag.OverSamplingUniform(sub_size=3),
         ),
     )
 
@@ -38,7 +38,7 @@ def test__dataset_generator_from_aggregator__analysis_has_single_dataset(
             dataset_list[0].grids.uniform.over_sampling, ag.OverSamplingIterate
         )
         assert isinstance(
-            dataset_list[0].grids.pixelization.over_sampling, ag.OverSamplingIterate
+            dataset_list[0].grids.pixelization.over_sampling, ag.OverSamplingUniform
         )
         assert dataset_list[0].grids.uniform.over_sampling.sub_steps == [2]
         assert dataset_list[0].grids.uniform.over_sampling.fractional_accuracy == 0.5

--- a/test_autogalaxy/aggregator/test_aggregator_imaging.py
+++ b/test_autogalaxy/aggregator/test_aggregator_imaging.py
@@ -12,11 +12,12 @@ def test__dataset_generator_from_aggregator__analysis_has_single_dataset(
         data=image_7x7,
         psf=psf_3x3,
         noise_map=noise_map_7x7,
-        over_sampling=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
-        over_sampling_pixelization=ag.OverSamplingIterate(
+        over_sampling=ag.OverSamplingDataset(
+            uniform=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
+            pixelization=ag.OverSamplingIterate(
             fractional_accuracy=0.5, sub_steps=[2]
         ),
-    )
+    ))
 
     masked_imaging_7x7 = imaging.apply_mask(mask=mask_2d_7x7)
 

--- a/test_autogalaxy/aggregator/test_aggregator_imaging.py
+++ b/test_autogalaxy/aggregator/test_aggregator_imaging.py
@@ -14,10 +14,9 @@ def test__dataset_generator_from_aggregator__analysis_has_single_dataset(
         noise_map=noise_map_7x7,
         over_sampling=ag.OverSamplingDataset(
             uniform=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
-            pixelization=ag.OverSamplingIterate(
-            fractional_accuracy=0.5, sub_steps=[2]
+            pixelization=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
         ),
-    ))
+    )
 
     masked_imaging_7x7 = imaging.apply_mask(mask=mask_2d_7x7)
 
@@ -35,12 +34,14 @@ def test__dataset_generator_from_aggregator__analysis_has_single_dataset(
 
     for dataset_list in dataset_gen:
         assert (dataset_list[0].data == masked_imaging_7x7.data).all()
-        assert isinstance(dataset_list[0].grid.over_sampling, ag.OverSamplingIterate)
+        assert isinstance(
+            dataset_list[0].grids.uniform.over_sampling, ag.OverSamplingIterate
+        )
         assert isinstance(
             dataset_list[0].grids.pixelization.over_sampling, ag.OverSamplingIterate
         )
-        assert dataset_list[0].grid.over_sampling.sub_steps == [2]
-        assert dataset_list[0].grid.over_sampling.fractional_accuracy == 0.5
+        assert dataset_list[0].grids.uniform.over_sampling.sub_steps == [2]
+        assert dataset_list[0].grids.uniform.over_sampling.fractional_accuracy == 0.5
 
     clean(database_file=database_file)
 

--- a/test_autogalaxy/aggregator/test_aggregator_imaging.py
+++ b/test_autogalaxy/aggregator/test_aggregator_imaging.py
@@ -37,7 +37,7 @@ def test__dataset_generator_from_aggregator__analysis_has_single_dataset(
         assert (dataset_list[0].data == masked_imaging_7x7.data).all()
         assert isinstance(dataset_list[0].grid.over_sampling, ag.OverSamplingIterate)
         assert isinstance(
-            dataset_list[0].grid_pixelization.over_sampling, ag.OverSamplingIterate
+            dataset_list[0].grids.pixelization.over_sampling, ag.OverSamplingIterate
         )
         assert dataset_list[0].grid.over_sampling.sub_steps == [2]
         assert dataset_list[0].grid.over_sampling.fractional_accuracy == 0.5

--- a/test_autogalaxy/aggregator/test_aggregator_interferometer.py
+++ b/test_autogalaxy/aggregator/test_aggregator_interferometer.py
@@ -43,7 +43,7 @@ def test__interferometer_generator_from_aggregator__analysis_has_single_dataset(
         assert (dataset_list[0].real_space_mask == mask_2d_7x7).all()
         assert isinstance(dataset_list[0].grid.over_sampling, ag.OverSamplingIterate)
         assert isinstance(
-            dataset_list[0].grid_pixelization.over_sampling, ag.OverSamplingIterate
+            dataset_list[0].grids.pixelization.over_sampling, ag.OverSamplingIterate
         )
         assert dataset_list[0].grid.over_sampling.sub_steps == [2]
         assert dataset_list[0].grid.over_sampling.fractional_accuracy == 0.5

--- a/test_autogalaxy/aggregator/test_aggregator_interferometer.py
+++ b/test_autogalaxy/aggregator/test_aggregator_interferometer.py
@@ -18,10 +18,11 @@ def test__interferometer_generator_from_aggregator__analysis_has_single_dataset(
         noise_map=visibilities_noise_map_7,
         uv_wavelengths=uv_wavelengths_7x2,
         real_space_mask=mask_2d_7x7,
-        over_sampling=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
-        over_sampling_pixelization=ag.OverSamplingIterate(
+        over_sampling=ag.OverSamplingDataset(
+            uniform=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
+            pixelization=ag.OverSamplingIterate(
             fractional_accuracy=0.5, sub_steps=[2]
-        ),
+        )),
         transformer_class=ag.TransformerDFT,
     )
 

--- a/test_autogalaxy/aggregator/test_aggregator_interferometer.py
+++ b/test_autogalaxy/aggregator/test_aggregator_interferometer.py
@@ -20,9 +20,8 @@ def test__interferometer_generator_from_aggregator__analysis_has_single_dataset(
         real_space_mask=mask_2d_7x7,
         over_sampling=ag.OverSamplingDataset(
             uniform=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
-            pixelization=ag.OverSamplingIterate(
-            fractional_accuracy=0.5, sub_steps=[2]
-        )),
+            pixelization=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
+        ),
         transformer_class=ag.TransformerDFT,
     )
 
@@ -41,12 +40,14 @@ def test__interferometer_generator_from_aggregator__analysis_has_single_dataset(
     for dataset_list in dataset_gen:
         assert (dataset_list[0].data == interferometer_7.data).all()
         assert (dataset_list[0].real_space_mask == mask_2d_7x7).all()
-        assert isinstance(dataset_list[0].grid.over_sampling, ag.OverSamplingIterate)
+        assert isinstance(
+            dataset_list[0].grids.uniform.over_sampling, ag.OverSamplingIterate
+        )
         assert isinstance(
             dataset_list[0].grids.pixelization.over_sampling, ag.OverSamplingIterate
         )
-        assert dataset_list[0].grid.over_sampling.sub_steps == [2]
-        assert dataset_list[0].grid.over_sampling.fractional_accuracy == 0.5
+        assert dataset_list[0].grids.uniform.over_sampling.sub_steps == [2]
+        assert dataset_list[0].grids.uniform.over_sampling.fractional_accuracy == 0.5
         assert isinstance(dataset_list[0].transformer, ag.TransformerDFT)
 
     clean(database_file=database_file)

--- a/test_autogalaxy/aggregator/test_aggregator_interferometer.py
+++ b/test_autogalaxy/aggregator/test_aggregator_interferometer.py
@@ -20,7 +20,7 @@ def test__interferometer_generator_from_aggregator__analysis_has_single_dataset(
         real_space_mask=mask_2d_7x7,
         over_sampling=ag.OverSamplingDataset(
             uniform=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
-            pixelization=ag.OverSamplingIterate(fractional_accuracy=0.5, sub_steps=[2]),
+            pixelization=ag.OverSamplingUniform(sub_size=3),
         ),
         transformer_class=ag.TransformerDFT,
     )
@@ -44,7 +44,7 @@ def test__interferometer_generator_from_aggregator__analysis_has_single_dataset(
             dataset_list[0].grids.uniform.over_sampling, ag.OverSamplingIterate
         )
         assert isinstance(
-            dataset_list[0].grids.pixelization.over_sampling, ag.OverSamplingIterate
+            dataset_list[0].grids.pixelization.over_sampling, ag.OverSamplingUniform
         )
         assert dataset_list[0].grids.uniform.over_sampling.sub_steps == [2]
         assert dataset_list[0].grids.uniform.over_sampling.fractional_accuracy == 0.5

--- a/test_autogalaxy/analysis/test_plotter_interface.py
+++ b/test_autogalaxy/analysis/test_plotter_interface.py
@@ -23,7 +23,9 @@ def test__galaxies(
     plotter_interface = PlotterInterface(image_path=plot_path)
 
     plotter_interface.galaxies(
-        galaxies=galaxies_7x7, grid=masked_imaging_7x7.grids.uniform, during_analysis=False
+        galaxies=galaxies_7x7,
+        grid=masked_imaging_7x7.grids.uniform,
+        during_analysis=False,
     )
 
     assert path.join(plot_path, "subplot_galaxies.png") in plot_patch.paths
@@ -54,7 +56,9 @@ def test__galaxies_1d(
     plotter_interface = PlotterInterface(image_path=plot_path)
 
     plotter_interface.galaxies_1d(
-        galaxies=galaxies_7x7, grid=masked_imaging_7x7.grids.uniform, during_analysis=False
+        galaxies=galaxies_7x7,
+        grid=masked_imaging_7x7.grids.uniform,
+        during_analysis=False,
     )
 
     plot_path = path.join(plot_path, "galaxies_1d")

--- a/test_autogalaxy/analysis/test_plotter_interface.py
+++ b/test_autogalaxy/analysis/test_plotter_interface.py
@@ -23,7 +23,7 @@ def test__galaxies(
     plotter_interface = PlotterInterface(image_path=plot_path)
 
     plotter_interface.galaxies(
-        galaxies=galaxies_7x7, grid=masked_imaging_7x7.grid, during_analysis=False
+        galaxies=galaxies_7x7, grid=masked_imaging_7x7.grids.uniform, during_analysis=False
     )
 
     assert path.join(plot_path, "subplot_galaxies.png") in plot_patch.paths
@@ -54,7 +54,7 @@ def test__galaxies_1d(
     plotter_interface = PlotterInterface(image_path=plot_path)
 
     plotter_interface.galaxies_1d(
-        galaxies=galaxies_7x7, grid=masked_imaging_7x7.grid, during_analysis=False
+        galaxies=galaxies_7x7, grid=masked_imaging_7x7.grids.uniform, during_analysis=False
     )
 
     plot_path = path.join(plot_path, "galaxies_1d")

--- a/test_autogalaxy/imaging/test_fit_imaging.py
+++ b/test_autogalaxy/imaging/test_fit_imaging.py
@@ -263,14 +263,14 @@ def test__galaxy_model_image_dict(masked_imaging_7x7):
     fit = ag.FitImaging(dataset=masked_imaging_7x7, galaxies=[g0, g1, g2, g3])
 
     g0_blurred_image_2d = g0.blurred_image_2d_from(
-        grid=masked_imaging_7x7.grid,
-        blurring_grid=masked_imaging_7x7.blurring_grid,
+        grid=masked_imaging_7x7.grids.uniform,
+        blurring_grid=masked_imaging_7x7.grids.blurring,
         convolver=masked_imaging_7x7.convolver,
     )
 
     g1_blurred_image_2d = g1.blurred_image_2d_from(
-        grid=masked_imaging_7x7.grid,
-        blurring_grid=masked_imaging_7x7.blurring_grid,
+        grid=masked_imaging_7x7.grids.uniform,
+        blurring_grid=masked_imaging_7x7.grids.blurring,
         convolver=masked_imaging_7x7.convolver,
     )
 
@@ -452,14 +452,14 @@ def test___unmasked_blurred_images(masked_imaging_7x7):
     fit = ag.FitImaging(dataset=masked_imaging_7x7, galaxies=[g0, g1])
 
     unmasked_blurred_image = galaxies.unmasked_blurred_image_2d_from(
-        grid=masked_imaging_7x7.grid, psf=masked_imaging_7x7.psf
+        grid=masked_imaging_7x7.grids.uniform, psf=masked_imaging_7x7.psf
     )
 
     assert (fit.unmasked_blurred_image == unmasked_blurred_image).all()
 
     unmasked_blurred_image_of_galaxies_list = (
         galaxies.unmasked_blurred_image_2d_list_from(
-            grid=masked_imaging_7x7.grid, psf=masked_imaging_7x7.psf
+            grid=masked_imaging_7x7.grids.uniform, psf=masked_imaging_7x7.psf
         )
     )
 

--- a/test_autogalaxy/imaging/test_simulate_and_fit_imaging.py
+++ b/test_autogalaxy/imaging/test_simulate_and_fit_imaging.py
@@ -191,9 +191,9 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_agree_with_standa
     assert fit_linear.figure_of_merit == pytest.approx(-45.02798, 1.0e-4)
 
     galaxy_image = galaxy.blurred_image_2d_from(
-        grid=masked_dataset.grid,
+        grid=masked_dataset.grids.uniform,
         convolver=masked_dataset.convolver,
-        blurring_grid=masked_dataset.blurring_grid,
+        blurring_grid=masked_dataset.grids.blurring,
     )
 
     assert fit_linear.galaxy_model_image_dict[galaxy_linear] == pytest.approx(

--- a/test_autogalaxy/interferometer/test_fit_interferometer.py
+++ b/test_autogalaxy/interferometer/test_fit_interferometer.py
@@ -194,7 +194,7 @@ def test___galaxy_model_image_dict(interferometer_7):
 
     mapper = ag.Mapper(
         mapper_grids=mapper_grids,
-        over_sampler=interferometer_7.grid_pixelization.over_sampler,
+        over_sampler=interferometer_7.grids.pixelization.over_sampler,
         border_relocator=interferometer_7.border_relocator,
         regularization=pixelization.regularization,
     )
@@ -321,7 +321,7 @@ def test___galaxy_model_visibilities_dict(interferometer_7):
 
     mapper = ag.Mapper(
         mapper_grids=mapper_grids,
-        over_sampler=interferometer_7.grid_pixelization.over_sampler,
+        over_sampler=interferometer_7.grids.pixelization.over_sampler,
         border_relocator=interferometer_7.border_relocator,
         regularization=pixelization.regularization,
     )

--- a/test_autogalaxy/interferometer/test_fit_interferometer.py
+++ b/test_autogalaxy/interferometer/test_fit_interferometer.py
@@ -148,8 +148,8 @@ def test___galaxy_model_image_dict(interferometer_7):
         settings_inversion=ag.SettingsInversion(use_w_tilde=False),
     )
 
-    g0_image = g0.image_2d_from(grid=interferometer_7.grid)
-    g1_image = g1.image_2d_from(grid=interferometer_7.grid)
+    g0_image = g0.image_2d_from(grid=interferometer_7.grids.uniform)
+    g1_image = g1.image_2d_from(grid=interferometer_7.grids.uniform)
 
     assert fit.galaxy_model_image_dict[g0] == pytest.approx(g0_image, 1.0e-4)
     assert fit.galaxy_model_image_dict[g1] == pytest.approx(g1_image, 1.0e-4)
@@ -187,15 +187,15 @@ def test___galaxy_model_image_dict(interferometer_7):
 
     mapper_grids = pixelization.mesh.mapper_grids_from(
         mask=interferometer_7.real_space_mask,
-        source_plane_data_grid=interferometer_7.grid,
-        border_relocator=interferometer_7.border_relocator,
+        source_plane_data_grid=interferometer_7.grids.uniform,
+        border_relocator=interferometer_7.grids.border_relocator,
         source_plane_mesh_grid=None,
     )
 
     mapper = ag.Mapper(
         mapper_grids=mapper_grids,
         over_sampler=interferometer_7.grids.pixelization.over_sampler,
-        border_relocator=interferometer_7.border_relocator,
+        border_relocator=interferometer_7.grids.border_relocator,
         regularization=pixelization.regularization,
     )
 
@@ -266,10 +266,10 @@ def test___galaxy_model_visibilities_dict(interferometer_7):
     )
 
     g0_visibilities = g0.visibilities_from(
-        grid=interferometer_7.grid, transformer=interferometer_7.transformer
+        grid=interferometer_7.grids.uniform, transformer=interferometer_7.transformer
     )
     g1_visibilities = g1.visibilities_from(
-        grid=interferometer_7.grid, transformer=interferometer_7.transformer
+        grid=interferometer_7.grids.uniform, transformer=interferometer_7.transformer
     )
 
     assert fit.galaxy_model_visibilities_dict[g0] == pytest.approx(
@@ -314,15 +314,15 @@ def test___galaxy_model_visibilities_dict(interferometer_7):
 
     mapper_grids = pixelization.mesh.mapper_grids_from(
         mask=interferometer_7.real_space_mask,
-        source_plane_data_grid=interferometer_7.grid,
-        border_relocator=interferometer_7.border_relocator,
+        source_plane_data_grid=interferometer_7.grids.uniform,
+        border_relocator=interferometer_7.grids.border_relocator,
         source_plane_mesh_grid=None,
     )
 
     mapper = ag.Mapper(
         mapper_grids=mapper_grids,
         over_sampler=interferometer_7.grids.pixelization.over_sampler,
-        border_relocator=interferometer_7.border_relocator,
+        border_relocator=interferometer_7.grids.border_relocator,
         regularization=pixelization.regularization,
     )
 

--- a/test_autogalaxy/interferometer/test_simulate_and_fit_interferometer.py
+++ b/test_autogalaxy/interferometer/test_simulate_and_fit_interferometer.py
@@ -198,14 +198,14 @@ def test__linear_light_profiles_agree_with_standard_light_profiles():
     ] == pytest.approx(0.2, 1.0e-2)
     assert fit.log_likelihood == pytest.approx(fit_linear.log_likelihood, 1.0e-4)
 
-    galaxy_image = galaxy.image_2d_from(grid=dataset.grid)
+    galaxy_image = galaxy.image_2d_from(grid=dataset.grids.uniform)
 
     assert fit_linear.galaxy_model_image_dict[galaxy_linear] == pytest.approx(
         galaxy_image, 1.0e-4
     )
 
     galaxy_visibilities = galaxy.visibilities_from(
-        grid=dataset.grid, transformer=dataset.transformer
+        grid=dataset.grids.uniform, transformer=dataset.transformer
     )
 
     assert fit_linear.galaxy_model_visibilities_dict[galaxy_linear] == pytest.approx(

--- a/test_autogalaxy/quantity/test_dataset_quantity.py
+++ b/test_autogalaxy/quantity/test_dataset_quantity.py
@@ -83,7 +83,7 @@ def test__grid(
         noise_map=ag.Array2D.full(
             fill_value=2.0, shape_native=(7, 7), pixel_scales=1.0
         ),
-        over_sampling=ag.OverSamplingIterate(),
+        over_sampling=ag.OverSamplingDataset(uniform=ag.OverSamplingIterate()),
     )
 
     dataset = dataset_quantity.apply_mask(mask=mask_2d_7x7)

--- a/test_autogalaxy/quantity/test_dataset_quantity.py
+++ b/test_autogalaxy/quantity/test_dataset_quantity.py
@@ -75,8 +75,8 @@ def test__grid(
 ):
     dataset = dataset_quantity_7x7_array_2d.apply_mask(mask=mask_2d_7x7)
 
-    assert isinstance(dataset.grid, ag.Grid2D)
-    assert (dataset.grid == grid_2d_7x7).all()
+    assert isinstance(dataset.grids.uniform, ag.Grid2D)
+    assert (dataset.grids.uniform == grid_2d_7x7).all()
 
     dataset_quantity = ag.DatasetQuantity(
         data=ag.Array2D.ones(shape_native=(7, 7), pixel_scales=1.0),
@@ -88,8 +88,8 @@ def test__grid(
 
     dataset = dataset_quantity.apply_mask(mask=mask_2d_7x7)
 
-    assert isinstance(dataset.grid.over_sampling, ag.OverSamplingIterate)
-    assert (dataset.grid == grid_2d_7x7).all()
+    assert isinstance(dataset.grids.uniform.over_sampling, ag.OverSamplingIterate)
+    assert (dataset.grids.uniform == grid_2d_7x7).all()
 
 
 def test__vector_data__y_x():


### PR DESCRIPTION
Refactors over sampling and implements an additional form which computes lensed source emission on a non-uniform over sampled grid input by a user, as described in the following example:

https://github.com/Jammy2211/autolens_workspace/blob/main/scripts/imaging/advanced/chaining/examples/over_sample.py