### PR TITLE
Multipole Fix

### DIFF
--- a/autogalaxy/profiles/mass/total/power_law_multipole.py
+++ b/autogalaxy/profiles/mass/total/power_law_multipole.py
@@ -178,7 +178,7 @@ class PowerLawMultipole(MassProfile):
 
         a_angle = (
             (
-                self.m**2.0
+                self.m
                 * self.einstein_radius ** (self.slope - 1.0)
                 * radial_grid ** (2.0 - self.slope)
             )

--- a/test_autogalaxy/profiles/mass/total/test_power_law_multipole.py
+++ b/test_autogalaxy/profiles/mass/total/test_power_law_multipole.py
@@ -16,8 +16,8 @@ def test__deflections_yx_2d_from():
 
     deflections = mp.deflections_yx_2d_from(grid=ag.Grid2DIrregular([[1.0, 0.0]]))
 
-    assert deflections[0, 0] == pytest.approx(-0.072229375535, 1e-3)
-    assert deflections[0, 1] == pytest.approx(-0.2089041286, 1e-3)
+    assert deflections[0, 0] == pytest.approx(-0.036501212434, 1e-3)
+    assert deflections[0, 1] == pytest.approx(-0.04812739471, 1e-3)
 
     mp = ag.mp.PowerLawMultipole(
         m=4,
@@ -29,8 +29,8 @@ def test__deflections_yx_2d_from():
 
     deflections = mp.deflections_yx_2d_from(grid=ag.Grid2DIrregular([[1.0, 0.0]]))
 
-    assert deflections[0, 0] == pytest.approx(-0.2532106, 1e-3)
-    assert deflections[0, 1] == pytest.approx(-0.5514646, 1e-3)
+    assert deflections[0, 0] == pytest.approx(-0.093819734, 1e-3)
+    assert deflections[0, 1] == pytest.approx(-0.12642225085, 1e-3)
 
 
 def test__convergence_2d_from():


### PR DESCRIPTION
Fix to multipole implementation where:

```
        a_angle = (
            (
                self.m # NOTE: THIS WAS PREVIOUS SQUARED WHEN IT SHOULDNT BE
                * self.einstein_radius ** (self.slope - 1.0)
                * radial_grid ** (2.0 - self.slope)
            )
            / (self.m**2.0 - (3.0 - self.slope))
            * self.k_m
            * np.sin(self.m * (polar_angle_grid - self.angle_m))
        )
```