### PR TITLE
Feature/ellipse masking

### DIFF
--- a/autogalaxy/ellipse/dataset_interp.py
+++ b/autogalaxy/ellipse/dataset_interp.py
@@ -45,6 +45,19 @@ class DatasetInterp:
         return (x, y)
 
     @cached_property
+    def mask_interp(self) -> interpolate.RegularGridInterpolator:
+        """
+        Returns a 2D interpolation of the mask, which is used to determine whether inteprolated values use a masked
+        pixel for the interpolation and thus should not be included in a fit.
+        """
+        return interpolate.RegularGridInterpolator(
+            points=self.points_interp,
+            values=np.float64(self.dataset.data.mask),
+            bounds_error=False,
+            fill_value=0.0,
+        )
+
+    @cached_property
     def data_interp(self) -> interpolate.RegularGridInterpolator:
         """
         Returns a 2D interpolation of the data, which is used to evaluate the data at any point in 2D space.

--- a/autogalaxy/ellipse/ellipse/ellipse.py
+++ b/autogalaxy/ellipse/ellipse/ellipse.py
@@ -115,6 +115,9 @@ class Ellipse(EllProfile):
 
         They are subtracted by the `angle` of the ellipse to give the angles from the major-axis of the ellipse.
 
+        The final angle, which is 2.0 * np.pi radians, is a repeat of the first angle of zero radians, therefore
+        the final angle is removed.
+
         The number of angles computed is the minimum of 500 and the integer of the circular radius of the ellipse.
         This value is chosen to ensure that the number of angles computed matches the number of pixels in the
         data that the ellipse is being fitted to.
@@ -130,7 +133,7 @@ class Ellipse(EllProfile):
         """
         total_points = self.total_points_from(pixel_scale)
 
-        return np.linspace(0.0, 2.0 * np.pi, total_points)
+        return np.linspace(0.0, 2.0 * np.pi, total_points)[:-1]
 
     def ellipse_radii_from_major_axis_from(self, pixel_scale: float) -> np.ndarray:
         """

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -239,11 +239,11 @@ class FitEllipse(aa.FitDataset):
 
         normalized_residual_map = (self.residual_map) / self.noise_map_interp
 
-        # NOTE:
-        idx = np.logical_or(
-            np.isnan(normalized_residual_map), np.isinf(normalized_residual_map)
-        )
-        normalized_residual_map[idx] = 0.0
+        # # NOTE:
+        # idx = np.logical_or(
+        #     np.isnan(normalized_residual_map), np.isinf(normalized_residual_map)
+        # )
+        # normalized_residual_map[idx] = 0.0
 
         return aa.ArrayIrregular(values=normalized_residual_map)
 

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -238,16 +238,7 @@ class FitEllipse(aa.FitDataset):
         -------
         The normalized residual-map of the fit, which is the residual-map divided by the noise-map.
         """
-
-        normalized_residual_map = (self.residual_map) / self.noise_map_interp
-
-        # # NOTE:
-        # idx = np.logical_or(
-        #     np.isnan(normalized_residual_map), np.isinf(normalized_residual_map)
-        # )
-        # normalized_residual_map[idx] = 0.0
-
-        return aa.ArrayIrregular(values=normalized_residual_map)
+        return aa.ArrayIrregular(values=self.residual_map / self.noise_map_interp)
 
     @property
     def chi_squared_map(self) -> aa.ArrayIrregular:

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -133,6 +133,33 @@ class FitEllipse(aa.FitDataset):
         return aa.ArrayIrregular(values=self.data_interp / self.noise_map_interp)
 
     @property
+    def total_points_interp(self) -> int:
+        """
+        Returns the total number of points used to interpolate the data and noise-map values of the ellipse.
+
+        For example, if the ellipse spans 10 pixels, the total number of points will be 10.
+
+        The calculation removes points if they meet one of the following two criteria:
+
+        1) They are removed by the mask of the dataset.
+        2) If the signal-to-noise-map of the ellipse is below 1.0e-6, which means that the noise-map has been
+        increased to a very high value to remove this data point (e.g. it contains emission from foreground
+        objectS).
+
+        The (y,x) coordinates on the ellipse where the interpolation occurs are computed in the
+        `points_from_major_axis` property of the `Ellipse` class, with the documentation describing how these points
+        are computed.
+
+        Returns
+        -------
+        The noise-map values of the ellipse fits, computed via a 2D interpolation of where the ellipse
+        overlaps the noise-map.
+        """
+        print(self.data_interp)
+        print(self.residual_map)
+        return self.noise_map_interp.shape[0]
+
+    @property
     def model_data(self) -> aa.ArrayIrregular:
         """
         Returns the model-data, which is the data values where the ellipse overlaps the data minus the mean

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -80,8 +80,8 @@ class FitEllipse(aa.FitDataset):
         """
         points = self.points_from_major_axis_from()
 
-        if np.isclose(points[0,0], points[-1, 0], 1.0e-8):
-            if np.isclose(points[0,1], points[-1, 1], 1.0e-8):
+        if np.isclose(points[0, 0], points[-1, 0], 1.0e-8):
+            if np.isclose(points[0, 1], points[-1, 1], 1.0e-8):
                 return points[0:-1, :]
 
         return points
@@ -133,9 +133,7 @@ class FitEllipse(aa.FitDataset):
 
         data[self.mask_interp] = np.nan
 
-        return aa.ArrayIrregular(
-            values=data
-        )
+        return aa.ArrayIrregular(values=data)
 
     @property
     def noise_map_interp(self) -> aa.ArrayIrregular:
@@ -159,9 +157,7 @@ class FitEllipse(aa.FitDataset):
 
         noise_map[self.mask_interp] = np.nan
 
