### PR TITLE
fix: re-export subplot_interferometer_dataset from autogalaxy.plot

### DIFF
--- a/autogalaxy/plot/__init__.py
+++ b/autogalaxy/plot/__init__.py
@@ -14,6 +14,7 @@ from autoarray.dataset.plot.imaging_plots import (
     fits_imaging,
 )
 from autoarray.dataset.plot.interferometer_plots import (
+    subplot_interferometer_dataset,
     subplot_interferometer_dirty_images,
     fits_interferometer,
 )


### PR DESCRIPTION
## Summary
- The `subplot_interferometer_dataset` helper exists in `autoarray.plot` and is already re-exported by `autolens.plot`, but was missing from `autogalaxy.plot` alongside `subplot_interferometer_dirty_images`.
- One-line import addition brings autogalaxy.plot in line with autolens.plot.

## Test plan
- [x] `autogalaxy_workspace/scripts/interferometer/fit.py` now executes past line 101 (`aplt.subplot_interferometer_dataset(dataset=dataset)`) without AttributeError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)