### PR TITLE
Retire main_build: check out PyAutoFit main in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: rhayes777/PyAutoFit
-        ref: main_build
         path: PyAutoFit
     - name: Checkout PyAutoArray
       uses: actions/checkout@v2
@@ -53,11 +52,6 @@ jobs:
         export BRANCH="${{ steps.extract_branch.outputs.branch }}"
         for PACKAGE in ${PACKAGES[@]}; do
           pushd $PACKAGE
-          if [[ "$PACKAGE" == "PyAutoFit" && "$BRANCH" == "main" ]]; then
-            echo "Skipping branch override for PyAutoFit (keeping main_build)"
-            popd
-            continue
-          fi
           export existed_in_remote=$(git ls-remote --heads origin ${BRANCH})
           if [[ -z ${existed_in_remote} ]]; then
             echo "Branch $BRANCH did not exist in $PACKAGE"


### PR DESCRIPTION
## Summary
- PyAutoFit's \`main_build\` branch has been retired — \`origin/main\` now tracks the same tip.
- Drop \`ref: main_build\` from the PyAutoFit checkout step so it uses the default branch (\`main\`) like every other dependency.
- Remove the \`Skipping branch override for PyAutoFit (keeping main_build)\` special-case block in the "Change to same branch if exists in deps" step, so PyAutoFit now participates in normal branch-matching logic.

## Test plan
- [ ] CI on this PR passes with PyAutoFit checked out from \`main\`.
- [ ] Push a test branch that exists in both PyAutoGalaxy and PyAutoFit and confirm the branch-override logic picks it up in PyAutoFit.

Generated with [Claude Code](https://claude.com/claude-code)