-        return aa.ArrayIrregular(
-            values=noise_map
-        )
+        return aa.ArrayIrregular(values=noise_map)
 
     @property
     def signal_to_noise_map_interp(self) -> aa.ArrayIrregular:

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -279,7 +279,7 @@ class FitEllipse(aa.FitDataset):
         -------
         The noise normalization term of the log likelihood.
         """
-        return np.sum(np.log(2 * np.pi * self.noise_map_interp**2.0))
+        return np.nansum(np.log(2 * np.pi * self.noise_map_interp**2.0))
 
     @property
     def log_likelihood(self):

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -116,7 +116,7 @@ class FitEllipse(aa.FitDataset):
         are computed.
 
         If the interpolation of an ellipse point uses one or more masked values, this point is not reliable, therefore
-        the data value is converted to `np.nan` and not used by other fitting quantities.
+        the value is converted to `np.nan` and not used by other fitting quantities.
 
         Returns
         -------
@@ -141,13 +141,20 @@ class FitEllipse(aa.FitDataset):
         `points_from_major_axis` property of the `Ellipse` class, with the documentation describing how these points
         are computed.
 
+        If the interpolation of an ellipse point uses one or more masked values, this point is not reliable, therefore
+        the value is converted to `np.nan` and not used by other fitting quantities.
+
         Returns
         -------
         The noise-map values of the ellipse fits, computed via a 2D interpolation of where the ellipse
         overlaps the noise-map.
         """
+        noise_map = self.interp.noise_map_interp(self._points_from_major_axis)
+
+        noise_map[self.mask_interp] = np.nan
+
         return aa.ArrayIrregular(
-            values=self.interp.noise_map_interp(self._points_from_major_axis)
+            values=noise_map
         )
 
     @property

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -112,6 +112,27 @@ class FitEllipse(aa.FitDataset):
         return self.interp.mask_interp(self._points_from_major_axis) > 0.0
 
     @property
+    def total_points_interp(self) -> int:
+        """
+        Returns the total number of points used to interpolate the data and noise-map values of the ellipse.
+
+        For example, if the ellipse spans 10 pixels, the total number of points will be 10.
+
+        The calculation removes points if one or more interpolated value uses a masked value, meaning the interpolation
+        is not reliable.
+
+        The (y,x) coordinates on the ellipse where the interpolation occurs are computed in the
+        `points_from_major_axis` property of the `Ellipse` class, with the documentation describing how these points
+        are computed.
+
+        Returns
+        -------
+        The noise-map values of the ellipse fits, computed via a 2D interpolation of where the ellipse
+        overlaps the noise-map.
+        """
+        return self.data_interp[np.invert(self.mask_interp)].shape[0]
+
+    @property
     def data_interp(self) -> aa.ArrayIrregular:
         """
         Returns the data values of the dataset that the ellipse fits, which are computed by overlaying the ellipse over
@@ -171,27 +192,6 @@ class FitEllipse(aa.FitDataset):
         the ellipse overlaps the data and noise-map.
         """
         return aa.ArrayIrregular(values=self.data_interp / self.noise_map_interp)
-
-    @property
-    def total_points_interp(self) -> int:
-        """
-        Returns the total number of points used to interpolate the data and noise-map values of the ellipse.
-
-        For example, if the ellipse spans 10 pixels, the total number of points will be 10.
-
-        The calculation removes points if one or more interpolated value uses a masked value, meaning the interpolation
-        is not reliable.
-
-        The (y,x) coordinates on the ellipse where the interpolation occurs are computed in the
-        `points_from_major_axis` property of the `Ellipse` class, with the documentation describing how these points
-        are computed.
-
-        Returns
-        -------
-        The noise-map values of the ellipse fits, computed via a 2D interpolation of where the ellipse
-        overlaps the noise-map.
-        """
-        return self.data_interp[np.invert(self.mask_interp)].shape[0]
 
     @property
     def model_data(self) -> aa.ArrayIrregular:

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -221,6 +221,7 @@ class FitEllipse(aa.FitDataset):
         -------
         The residual-map of the fit, which is the data minus the model data and therefore the same as the model data.
         """
+        print(self.model_data)
         return aa.ArrayIrregular(values=self.model_data - np.nanmean(self.model_data))
 
     @property

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -268,7 +268,7 @@ class FitEllipse(aa.FitDataset):
         -------
         The chi-squared of the fit.
         """
-        return float(np.sum(self.chi_squared_map))
+        return float(np.nansum(self.chi_squared_map))
 
     @property
     def noise_normalization(self):

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -177,12 +177,8 @@ class FitEllipse(aa.FitDataset):
 
         For example, if the ellipse spans 10 pixels, the total number of points will be 10.
 
-        The calculation removes points if they meet one of the following two criteria:
-
-        1) They are removed by the mask of the dataset.
-        2) If the signal-to-noise-map of the ellipse is below 1.0e-6, which means that the noise-map has been
-        increased to a very high value to remove this data point (e.g. it contains emission from foreground
-        objectS).
+        The calculation removes points if one or more interpolated value uses a masked value, meaning the interpolation
+        is not reliable.
 
         The (y,x) coordinates on the ellipse where the interpolation occurs are computed in the
         `points_from_major_axis` property of the `Ellipse` class, with the documentation describing how these points
@@ -193,9 +189,7 @@ class FitEllipse(aa.FitDataset):
         The noise-map values of the ellipse fits, computed via a 2D interpolation of where the ellipse
         overlaps the noise-map.
         """
-        print(self.data_interp)
-        print(self.residual_map)
-        return self.noise_map_interp.shape[0]
+        return self.data_interp[np.invert(self.mask_interp)].shape[0]
 
     @property
     def model_data(self) -> aa.ArrayIrregular:

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -78,13 +78,7 @@ class FitEllipse(aa.FitDataset):
         -------
         The (y,x) coordinates on the ellipse where the interpolation occurs.
         """
