### PR TITLE
Feature/disable noise

### DIFF
--- a/autogalaxy/imaging/simulator.py
+++ b/autogalaxy/imaging/simulator.py
@@ -12,19 +12,28 @@ class SimulatorImaging(aa.SimulatorImaging):
         self, galaxies: List[Galaxy], grid: aa.type.Grid2DLike
     ) -> aa.Imaging:
         """
-        Simulate an `Imaging` dataset from an input plane and grid.
+        Simulate an `Imaging` dataset from an input list of `Galaxy` objects and a 2D grid of (y,x) coordinates.
 
-        The planbe is used to generate the image of the galaxies which is simulated.
+        The light profiles of each galaxy are used to generate the image of the galaxies which is simulated.
 
         The steps of the `SimulatorImaging` simulation process (e.g. PSF convolution, noise addition) are
-        described in the `SimulatorImaging` `__init__` method docstring.
+        described in the `SimulatorImaging` `__init__` method docstring, found in the PyAutoArray project.
+
+        If one of more galaxy light profiles are a `LightProfileSNR` object, the `intensity` of the light profile is
+        automatically set such that the signal-to-noise ratio of the light profile is equal to its input
+        `signal_to_noise_ratio` value.
+
+        For example, if a `LightProfileSNR` object has a `signal_to_noise_ratio` of 5.0, the intensity of the light
+        profile is set such that the peak surface brightness of the profile is 5.0 times the background noise level of
+        the image.
 
         Parameters
         ----------
         galaxies
             The galaxies whose light is simulated.
         grid
-            The image-plane grid which the image of the strong lens is generated on.
+            The 2D grid of (y,x) coordinates which the light profiles of the galaxies are evaluated using in order
+            to generate the image of the galaxies.
         """
 
         galaxies = Galaxies(galaxies=galaxies)

--- a/autogalaxy/imaging/simulator.py
+++ b/autogalaxy/imaging/simulator.py
@@ -30,7 +30,8 @@ class SimulatorImaging(aa.SimulatorImaging):
         Parameters
         ----------
         galaxies
-            The galaxies whose light is simulated.
+            The galaxies whose light profiles are evaluated using the input 2D grid of (y,x) coordinates in order to
+            generate the image of the galaxies which is then simulated.
         grid
             The 2D grid of (y,x) coordinates which the light profiles of the galaxies are evaluated using in order
             to generate the image of the galaxies.

--- a/autogalaxy/interferometer/simulator.py
+++ b/autogalaxy/interferometer/simulator.py
@@ -22,7 +22,7 @@ class SimulatorInterferometer(aa.SimulatorInterferometer):
             An arrays representing the effective exposure time of each pixel.
         psf: PSF
             An arrays describing the PSF the simulated image is blurred with.
-        add_poisson_noise: Bool
+        add_poisson_noise_to_data: Bool
             If `True` poisson noise_maps is simulated and added to the image, based on the total counts in each image
             pixel
         noise_seed: int

--- a/docs/overview/overview_1_start_here.rst
+++ b/docs/overview/overview_1_start_here.rst
@@ -268,7 +268,7 @@ object.
         exposure_time=300.0,
         background_sky_level=1.0,
         psf=ag.Kernel2D.from_gaussian(shape_native=(11, 11), sigma=0.1, pixel_scales=0.05),
-        add_poisson_noise=True,
+        add_poisson_noise_to_data=True,
     )
 
 

--- a/test_autogalaxy/imaging/test_simulate_and_fit_imaging.py
+++ b/test_autogalaxy/imaging/test_simulate_and_fit_imaging.py
@@ -23,7 +23,7 @@ def test__perfect_fit__chi_squared_0():
     )
 
     simulator = ag.SimulatorImaging(
-        exposure_time=300.0, psf=psf, add_poisson_noise=False
+        exposure_time=300.0, psf=psf, add_poisson_noise_to_data=False
     )
 
     dataset = simulator.via_galaxies_from(galaxies=[galaxy_0, galaxy_1], grid=grid)
@@ -146,7 +146,7 @@ def test__simulate_imaging_data_and_fit__linear_light_profiles_agree_with_standa
     )
 
     simulator = ag.SimulatorImaging(
-        exposure_time=300.0, psf=psf, add_poisson_noise=False
+        exposure_time=300.0, psf=psf, add_poisson_noise_to_data=False
     )
 
     dataset = simulator.via_galaxies_from(galaxies=[galaxy], grid=grid)

--- a/test_autogalaxy/imaging/test_simulator.py
+++ b/test_autogalaxy/imaging/test_simulator.py
@@ -85,7 +85,7 @@ def test__simulator__via_galaxies_from():
         psf=psf,
         exposure_time=10000.0,
         background_sky_level=100.0,
-        add_poisson_noise=False,
+        add_poisson_noise_to_data=False,
     )
 
     dataset = simulator.via_galaxies_from(galaxies=[galaxy_0, galaxy_1], grid=grid)
@@ -130,7 +130,7 @@ def test__simulator__simulate_imaging_from_galaxy__source_galaxy__compare_to_ima
         psf=psf,
         exposure_time=10000.0,
         background_sky_level=100.0,
-        add_poisson_noise=True,
+        add_poisson_noise_to_data=True,
         noise_seed=1,
     )
 

--- a/test_autogalaxy/imaging/test_simulator.py
+++ b/test_autogalaxy/imaging/test_simulator.py
@@ -86,6 +86,7 @@ def test__simulator__via_galaxies_from():
         exposure_time=10000.0,
         background_sky_level=100.0,
         add_poisson_noise_to_data=False,
+        include_poisson_noise_in_noise_map=False,
     )
 
     dataset = simulator.via_galaxies_from(galaxies=[galaxy_0, galaxy_1], grid=grid)


### PR DESCRIPTION
More customization of the `SimulatorImaging` object so that the `data` can be simulated without Poisson noise but the `noise_map` still include values as if it were included, and visa versa.