### PR TITLE
refactor: rename env vars to PYAUTO_* prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,10 +41,10 @@ black autogalaxy/
 
 ### Plot Output Mode
 
-Set `PYAUTOARRAY_OUTPUT_MODE=1` to capture every figure produced by a script into numbered PNG files in `./output_mode/<script_name>/`. This is useful for visually inspecting all plots from an integration test without needing a display.
+Set `PYAUTO_OUTPUT_MODE=1` to capture every figure produced by a script into numbered PNG files in `./output_mode/<script_name>/`. This is useful for visually inspecting all plots from an integration test without needing a display.
 
 ```bash
-PYAUTOARRAY_OUTPUT_MODE=1 python scripts/my_script.py
+PYAUTO_OUTPUT_MODE=1 python scripts/my_script.py
 # -> ./output_mode/my_script/0_fit.png, 1_tracer.png, ...
 ```
 

--- a/autogalaxy/analysis/model_util.py
+++ b/autogalaxy/analysis/model_util.py
@@ -90,7 +90,7 @@ def mge_model_from(
 
     import os
 
-    if os.environ.get("PYAUTO_WORKSPACE_SMALL_DATASETS") == "1":
+    if os.environ.get("PYAUTO_SMALL_DATASETS") == "1":
         total_gaussians = 2
         gaussian_per_basis = 1
 

--- a/autogalaxy/quantity/model/visualizer.py
+++ b/autogalaxy/quantity/model/visualizer.py
@@ -1,7 +1,7 @@
 import os
 
 import autofit as af
-from autoconf.test_mode import is_test_mode
+from autoconf.test_mode import skip_visualization
 
 from autogalaxy.quantity.model.plotter import PlotterQuantity
 
@@ -66,7 +66,7 @@ class VisualizerQuantity(af.Visualizer):
             via a non-linear search).
         """
 
-        if is_test_mode():
+        if skip_visualization():
             return
 
         fit = analysis.fit_quantity_for_instance(instance=instance)


### PR DESCRIPTION
## Summary
Rename `PYAUTO_WORKSPACE_SMALL_DATASETS` → `PYAUTO_SMALL_DATASETS` and switch quantity visualizer from `is_test_mode()` to `skip_visualization()`.

Depends on: rhayes777/PyAutoConf#86, Jammy2211/PyAutoArray#265

## API Changes
One env var rename. Quantity visualizer now controlled by `PYAUTO_SKIP_VISUALIZATION` instead of `PYAUTOFIT_TEST_MODE`. See full details below.

## Test Plan
- [x] All 822 PyAutoGalaxy tests pass
- [x] CLAUDE.md documentation updated

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed Behaviour
- `PYAUTO_WORKSPACE_SMALL_DATASETS` renamed to `PYAUTO_SMALL_DATASETS` (model_util.py)
- `VisualizerQuantity.visualize()` now checks `skip_visualization()` instead of `is_test_mode()`

### Migration
- Before: `PYAUTO_WORKSPACE_SMALL_DATASETS=1` → After: `PYAUTO_SMALL_DATASETS=1`

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)