### PR TITLE
docs: update Python version to 3.12-3.13

### DIFF
--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -17,11 +17,11 @@ First, update conda:
 
 Next, create a conda environment (we name this ``autogalaxy`` to signify it is for the **PyAutoGalaxy** install):
 
-The command below creates this environment with Python 3.11, the most recent supported version of Python:
+The command below creates this environment with Python 3.12:
 
 .. code-block:: bash
 
-    conda create -n autogalaxy python=3.11
+    conda create -n autogalaxy python=3.12
 
 Activate the conda environment (you will have to do this every time you want to run **PyAutoGalaxy**):
 

--- a/docs/installation/overview.rst
+++ b/docs/installation/overview.rst
@@ -3,7 +3,7 @@
 Overview
 ========
 
-**PyAutoGalaxy** requires Python 3.9 - 3.12 and support the Linux, MacOS and Windows operating systems.
+**PyAutoGalaxy** requires Python 3.12 - 3.13 and supports the Linux, MacOS and Windows operating systems.
 
 **PyAutoGalaxy** can be installed via the Python distribution `Anaconda <https://www.anaconda.com/>`_ or using
 `PyPI <https://pypi.org/>`_ to ``pip install autogalaxy`` into your Python distribution.


### PR DESCRIPTION
## Summary
Update installation docs to reflect Python 3.12-3.13 support (was 3.9-3.12). Also updates conda environment example from python=3.11 to python=3.12.

## API Changes
None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)