### PR TITLE
Drop Python 3.9-3.11, add 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, '3.10', '3.11', '3.12']
+        python-version: ['3.12', '3.13']
     steps:
     - name: Checkout PyAutoConf
       uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description="Open-Source Multi Wavelength Galaxy Structure & Morphology"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 authors = [
     { name = "James Nightingale", email = "James.Nightingale@newcastle.ac.uk" },
     { name = "Richard Hayes", email = "richard@rghsoftware.co.uk" },
@@ -18,10 +18,8 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
   "Natural Language :: English",
   "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12"
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13"
 ]
 keywords = ["cli"]
 dependencies = [


### PR DESCRIPTION
## Summary
- CI matrix updated from `[3.9, 3.10, 3.11, 3.12]` to `[3.12, 3.13]`
- `requires-python` changed from `>=3.9` to `>=3.12`
- PyPI classifiers updated to 3.12 + 3.13

Python 3.9 EOL since Oct 2025. Standardizing on 3.12 + 3.13 across all repos.

## Test plan
- [ ] CI passes on both 3.12 and 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)