-        points = self.points_from_major_axis_from()
-
-        if np.isclose(points[0, 0], points[-1, 0], 1.0e-8):
-            if np.isclose(points[0, 1], points[-1, 1], 1.0e-8):
-                return points[0:-1, :]
-
-        return points
+        return self.points_from_major_axis_from()
 
     @property
     def mask_interp(self) -> np.ndarray:

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -78,7 +78,13 @@ class FitEllipse(aa.FitDataset):
         -------
         The (y,x) coordinates on the ellipse where the interpolation occurs.
         """
-        return self.points_from_major_axis_from()
+        points = self.points_from_major_axis_from()
+
+        if np.isclose(points[0,0], points[-1, 0], 1.0e-8):
+            if np.isclose(points[0,1], points[-1, 1], 1.0e-8):
+                return points[0:-1, :]
+
+        return points
 
     @property
     def mask_interp(self) -> np.ndarray:
@@ -221,7 +227,6 @@ class FitEllipse(aa.FitDataset):
         -------
         The residual-map of the fit, which is the data minus the model data and therefore the same as the model data.
         """
-        print(self.model_data)
         return aa.ArrayIrregular(values=self.model_data - np.nanmean(self.model_data))
 
     @property

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -208,7 +208,7 @@ class FitEllipse(aa.FitDataset):
         return self.data_interp
 
     @property
-    def residual_map(self):
+    def residual_map(self) -> aa.ArrayIrregular:
         """
         Returns the residual-map of the fit, which is the data minus the model data and therefore the same
         as the model data.
@@ -217,6 +217,10 @@ class FitEllipse(aa.FitDataset):
         -------
         The residual-map of the fit, which is the data minus the model data and therefore the same as the model data.
         """
+
+        if not self.model_data:
+            return aa.ArrayIrregular(values=np.zeros(self.model_data.shape))
+
         return aa.ArrayIrregular(values=self.model_data - np.nanmean(self.model_data))
 
     @property

--- a/test_autogalaxy/ellipse/test_dataset_interp.py
+++ b/test_autogalaxy/ellipse/test_dataset_interp.py
@@ -2,6 +2,35 @@ import pytest
 
 import autogalaxy as ag
 
+def test__mask_interp():
+
+    data = ag.Array2D.no_mask(
+        values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], pixel_scales=1.0
+    )
+    noise_map = ag.Array2D.ones(shape_native=(3, 3), pixel_scales=1.0)
+
+    dataset = ag.Imaging(data=data, noise_map=noise_map)
+
+    interp = ag.DatasetInterp(dataset=dataset)
+
+    assert interp.mask_interp((0.5, 0.5)) == pytest.approx(0.0, 1.0e-4)
+
+    mask = ag.Mask2D(
+        mask=[[False, False, False],
+              [False, True, False],
+              [False, False, False]],
+        pixel_scales=1.0
+    )
+
+    data = data.apply_mask(mask=mask)
+
+    dataset = ag.Imaging(data=data, noise_map=noise_map)
+
+    interp = ag.DatasetInterp(dataset=dataset)
+
+    assert interp.mask_interp((0.5, 0.5)) == pytest.approx(0.25, 1.0e-4)
+
+
 
 def test__data_interp():
     data = ag.Array2D.no_mask(

--- a/test_autogalaxy/ellipse/test_dataset_interp.py
+++ b/test_autogalaxy/ellipse/test_dataset_interp.py
@@ -2,8 +2,8 @@ import pytest
 
 import autogalaxy as ag
 
-def test__mask_interp():
 
+def test__mask_interp():
     data = ag.Array2D.no_mask(
         values=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], pixel_scales=1.0
     )
@@ -16,10 +16,8 @@ def test__mask_interp():
     assert interp.mask_interp((0.5, 0.5)) == pytest.approx(0.0, 1.0e-4)
 
     mask = ag.Mask2D(
-        mask=[[False, False, False],
-              [False, True, False],
-              [False, False, False]],
-        pixel_scales=1.0
+        mask=[[False, False, False], [False, True, False], [False, False, False]],
+        pixel_scales=1.0,
     )
 
     data = data.apply_mask(mask=mask)
@@ -29,7 +27,6 @@ def test__mask_interp():
     interp = ag.DatasetInterp(dataset=dataset)
 
     assert interp.mask_interp((0.5, 0.5)) == pytest.approx(0.25, 1.0e-4)
-
 
 
 def test__data_interp():

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -78,6 +78,17 @@ def test__mask_interp(imaging_lh, imaging_lh_masked):
 
     assert fit.mask_interp == pytest.approx([False, True, True, True, True], 1.0e-4)
 
