### PR TITLE
fix: pin autofit/autoarray dependency versions and update homepage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,15 +23,15 @@ classifiers = [
 ]
 keywords = ["cli"]
 dependencies = [
-    "autofit",
-    "autoarray",
+    "autofit==2026.4.13.3",
+    "autoarray==2026.4.13.3",
     "colossus==1.3.1",
     "astropy>=5.0,<=7.2.0",
     "nautilus-sampler==1.0.5"
 ]
 
 [project.urls]
-Homepage = "https://github.com/Jammy2211/PyAutoGalaxy"
+Homepage = "https://github.com/PyAutoLabs/PyAutoGalaxy"
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
## Summary
- Pin `autofit` and `autoarray` to exact versions (`==2026.4.13.3`) so pip cannot resolve to wrong PyPI packages
- Update homepage URL from `Jammy2211/PyAutoGalaxy` to `PyAutoLabs/PyAutoGalaxy`
- The release workflow will auto-update the pinned versions via sed

## Test plan
- [ ] `pip install` resolves `autofit` and `autoarray` to the correct PyAuto packages
- [ ] Release workflow sed pattern matches and updates both pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)