### PR TITLE
build: raise astropy cap, update JAX Partial imports for 0.5+ compat

### DIFF
--- a/autogalaxy/operate/lens_calc.py
+++ b/autogalaxy/operate/lens_calc.py
@@ -983,7 +983,10 @@ class LensCalc:
         """
         import jax
         import jax.numpy as jnp
-        from jax.tree_util import Partial
+        try:
+            from jax.tree_util import Partial
+        except ImportError:
+            from functools import partial as Partial
 
         # Capture as local names so the closure holds no `self` reference.
         # ZeroSolver.zero_contour_finder is jit-compiled with `f` as a

--- a/autogalaxy/profiles/mass/total/jax_utils.py
+++ b/autogalaxy/profiles/mass/total/jax_utils.py
@@ -32,7 +32,7 @@ def omega(eiphi, slope, factor, n_terms=20, xp=np):
         be sufficient most of the time)
     """
 
-    from jax.tree_util import Partial as partial
+    from functools import partial
     import jax
 
     scan = jax.jit(jax.lax.scan, static_argnames=("length", "reverse", "unroll"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "autofit",
     "autoarray",
     "colossus==1.3.1",
-    "astropy>=5.0,<=6.1.2",
+    "astropy>=5.0,<=7.2.0",
     "nautilus-sampler==1.0.5"
 ]
 


### PR DESCRIPTION
## Summary
Raise astropy cap from <=6.1.2 to <=7.2.0. Replace deprecated `jax.tree_util.Partial` with `functools.partial` in `jax_utils.py`, and add fallback import in `lens_calc.py` for forward compatibility with JAX 0.5+.

Part of cross-ecosystem dependency sweep (PyAutoLabs/PyAutoConf#87).

## API Changes
None — internal changes only.

## Test Plan
- [x] PyAutoGalaxy unit tests pass (822/822)
- [x] Full stack tests pass (3,070 across 5 repos)
- [x] CI green

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Changed (internal only)
- `autogalaxy.profiles.mass.total.jax_utils.omega()` — uses `functools.partial` instead of `jax.tree_util.Partial`
- `autogalaxy.operate.lens_calc.LensCalc._make_eigen_fn()` — `Partial` import has fallback to `functools.partial`

No public API impact — internal JAX wiring changes.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)