### PR TITLE
Voronoi Test Skipping

### DIFF
--- a/test_autogalaxy/analysis/test_plotter_interface.py
+++ b/test_autogalaxy/analysis/test_plotter_interface.py
@@ -69,14 +69,14 @@ def test__galaxies_1d(
 
 
 def test__inversion(
-    masked_imaging_7x7, voronoi_inversion_9_3x3, include_2d_all, plot_path, plot_patch
+    masked_imaging_7x7, rectangular_inversion_7x7_3x3, include_2d_all, plot_path, plot_patch
 ):
     if path.exists(plot_path):
         shutil.rmtree(plot_path)
 
     plotter_interface = PlotterInterface(image_path=plot_path)
 
-    plotter_interface.inversion(inversion=voronoi_inversion_9_3x3, during_analysis=True)
+    plotter_interface.inversion(inversion=rectangular_inversion_7x7_3x3, during_analysis=True)
 
     assert path.join(plot_path, "subplot_inversion_0.png") in plot_patch.paths
 

--- a/test_autogalaxy/conftest.py
+++ b/test_autogalaxy/conftest.py
@@ -64,6 +64,9 @@ def make_psf_3x3_no_blur():
 def make_rectangular_inversion_7x7_3x3():
     return fixtures.make_rectangular_inversion_7x7_3x3()
 
+@pytest.fixture(name="delaunay_inversion_9_3x3")
+def make_delaunay_inversion_9_3x3():
+    return fixtures.make_delaunay_inversion_9_3x3()
 
 @pytest.fixture(name="voronoi_inversion_9_3x3")
 def make_voronoi_inversion_9_3x3():


### PR DESCRIPTION
Updates unit tests so that if a user does not have the Voronoi NN library installed, pytest skips the appropriate tests.