### PR TITLE
Calculate critical curves using JAX

### DIFF
--- a/autogalaxy/profiles/geometry_profiles.py
+++ b/autogalaxy/profiles/geometry_profiles.py
@@ -4,8 +4,10 @@ from typing import Optional, Tuple, Type
 
 if os.environ.get("USE_JAX", "0") == "1":
     import jax.numpy as np
+    use_jax = True
 else:
     import numpy as np
+    use_jax = False
 
 import autoarray as aa
 
@@ -129,7 +131,10 @@ class SphProfile(GeometryProfile):
         radius
             The circular radius of each coordinate from the profile center.
         """
-        grid_angles = np.arctan2(grid[:, 0], grid[:, 1])
+        if use_jax:
+            grid_angles = np.arctan2(grid.array[:, 0], grid.array[:, 1])
+        else:
+            grid_angles = np.arctan2(grid[:, 0], grid[:, 1])
         cos_theta, sin_theta = self.angle_to_profile_grid_from(grid_angles=grid_angles)
         return np.multiply(radius[:, None], np.vstack((sin_theta, cos_theta)).T)
 
@@ -145,7 +150,10 @@ class SphProfile(GeometryProfile):
         grid
             The (y, x) coordinates in the original reference frame of the grid.
         """
-        return np.subtract(grid, self.centre)
+        if use_jax:
+            return np.subtract(grid.array, np.array(self.centre))
+        else:
+            return np.subtract(grid, self.centre)
 
     @aa.grid_dec.to_grid
     def transformed_from_reference_frame_grid_from(self, grid, **kwargs):

--- a/autogalaxy/profiles/light/standard/gaussian.py
+++ b/autogalaxy/profiles/light/standard/gaussian.py
@@ -1,4 +1,5 @@
-import numpy as np
+# import numpy as np
+from autofit.jax_wrapper import numpy as np, use_jax
 from typing import Optional, Tuple
 
 import autoarray as aa
@@ -59,15 +60,26 @@ class Gaussian(LightProfile):
         grid_radii
             The radial distances from the centre of the profile, for each coordinate on the grid.
         """
-        return np.multiply(
-            self._intensity,
-            np.exp(
-                -0.5
-                * np.square(
-                    np.divide(grid_radii, self.sigma / np.sqrt(self.axis_ratio))
-                )
-            ),
-        )
+        if use_jax:
+            return np.multiply(
+                self._intensity,
+                np.exp(
+                    -0.5
+                    * np.square(
+                        np.divide(grid_radii.array, self.sigma / np.sqrt(self.axis_ratio))
+                    )
+                ),
+            )
+        else:
+            return np.multiply(
+                self._intensity,
+                np.exp(
+                    -0.5
+                    * np.square(
+                        np.divide(grid_radii, self.sigma / np.sqrt(self.axis_ratio))
+                    )
+                ),
+            )
 
     @aa.over_sample
     @aa.grid_dec.to_array

--- a/autogalaxy/profiles/mass/stellar/gaussian.py
+++ b/autogalaxy/profiles/mass/stellar/gaussian.py
@@ -1,5 +1,8 @@
 import copy
 import numpy as np
+from autofit.jax_wrapper import use_jax
+if use_jax:
+    import jax
 from scipy.special import wofz
 from scipy.integrate import quad
 from typing import Tuple
@@ -188,7 +191,14 @@ class Gaussian(MassProfile, StellarProfile):
     @property
     def axis_ratio(self):
         axis_ratio = super().axis_ratio
-        return axis_ratio if axis_ratio < 0.9999 else 0.9999
+        if use_jax:
+            return jax.lax.select(
+                axis_ratio < 0.9999,
+                axis_ratio,
+                0.9999
+            )
+        else:
+            return axis_ratio if axis_ratio < 0.9999 else 0.9999
 
     def zeta_from(self, grid: aa.type.Grid2DLike):
         q2 = self.axis_ratio**2.0


### PR DESCRIPTION
This overhauls the current critical curve method from a grid search to an application of Newton's method for zero finding.

The steps are as follows:

1) Create a set of `n_points` initial points in a circle of radius `init_r` and centred on `init_centre`

2) Apply `n_steps` of Newton's method to these points in the "radial" direction only (i.e. keeping the angle fixed).  Jax's auto differentiation is used to find the radial derivatives of the eigenvalue function for this step.

3) Filter the results and only keep points that have their eigenvalue `threshold` of 0. This step is needed because Newton's method will fail when the radial derivative is equal to zero (i.e. near a max or min of the eigenvalue).

No underlying grid is needed for this method, but the quality of the results are dependent on the initial circle of points.  For best results, the circle should be drawn around *each* max/min of the eigenvalue function. This is typically the centre of each mass in the profile.