+def test__total_points_interp(imaging_lh, imaging_lh_masked):
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
+
+    assert fit.total_points_interp == 5
+
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
+
+    assert fit.total_points_interp == 1
+
 
 def test__data_interp(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
@@ -120,18 +131,6 @@ def test__signal_to_noise_map_interp(imaging_lh, imaging_lh_masked):
 
     assert fit.signal_to_noise_map_interp[0] == pytest.approx(3.0, 1.0e-4)
     assert np.isnan(fit.signal_to_noise_map_interp[1:5]).all()
-
-
-def test__total_points_interp(imaging_lh, imaging_lh_masked):
-    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
-
-    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
-
-    assert fit.total_points_interp == 6
-
-    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
-
-    assert fit.total_points_interp == 2
 
 
 def test__residual_map(imaging_lh):

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -3,6 +3,35 @@ import pytest
 
 import autogalaxy as ag
 
+mask = ag.Mask2D(
+    mask=[
+        [True, True, True, True, True, True, True],
+        [True, True, True, True, True, True, True],
+        [True, True, False, False, False, True, True],
+        [True, True, False, True, False, True, True],
+        [True, True, False, False, False, True, True],
+        [True, True, True, True, True, True, True],
+        [True, True, True, True, True, True, True],
+    ],
+    pixel_scales=1.0,
+)
+
+
+def test__mask_interp(imaging_7x7):
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+
+    assert fit.mask_interp[0] == pytest.approx(False, 1.0e-4)
+    assert fit.mask_interp[1] == pytest.approx(False, 1.0e-4)
+
+    imaging_7x7 = imaging_7x7.apply_mask(mask=mask)
+
+    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+
+    assert fit.mask_interp[0] == pytest.approx(False, 1.0e-4)
+    assert fit.mask_interp[1] == pytest.approx(True, 1.0e-4)
+
 
 def test__data_interp(imaging_7x7):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
@@ -12,6 +41,12 @@ def test__data_interp(imaging_7x7):
     assert fit.data_interp[0] == pytest.approx(1.0, 1.0e-4)
     assert fit.data_interp[1] == pytest.approx(1.0, 1.0e-4)
 
+    imaging_7x7 = imaging_7x7.apply_mask(mask=mask)
+
+    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+
+    assert fit.data_interp[0] == pytest.approx(1.0, 1.0e-4)
+    assert np.isnan(fit.data_interp[1])
 
 def test__noise_map_interp(imaging_7x7):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
@@ -21,34 +56,35 @@ def test__noise_map_interp(imaging_7x7):
     assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
     assert fit.noise_map_interp[1] == pytest.approx(2.0, 1.0e-4)
 
-def test__total_points_interp(imaging_7x7):
 
-    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
-
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
-
-    assert fit.total_points_interp == 6
-
-    mask = np.array(
-        [
-            [True, True, True, True, True, True, True],
-            [True, True, True, True, True, True, True],
-            [True, True, True, True, True, True, True],
-            [True, True, False, False, False, True, True],
-            [True, True, False, False, False, True, True],
-            [True, True, True, True, True, True, True],
-            [True, True, True, True, True, True, True],
-        ]
-    )
-
-    mask = ag.Mask2D(mask=mask, pixel_scales=(1.0, 1.0))
-
-    imaging = imaging_7x7.apply_mask(mask=mask)
-
-    fit = ag.FitEllipse(dataset=imaging, ellipse=ellipse_0)
-
-    assert fit.total_points_interp == 4
-
+#
+# def test__total_points_interp(imaging_7x7):
+#
+#     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+#
+#     fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+#
+#     assert fit.total_points_interp == 6
+#
+#     mask = np.array(
+#         [
+#             [True, True, True, True, True, True, True],
+#             [True, True, True, True, True, True, True],
+#             [True, True, True, True, True, True, True],
+#             [True, True, False, False, False, True, True],
+#             [True, True, False, False, False, True, True],
+#             [True, True, True, True, True, True, True],
+#             [True, True, True, True, True, True, True],
+#         ]
+#     )
+#
+#     mask = ag.Mask2D(mask=mask, pixel_scales=(1.0, 1.0))
+#
+#     imaging = imaging_7x7.apply_mask(mask=mask)
+#
+#     fit = ag.FitEllipse(dataset=imaging, ellipse=ellipse_0)
+#
+#     assert fit.total_points_interp == 4
 
 
 def test__log_likelihood(imaging_7x7):

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -6,7 +6,6 @@ import autogalaxy as ag
 
 @pytest.fixture(name="imaging_lh")
 def make_imaging_lh(imaging_7x7):
-
     data = ag.Array2D.ones(shape_native=(7, 7), pixel_scales=(1.0, 1.0))
 
     data[16] = 1.0
@@ -24,9 +23,9 @@ def make_imaging_lh(imaging_7x7):
         noise_map=imaging_7x7.noise_map,
     )
 
+
 @pytest.fixture(name="imaging_lh_masked")
 def make_imaging_lh_masked(imaging_lh):
