### PR TITLE
When using JAX don't import Numpy

### DIFF
--- a/autogalaxy/profiles/geometry_profiles.py
+++ b/autogalaxy/profiles/geometry_profiles.py
@@ -1,6 +1,11 @@
+import os
+
 from typing import Optional, Tuple, Type
 
-import numpy as np
+if os.environ.get("USE_JAX", "0") == "1":
+    import jax.numpy as np
+else:
+    import numpy as np
 
 import autoarray as aa
 


### PR DESCRIPTION
Switches out `numpy` for `jax.numpy`.  A very simple fix that makes radial profiles work as expected.