### PR TITLE
Feature/ellipse disable data

### DIFF
--- a/autogalaxy/config/visualize/plots.yaml
+++ b/autogalaxy/config/visualize/plots.yaml
@@ -83,7 +83,9 @@ fit_interferometer:                        # Settings for plots of fits to inter
   dirty_residual_map: false
   dirty_normalized_residual_map: false
   dirty_chi_squared_map: false
-
+fit_ellipse:                               # Settings for plots of ellipse fitting fits (e.g. FitEllipse)
+  data : true                              # Plot the data of the ellipse fit?
+  data_no_ellipse: true                    # Plot the data without the black data ellipses, which obscure noisy data?
 fit_quantity:                              # Settings for plots of fit quantities (e.g. FitQuantityPlotter).
   all_at_end_png: true                     # Plot all individual plots listed below as .png (even if False)?
   all_at_end_fits: true                    # Plot all individual plots listed below as .fits (even if False)?

--- a/autogalaxy/ellipse/model/plotter_interface.py
+++ b/autogalaxy/ellipse/model/plotter_interface.py
@@ -94,15 +94,23 @@ class PlotterInterfaceEllipse(PlotterInterface):
             fit_list=fit_list, mat_plot_2d=mat_plot_2d, include_2d=self.include_2d
         )
 
-        # fit_plotter.figures_2d(
-        #     data=should_plot("data"),
-        # )
+        fit_plotter.figures_2d(data=should_plot("data"))
 
-        fit_plotter.figures_2d(data=True)
+        if should_plot("data_no_ellipse"):
+            fit_plotter.figures_2d(
+                data=True,
+                disable_data_contours=True,
+            )
 
         fit_plotter.mat_plot_2d.use_log10 = True
 
-        fit_plotter.figures_2d(data=True)
+        fit_plotter.figures_2d(data=should_plot("data"))
+
+        if should_plot("data_no_ellipse"):
+            fit_plotter.figures_2d(
+                data=True,
+                disable_data_contours=True,
+            )
 
         if not during_analysis and should_plot("all_at_end_png"):
             mat_plot_2d = self.mat_plot_2d_from(subfolders=path.join(subfolders, "end"))
@@ -111,6 +119,8 @@ class PlotterInterfaceEllipse(PlotterInterface):
                 fit_list=fit_list, mat_plot_2d=mat_plot_2d, include_2d=self.include_2d
             )
 
+            fit_plotter.figures_2d(data=True)
             fit_plotter.figures_2d(
                 data=True,
+                disable_data_contours=True,
             )

--- a/autogalaxy/ellipse/plot/fit_ellipse_plotters.py
+++ b/autogalaxy/ellipse/plot/fit_ellipse_plotters.py
@@ -50,6 +50,7 @@ class FitEllipsePlotter(Plotter):
     def figures_2d(
         self,
         data: bool = False,
+        disable_data_contours: bool = False,
         suffix: str = "",
     ):
         """
@@ -62,12 +63,16 @@ class FitEllipsePlotter(Plotter):
         ----------
         data
             Whether to make a 1D plot (via `imshow`) of the image data.
+        disable_data_contours
+            If `True`, the data is plotted without the black data contours over the top (but the white contours
+            showing the ellipses are still plotted).
         """
 
+        if disable_data_contours:
+            contour_original = self.mat_plot_2d.contour
+            self.mat_plot_2d.contour = False
+
         if data:
-            # # Used for 1D plot
-            #
-            # # colors = [ax.cmap(ax.norm(level)) for level in levels][::-1]
 
             self.mat_plot_2d.contour = aplt.Contour(
                 manual_levels=np.sort(
@@ -95,3 +100,6 @@ class FitEllipsePlotter(Plotter):
                     filename=f"ellipse_fit",
                 ),
             )
+
+        if disable_data_contours:
+            self.mat_plot_2d.contour = contour_original

--- a/autogalaxy/ellipse/plot/fit_ellipse_plotters.py
+++ b/autogalaxy/ellipse/plot/fit_ellipse_plotters.py
@@ -68,12 +68,14 @@ class FitEllipsePlotter(Plotter):
             showing the ellipses are still plotted).
         """
 
+        filename_tag = ""
+
         if disable_data_contours:
             contour_original = self.mat_plot_2d.contour
             self.mat_plot_2d.contour = False
+            filename_tag = "_no_data_contours"
 
         if data:
-
             self.mat_plot_2d.contour = aplt.Contour(
                 manual_levels=np.sort(
                     [float(np.mean(fit.data_interp)) for fit in self.fit_list]
@@ -97,7 +99,7 @@ class FitEllipsePlotter(Plotter):
                 visuals_2d=visuals_2d,
                 auto_labels=aplt.AutoLabels(
                     title=f"Ellipse Fit",
-                    filename=f"ellipse_fit",
+                    filename=f"ellipse_fit{filename_tag}",
                 ),
             )
 

--- a/autogalaxy/ellipse/plot/fit_ellipse_plotters.py
+++ b/autogalaxy/ellipse/plot/fit_ellipse_plotters.py
@@ -70,17 +70,17 @@ class FitEllipsePlotter(Plotter):
 
         filename_tag = ""
 
-        if disable_data_contours:
-            contour_original = self.mat_plot_2d.contour
-            self.mat_plot_2d.contour = False
-            filename_tag = "_no_data_contours"
-
         if data:
             self.mat_plot_2d.contour = aplt.Contour(
                 manual_levels=np.sort(
                     [float(np.mean(fit.data_interp)) for fit in self.fit_list]
                 )
             )
+
+            if disable_data_contours:
+                contour_original = self.mat_plot_2d.contour
+                self.mat_plot_2d.contour = False
+                filename_tag = "_no_data_contours"
 
             ellipse_list = []
 
@@ -103,5 +103,5 @@ class FitEllipsePlotter(Plotter):
                 ),
             )
 
-        if disable_data_contours:
-            self.mat_plot_2d.contour = contour_original
+            if disable_data_contours:
+                self.mat_plot_2d.contour = contour_original


### PR DESCRIPTION
Disables the black contours of the data for an ellipse fit, outputting an separate image without them.

This is useful for low signal to noise data where the black contours obscure the fit:

![image](https://github.com/user-attachments/assets/dab4ac8b-8636-422e-befb-f41c1941359c)
![image](https://github.com/user-attachments/assets/b4829bb7-7e19-49e2-b7ee-90a3e1660f23)