-
     mask = ag.Mask2D(
         mask=[
             [True, True, True, True, True, True, True],
@@ -85,7 +84,9 @@ def test__data_interp(imaging_lh, imaging_lh_masked):
 
     fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
-    assert fit.data_interp == pytest.approx([6., 2.45584745, 2.42762725, 5.95433876, 8.16218654], 1.0e-4)
+    assert fit.data_interp == pytest.approx(
+        [6.0, 2.45584745, 2.42762725, 5.95433876, 8.16218654], 1.0e-4
+    )
 
     fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
 
@@ -109,19 +110,19 @@ def test__noise_map_interp(imaging_lh, imaging_lh_masked):
 def test__signal_to_noise_map_interp(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
-    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
-
-    assert fit.signal_to_noise_map_interp[0] == pytest.approx(0.5, 1.0e-4)
-    assert fit.signal_to_noise_map_interp[1] == pytest.approx(0.5, 1.0e-4)
-
     fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
-    assert fit.signal_to_noise_map_interp[0] == pytest.approx(0.5, 1.0e-4)
-    assert np.isnan(fit.signal_to_noise_map_interp[1])
+    assert fit.signal_to_noise_map_interp == pytest.approx(
+        [3.0, 1.22792372, 1.21381362, 2.97716938, 4.08109327], 1.0e-4
+    )
+
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
+
+    assert fit.signal_to_noise_map_interp[0] == pytest.approx(3.0, 1.0e-4)
+    assert np.isnan(fit.signal_to_noise_map_interp[1:5]).all()
 
 
 def test__total_points_interp(imaging_lh, imaging_lh_masked):
-
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
     fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
@@ -145,7 +146,6 @@ def test__residual_map(imaging_lh):
 
 
 def test__log_likelihood(imaging_7x7):
-
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)
 
     fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
@@ -157,6 +157,3 @@ def test__log_likelihood(imaging_7x7):
     fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
 
     assert fit.log_likelihood == pytest.approx(0.0, 1.0e-4)
-
-
-

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -68,18 +68,16 @@ def test___points_from_major_axis__multipole(imaging_lh):
     assert fit._points_from_major_axis[1, 1] == pytest.approx(-0.038278334, 1.0e-4)
 
 
-def test__mask_interp(imaging_7x7, imaging_lh):
+def test__mask_interp(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
-
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
-
-    assert fit.mask_interp[0] == pytest.approx(False, 1.0e-4)
-    assert fit.mask_interp[1] == pytest.approx(False, 1.0e-4)
 
     fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
-    assert fit.mask_interp[0] == pytest.approx(False, 1.0e-4)
-    assert fit.mask_interp[1] == pytest.approx(True, 1.0e-4)
+    assert fit.mask_interp == pytest.approx([False, False, False, False, False], 1.0e-4)
+
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
+
+    assert fit.mask_interp == pytest.approx([False, True, True, True, True], 1.0e-4)
 
 
 def test__data_interp(imaging_lh, imaging_lh_masked):
@@ -95,10 +93,10 @@ def test__data_interp(imaging_lh, imaging_lh_masked):
     assert np.isnan(fit.data_interp[1:5]).all()
 
 
-def test__noise_map_interp(imaging_7x7, imaging_lh):
+def test__noise_map_interp(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
 
     assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
     assert fit.noise_map_interp[1] == pytest.approx(2.0, 1.0e-4)
@@ -108,10 +106,10 @@ def test__noise_map_interp(imaging_7x7, imaging_lh):
     assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
     assert np.isnan(fit.noise_map_interp[1])
 
-def test__signal_to_noise_map_interp(imaging_7x7, imaging_lh):
+def test__signal_to_noise_map_interp(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
 
     assert fit.signal_to_noise_map_interp[0] == pytest.approx(0.5, 1.0e-4)
     assert fit.signal_to_noise_map_interp[1] == pytest.approx(0.5, 1.0e-4)
@@ -122,11 +120,11 @@ def test__signal_to_noise_map_interp(imaging_7x7, imaging_lh):
     assert np.isnan(fit.signal_to_noise_map_interp[1])
 
 
-def test__total_points_interp(imaging_7x7, imaging_lh):
+def test__total_points_interp(imaging_lh, imaging_lh_masked):
 
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
 
     assert fit.total_points_interp == 6
 
@@ -150,7 +148,7 @@ def test__log_likelihood(imaging_7x7):
 
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)
 
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
 
     assert fit.log_likelihood == pytest.approx(-0.02038637385, 1.0e-4)
 

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -96,15 +96,15 @@ def test__data_interp(imaging_lh, imaging_lh_masked):
 def test__noise_map_interp(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
+
+    assert fit.noise_map_interp == pytest.approx([2.0, 2.0, 2.0, 2.0, 2.0], 1.0e-4)
+
     fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
 
     assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
-    assert fit.noise_map_interp[1] == pytest.approx(2.0, 1.0e-4)
+    assert np.isnan(fit.noise_map_interp[1:5]).all()
 
-    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
-
-    assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
-    assert np.isnan(fit.noise_map_interp[1])
 
 def test__signal_to_noise_map_interp(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -63,34 +63,35 @@ def test__noise_map_interp(imaging_7x7):
     assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
     assert np.isnan(fit.noise_map_interp[1])
 
-#
-# def test__total_points_interp(imaging_7x7):
-#
-#     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
-#
-#     fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
-#
-#     assert fit.total_points_interp == 6
-#
-#     mask = np.array(
-#         [
-#             [True, True, True, True, True, True, True],
-#             [True, True, True, True, True, True, True],
-#             [True, True, True, True, True, True, True],
-#             [True, True, False, False, False, True, True],
-#             [True, True, False, False, False, True, True],
-#             [True, True, True, True, True, True, True],
-#             [True, True, True, True, True, True, True],
-#         ]
-#     )
-#
-#     mask = ag.Mask2D(mask=mask, pixel_scales=(1.0, 1.0))
-#
-#     imaging = imaging_7x7.apply_mask(mask=mask)
-#
-#     fit = ag.FitEllipse(dataset=imaging, ellipse=ellipse_0)
-#
-#     assert fit.total_points_interp == 4
+def test__signal_to_noise_map_interp(imaging_7x7):
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+
+    assert fit.signal_to_noise_map_interp[0] == pytest.approx(0.5, 1.0e-4)
+    assert fit.signal_to_noise_map_interp[1] == pytest.approx(0.5, 1.0e-4)
+
+    imaging_7x7 = imaging_7x7.apply_mask(mask=mask)
+
+    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+
+    assert fit.signal_to_noise_map_interp[0] == pytest.approx(0.5, 1.0e-4)
+    assert np.isnan(fit.signal_to_noise_map_interp[1])
+
+
+def test__total_points_interp(imaging_7x7):
+
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+
+    assert fit.total_points_interp == 6
+
+    imaging = imaging_7x7.apply_mask(mask=mask)
+
+    fit = ag.FitEllipse(dataset=imaging, ellipse=ellipse_0)
+
+    assert fit.total_points_interp == 4
 
 
 def test__log_likelihood(imaging_7x7):

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -43,6 +43,31 @@ def make_imaging_lh_masked(imaging_lh):
     return imaging_lh.apply_mask(mask=mask)
 
 
+def test__points_from_major_axis(imaging_lh):
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
+
+    assert fit._points_from_major_axis[1, 0] == pytest.approx(-0.21232, 1.0e-4)
+    assert fit._points_from_major_axis[1, 1] == pytest.approx(0.068987, 1.0e-4)
+
+    assert fit._points_from_major_axis[4, 0] == pytest.approx(0.16366515, 1.0e-4)
+    assert fit._points_from_major_axis[4, 1] == pytest.approx(0.05317803, 1.0e-4)
+
+
+def test___points_from_major_axis__multipole(imaging_lh):
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)
+
+    multipole = ag.EllipseMultipole(m=4, multipole_comps=(0.2, 0.3))
+
+    fit = ag.FitEllipse(
+        dataset=imaging_lh, ellipse=ellipse_0, multipole_list=[multipole]
+    )
+
+    assert fit._points_from_major_axis[1, 0] == pytest.approx(-0.542453, 1.0e-4)
+    assert fit._points_from_major_axis[1, 1] == pytest.approx(-0.038278334, 1.0e-4)
+
+
 def test__mask_interp(imaging_7x7, imaging_lh):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
@@ -62,12 +87,11 @@ def test__data_interp(imaging_lh, imaging_lh_masked):
 
     fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
-    assert fit.data_interp == pytest.approx([6., 2.45584745, 2.42762725, 5.95433876, 8.16218654, 6.], 1.0e-4)
+    assert fit.data_interp == pytest.approx([6., 2.45584745, 2.42762725, 5.95433876, 8.16218654], 1.0e-4)
 
     fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
 
     assert fit.data_interp[0] == pytest.approx(6.0, 1.0e-4)
-    assert fit.data_interp[5] == pytest.approx(6.0, 1.0e-4)
     assert np.isnan(fit.data_interp[1:5]).all()
 
 
@@ -137,23 +161,4 @@ def test__log_likelihood(imaging_7x7):
     assert fit.log_likelihood == pytest.approx(0.0, 1.0e-4)
 
 
-def test__points_from_major_axis(imaging_7x7):
-    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)
 
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
-
-    assert fit._points_from_major_axis[1, 0] == pytest.approx(-0.21232, 1.0e-4)
-    assert fit._points_from_major_axis[1, 1] == pytest.approx(0.068987, 1.0e-4)
-
-
-def test___points_from_major_axis__multipole(imaging_7x7):
-    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)
-
-    multipole = ag.EllipseMultipole(m=4, multipole_comps=(0.2, 0.3))
-
-    fit = ag.FitEllipse(
-        dataset=imaging_7x7, ellipse=ellipse_0, multipole_list=[multipole]
-    )
-
-    assert fit._points_from_major_axis[1, 0] == pytest.approx(-0.542453, 1.0e-4)
-    assert fit._points_from_major_axis[1, 1] == pytest.approx(-0.038278334, 1.0e-4)

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -149,6 +149,21 @@ def test__residual_map(imaging_lh, imaging_lh_masked):
     assert np.isnan(fit.noise_map_interp[1:5]).all()
 
 
+def test__normalized_residual_map(imaging_lh, imaging_lh_masked):
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
+
+    assert fit.normalized_residual_map == pytest.approx(
+        [ 0.5       , -1.27207628, -1.28618638,  0.47716938,  1.58109327], 1.0e-4
+    )
+
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
+
+    assert fit.normalized_residual_map[0] == pytest.approx(0.0, 1.0e-4)
+    assert np.isnan(fit.noise_map_interp[1:5]).all()
+
+
 def test__log_likelihood(imaging_7x7):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)
 

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -3,21 +3,41 @@ import pytest
 
 import autogalaxy as ag
 
-mask = ag.Mask2D(
-    mask=[
-        [True, True, True, True, True, True, True],
-        [True, True, True, True, True, True, True],
-        [True, True, False, False, False, True, True],
-        [True, True, False, True, False, True, True],
-        [True, True, False, False, False, True, True],
-        [True, True, True, True, True, True, True],
-        [True, True, True, True, True, True, True],
-    ],
-    pixel_scales=1.0,
-)
+
+@pytest.fixture(name="imaging_lh")
+def make_imaging_lh(imaging_7x7):
+
+    data = ag.Array2D.ones(shape_native=(7, 7), pixel_scales=(1.0, 1.0))
+
+    data[16] = 3.0
+    data[17] = 3.0
+    data[18] = 3.0
+
+    mask = ag.Mask2D(
+        mask=[
+            [True, True, True, True, True, True, True],
+            [True, True, True, True, True, True, True],
+            [True, True, False, False, False, True, True],
+            [True, True, False, True, False, True, True],
+            [True, True, False, False, False, True, True],
+            [True, True, True, True, True, True, True],
+            [True, True, True, True, True, True, True],
+        ],
+        pixel_scales=1.0,
+    )
+
+    imaging_lh = ag.Imaging(
+        data=data,
+        noise_map=imaging_7x7.noise_map,
+    )
+
+    imaging_lh = imaging_lh.apply_mask(mask=mask)
+
+    return imaging_lh
 
 
-def test__mask_interp(imaging_7x7):
+
+def test__mask_interp(imaging_7x7, imaging_lh):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
     fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
@@ -25,15 +45,13 @@ def test__mask_interp(imaging_7x7):
     assert fit.mask_interp[0] == pytest.approx(False, 1.0e-4)
     assert fit.mask_interp[1] == pytest.approx(False, 1.0e-4)
 
-    imaging_7x7 = imaging_7x7.apply_mask(mask=mask)
-
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
     assert fit.mask_interp[0] == pytest.approx(False, 1.0e-4)
     assert fit.mask_interp[1] == pytest.approx(True, 1.0e-4)
 
 
-def test__data_interp(imaging_7x7):
+def test__data_interp(imaging_7x7, imaging_lh):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
     fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
@@ -41,14 +59,12 @@ def test__data_interp(imaging_7x7):
     assert fit.data_interp[0] == pytest.approx(1.0, 1.0e-4)
     assert fit.data_interp[1] == pytest.approx(1.0, 1.0e-4)
 
-    imaging_7x7 = imaging_7x7.apply_mask(mask=mask)
-
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
     assert fit.data_interp[0] == pytest.approx(1.0, 1.0e-4)
     assert np.isnan(fit.data_interp[1])
 
-def test__noise_map_interp(imaging_7x7):
+def test__noise_map_interp(imaging_7x7, imaging_lh):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
     fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
@@ -56,14 +72,12 @@ def test__noise_map_interp(imaging_7x7):
     assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
     assert fit.noise_map_interp[1] == pytest.approx(2.0, 1.0e-4)
 
-    imaging_7x7 = imaging_7x7.apply_mask(mask=mask)
-
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
     assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
     assert np.isnan(fit.noise_map_interp[1])
 
-def test__signal_to_noise_map_interp(imaging_7x7):
+def test__signal_to_noise_map_interp(imaging_7x7, imaging_lh):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
     fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
@@ -71,15 +85,13 @@ def test__signal_to_noise_map_interp(imaging_7x7):
     assert fit.signal_to_noise_map_interp[0] == pytest.approx(0.5, 1.0e-4)
     assert fit.signal_to_noise_map_interp[1] == pytest.approx(0.5, 1.0e-4)
 
-    imaging_7x7 = imaging_7x7.apply_mask(mask=mask)
-
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
     assert fit.signal_to_noise_map_interp[0] == pytest.approx(0.5, 1.0e-4)
     assert np.isnan(fit.signal_to_noise_map_interp[1])
 
 
-def test__total_points_interp(imaging_7x7):
+def test__total_points_interp(imaging_7x7, imaging_lh):
 
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
@@ -87,15 +99,20 @@ def test__total_points_interp(imaging_7x7):
 
     assert fit.total_points_interp == 6
 
-    imaging = imaging_7x7.apply_mask(mask=mask)
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
-    fit = ag.FitEllipse(dataset=imaging, ellipse=ellipse_0)
-
-    assert fit.total_points_interp == 4
+    assert fit.total_points_interp == 2
 
 
 def test__log_likelihood(imaging_7x7):
+
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+
+    assert fit.log_likelihood == pytest.approx(-0.02038637385, 1.0e-4)
+
+    imaging_7x7 = imaging_7x7.apply_mask(mask=mask)
 
     fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
 

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -178,6 +178,7 @@ def test__chi_squared_map(imaging_lh, imaging_lh_masked):
     assert fit.chi_squared_map[0] == pytest.approx(0.0, 1.0e-4)
     assert np.isnan(fit.noise_map_interp[1:5]).all()
 
+
 def test__chi_squared(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
@@ -197,24 +198,20 @@ def test__noise_normalization(imaging_lh, imaging_lh_masked):
 
     fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
-    assert fit.noise_normalization == pytest.approx(
-        16.120857137, 1.0e-4
-    )
+    assert fit.noise_normalization == pytest.approx(16.120857137, 1.0e-4)
 
     fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
 
     assert fit.noise_normalization == pytest.approx(3.224171427, 1.0e-4)
 
 
-def test__log_likelihood(imaging_7x7):
+def test__log_likelihood(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)
 
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
+
+    assert fit.log_likelihood == pytest.approx(-0.16764008373, 1.0e-4)
+
     fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
-
-    assert fit.log_likelihood == pytest.approx(-0.02038637385, 1.0e-4)
-
-    imaging_7x7 = imaging_7x7.apply_mask(mask=mask)
-
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
 
     assert fit.log_likelihood == pytest.approx(0.0, 1.0e-4)

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -78,6 +78,7 @@ def test__mask_interp(imaging_lh, imaging_lh_masked):
 
     assert fit.mask_interp == pytest.approx([False, True, True, True, True], 1.0e-4)
 
+
 def test__total_points_interp(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
@@ -133,15 +134,19 @@ def test__signal_to_noise_map_interp(imaging_lh, imaging_lh_masked):
     assert np.isnan(fit.signal_to_noise_map_interp[1:5]).all()
 
 
-def test__residual_map(imaging_lh):
+def test__residual_map(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
 
     fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
-    print(fit.residual_map)
+    assert fit.residual_map == pytest.approx(
+        [1.0, -2.54415255, -2.57237275, 0.95433876, 3.16218654], 1.0e-4
+    )
 
-    assert fit.residual_map[0] == pytest.approx(0.5, 1.0e-4)
-    assert np.isnan(fit.residual_map[1])
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
+
+    assert fit.residual_map[0] == pytest.approx(0.0, 1.0e-4)
+    assert np.isnan(fit.noise_map_interp[1:5]).all()
 
 
 def test__log_likelihood(imaging_7x7):

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -56,6 +56,12 @@ def test__noise_map_interp(imaging_7x7):
     assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
     assert fit.noise_map_interp[1] == pytest.approx(2.0, 1.0e-4)
 
+    imaging_7x7 = imaging_7x7.apply_mask(mask=mask)
+
+    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+
+    assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
+    assert np.isnan(fit.noise_map_interp[1])
 
 #
 # def test__total_points_interp(imaging_7x7):

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -21,6 +21,35 @@ def test__noise_map_interp(imaging_7x7):
     assert fit.noise_map_interp[0] == pytest.approx(2.0, 1.0e-4)
     assert fit.noise_map_interp[1] == pytest.approx(2.0, 1.0e-4)
 
+def test__total_points_interp(imaging_7x7):
+
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
+
+    assert fit.total_points_interp == 6
+
+    mask = np.array(
+        [
+            [True, True, True, True, True, True, True],
+            [True, True, True, True, True, True, True],
+            [True, True, True, True, True, True, True],
+            [True, True, False, False, False, True, True],
+            [True, True, False, False, False, True, True],
+            [True, True, True, True, True, True, True],
+            [True, True, True, True, True, True, True],
+        ]
+    )
+
+    mask = ag.Mask2D(mask=mask, pixel_scales=(1.0, 1.0))
+
+    imaging = imaging_7x7.apply_mask(mask=mask)
+
+    fit = ag.FitEllipse(dataset=imaging, ellipse=ellipse_0)
+
+    assert fit.total_points_interp == 4
+
+
 
 def test__log_likelihood(imaging_7x7):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -178,6 +178,20 @@ def test__chi_squared_map(imaging_lh, imaging_lh_masked):
     assert fit.chi_squared_map[0] == pytest.approx(0.0, 1.0e-4)
     assert np.isnan(fit.noise_map_interp[1:5]).all()
 
+def test__chi_squared(imaging_lh, imaging_lh_masked):
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
+
+    assert fit.chi_squared == pytest.approx(
+        sum([0.25, 1.61817806, 1.65427539, 0.22769062, 2.49985593]), 1.0e-4
+    )
+
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
+
+    assert fit.chi_squared == pytest.approx(0.0, 1.0e-4)
+
+
 
 def test__log_likelihood(imaging_7x7):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -9,9 +9,23 @@ def make_imaging_lh(imaging_7x7):
 
     data = ag.Array2D.ones(shape_native=(7, 7), pixel_scales=(1.0, 1.0))
 
-    data[16] = 3.0
-    data[17] = 3.0
+    data[16] = 1.0
+    data[17] = 2.0
     data[18] = 3.0
+    data[23] = 4.0
+    data[24] = 5.0
+    data[25] = 6.0
+    data[30] = 7.0
+    data[31] = 8.0
+    data[32] = 9.0
+
+    return ag.Imaging(
+        data=data,
+        noise_map=imaging_7x7.noise_map,
+    )
+
+@pytest.fixture(name="imaging_lh_masked")
+def make_imaging_lh_masked(imaging_lh):
 
     mask = ag.Mask2D(
         mask=[
@@ -26,15 +40,7 @@ def make_imaging_lh(imaging_7x7):
         pixel_scales=1.0,
     )
 
-    imaging_lh = ag.Imaging(
-        data=data,
-        noise_map=imaging_7x7.noise_map,
-    )
-
-    imaging_lh = imaging_lh.apply_mask(mask=mask)
-
-    return imaging_lh
-
+    return imaging_lh.apply_mask(mask=mask)
 
 
 def test__mask_interp(imaging_7x7, imaging_lh):
@@ -51,18 +57,19 @@ def test__mask_interp(imaging_7x7, imaging_lh):
     assert fit.mask_interp[1] == pytest.approx(True, 1.0e-4)
 
 
-def test__data_interp(imaging_7x7, imaging_lh):
+def test__data_interp(imaging_lh, imaging_lh_masked):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
-
-    fit = ag.FitEllipse(dataset=imaging_7x7, ellipse=ellipse_0)
-
-    assert fit.data_interp[0] == pytest.approx(1.0, 1.0e-4)
-    assert fit.data_interp[1] == pytest.approx(1.0, 1.0e-4)
 
     fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
-    assert fit.data_interp[0] == pytest.approx(1.0, 1.0e-4)
-    assert np.isnan(fit.data_interp[1])
+    assert fit.data_interp == pytest.approx([6., 2.45584745, 2.42762725, 5.95433876, 8.16218654, 6.], 1.0e-4)
+
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
+
+    assert fit.data_interp[0] == pytest.approx(6.0, 1.0e-4)
+    assert fit.data_interp[5] == pytest.approx(6.0, 1.0e-4)
+    assert np.isnan(fit.data_interp[1:5]).all()
+
 
 def test__noise_map_interp(imaging_7x7, imaging_lh):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
@@ -102,6 +109,17 @@ def test__total_points_interp(imaging_7x7, imaging_lh):
     fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
     assert fit.total_points_interp == 2
+
+
+def test__residual_map(imaging_lh):
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
+
+    print(fit.residual_map)
+
+    assert fit.residual_map[0] == pytest.approx(0.5, 1.0e-4)
+    assert np.isnan(fit.residual_map[1])
 
 
 def test__log_likelihood(imaging_7x7):

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -192,6 +192,19 @@ def test__chi_squared(imaging_lh, imaging_lh_masked):
     assert fit.chi_squared == pytest.approx(0.0, 1.0e-4)
 
 
+def test__noise_normalization(imaging_lh, imaging_lh_masked):
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
+
+    assert fit.noise_normalization == pytest.approx(
+        16.120857137, 1.0e-4
+    )
+
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
+
+    assert fit.noise_normalization == pytest.approx(3.224171427, 1.0e-4)
+
 
 def test__log_likelihood(imaging_7x7):
     ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.5, 0.5), major_axis=1.0)

--- a/test_autogalaxy/ellipse/test_fit_ellipse.py
+++ b/test_autogalaxy/ellipse/test_fit_ellipse.py
@@ -155,12 +155,27 @@ def test__normalized_residual_map(imaging_lh, imaging_lh_masked):
     fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
 
     assert fit.normalized_residual_map == pytest.approx(
-        [ 0.5       , -1.27207628, -1.28618638,  0.47716938,  1.58109327], 1.0e-4
+        [0.5, -1.27207628, -1.28618638, 0.47716938, 1.58109327], 1.0e-4
     )
 
     fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
 
     assert fit.normalized_residual_map[0] == pytest.approx(0.0, 1.0e-4)
+    assert np.isnan(fit.noise_map_interp[1:5]).all()
+
+
+def test__chi_squared_map(imaging_lh, imaging_lh_masked):
+    ellipse_0 = ag.Ellipse(centre=(0.0, 0.0), ell_comps=(0.0, 0.0), major_axis=1.0)
+
+    fit = ag.FitEllipse(dataset=imaging_lh, ellipse=ellipse_0)
+
+    assert fit.chi_squared_map == pytest.approx(
+        [0.25, 1.61817806, 1.65427539, 0.22769062, 2.49985593], 1.0e-4
+    )
+
+    fit = ag.FitEllipse(dataset=imaging_lh_masked, ellipse=ellipse_0)
+
+    assert fit.chi_squared_map[0] == pytest.approx(0.0, 1.0e-4)
     assert np.isnan(fit.noise_map_interp[1:5]).all()
 
 


### PR DESCRIPTION
This pull request ensures that masking works for ellipse fitting correctly.

Previously, if a pixel evaluated for ellipse fitting computed one or more values for a neighboring pixel that was masked (and therefore has a value we distrust), it was still included in the likelihood calculation.

This PR ensures this behaviour no longer occurs and that any such pixel is omitted for all calculations.