### PR TITLE
Feature/jax interferometer

### DIFF
--- a/autogalaxy/operate/image.py
+++ b/autogalaxy/operate/image.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
+import jax
 import jax.numpy as jnp
-import numpy as np
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 from autoarray import Array2D
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
 
 import autoarray as aa
 
-from autogalaxy import exc
 
 
 class OperateImage:
@@ -189,12 +188,14 @@ class OperateImage:
 
         image_2d = self.image_2d_from(grid=grid)
 
-        if not jnp.any(image_2d.array):
-            return aa.Visibilities.zeros(
+        return jax.lax.cond(
+            jnp.any(image_2d.array),
+            lambda _: transformer.visibilities_from(image=image_2d),
+            lambda _: aa.Visibilities.zeros(
                 shape_slim=(transformer.uv_wavelengths.shape[0],)
-            )
-
-        return transformer.visibilities_from(image=image_2d)
+            ),
+            operand=None
+        )
 
 
 class OperateImageList(OperateImage):

--- a/autogalaxy/operate/image.py
+++ b/autogalaxy/operate/image.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
 import autoarray as aa
 
 
-
 class OperateImage:
     """
     Packages methods which operate on the 2D image returned from the `image_2d_from` function of a light object
@@ -194,7 +193,7 @@ class OperateImage:
             lambda _: aa.Visibilities.zeros(
                 shape_slim=(transformer.uv_wavelengths.shape[0],)
             ),
-            operand=None
+            operand=None,
         )
 
 


### PR DESCRIPTION
Full conversion of `TransformerDFT` object to support JAX likelihood evaluation (`jit` and `grad`) for simple light profiles.

Linear light profiles are next!