### PR TITLE
Expose dataset_util via autogalaxy.util.dataset

### DIFF
--- a/autogalaxy/util/__init__.py
+++ b/autogalaxy/util/__init__.py
@@ -19,6 +19,7 @@ from autoarray.inversion.inversion.interferometer import (
 )
 from autoarray.operators import transformer_util as transformer
 from autoarray.util import misc_util as misc
+from autoarray.util import dataset_util as dataset
 
 from autogalaxy.util import error_util as error
 from autogalaxy.analysis import chaining_util as chaining


### PR DESCRIPTION
## Summary
Re-exports `autoarray.util.dataset_util` as `ag.util.dataset` so downstream packages and workspaces can access `should_simulate()` through the autogalaxy namespace.

## API Changes
None — internal re-export only.

## Test Plan
- [x] PyAutoGalaxy unit tests pass (811 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)