### PR TITLE
fix: suppress CLI noise from escape sequences and third-party warnings

### DIFF
--- a/autogalaxy/convert.py
+++ b/autogalaxy/convert.py
@@ -277,7 +277,7 @@ def shear_angle_from(gamma_1: float, gamma_2: float, xp=np) -> float:
 def multipole_k_m_and_phi_m_from(
     multipole_comps: Tuple[float, float], m: int, xp=np
 ) -> Tuple[float, float]:
-    """
+    r"""
     Returns the multipole normalization value `k_m` and angle `phi` from the multipole component parameters.
 
     The normalization and angle are given by:
@@ -333,7 +333,7 @@ def multipole_k_m_phi_m_and_shape_angle_from(
         ellipse_angle: Optional[float],
         xp=np
 ) -> Tuple[float, float, float]:
-    """
+    r"""
     Returns the multipole normalization value `k_m`, angle `phi` and shape_angle `s` from the multipole
     component parameters. The shape angle is the difference between the angle of the underlying elliptical profile and
     the multipole `phi_m` and is what defines the shape of the perturbation around the ellipse oriented towards the
@@ -404,7 +404,7 @@ def multipole_comps_from(
     shape_angle: Optional[float]=None, ellipse_angle: Optional[float]=None,
     xp=np
 ) -> Tuple[float, float]:
-    """
+    r"""
     Returns the multipole component parameters from their normalization value `k_m` and angle `phi`.
 
     .. math::

--- a/autogalaxy/ellipse/ellipse/ellipse.py
+++ b/autogalaxy/ellipse/ellipse/ellipse.py
@@ -11,7 +11,7 @@ class Ellipse(EllProfile):
         ell_comps: Tuple[float, float] = (0.0, 0.0),
         major_axis: float = 1.0,
     ):
-        """
+        r"""
         class representing an ellispe, which is used to perform ellipse fitting to 2D data (e.g. an image).
 
         The elliptical components (`ell_comps`) of this profile are used to define the `axis_ratio` (q)

--- a/autogalaxy/ellipse/ellipse/ellipse_multipole.py
+++ b/autogalaxy/ellipse/ellipse/ellipse_multipole.py
@@ -12,7 +12,7 @@ class EllipseMultipole:
         m=4,
         multipole_comps: Tuple[float, float] = (0.0, 0.0),
     ):
-        """
+        r"""
         class representing the multipole of an ellispe with, which is used to perform ellipse fitting to
         2D data (e.g. an image).
 
@@ -122,7 +122,7 @@ class EllipseMultipoleScaled(EllipseMultipole):
         scaled_multipole_comps: Tuple[float, float] = (0.0, 0.0),
         major_axis=1.0,
     ):
-        """
+        r"""
         class representing the multipole of an ellipse, which is used to perform ellipse fitting to
         2D data (e.g. an image). This multipole is fit with its strength held relative to an ellipse with a
         major_axis of 1, allowing for a set of ellipse multipoles to be fit at different major axes but with

--- a/autogalaxy/profiles/geometry_profiles.py
+++ b/autogalaxy/profiles/geometry_profiles.py
@@ -189,7 +189,7 @@ class EllProfile(SphProfile):
         centre: Tuple[float, float] = (0.0, 0.0),
         ell_comps: Tuple[float, float] = (0.0, 0.0),
     ):
-        """
+        r"""
         An elliptical profile, which describes the geometry of profiles defined by an ellipse.
 
         The elliptical components (`ell_comps`) of this profile are used to define the `axis_ratio` (q)

--- a/autogalaxy/profiles/light/standard/gaussian.py
+++ b/autogalaxy/profiles/light/standard/gaussian.py
@@ -17,7 +17,7 @@ class Gaussian(LightProfile):
         intensity: float = 0.1,
         sigma: float = 1.0,
     ):
-        """
+        r"""
         The elliptical Gaussian light profile.
 
         The intensity distribution of the profile is given by:

--- a/autogalaxy/profiles/mass/dark/nfw.py
+++ b/autogalaxy/profiles/mass/dark/nfw.py
@@ -17,7 +17,7 @@ class NFW(gNFW, MassProfileCSE):
         kappa_s: float = 0.05,
         scale_radius: float = 1.0,
     ):
-        """
+        r"""
         The elliptical NFW profiles, used to fit the dark matter halo of the lens.
 
         Parameters
@@ -273,7 +273,7 @@ class NFWSph(NFW):
         kappa_s: float = 0.05,
         scale_radius: float = 1.0,
     ):
-        """
+        r"""
         The spherical NFW profiles, used to fit the dark matter halo of the lens.
 
         Parameters

--- a/autogalaxy/profiles/mass/stellar/gaussian_gradient.py
+++ b/autogalaxy/profiles/mass/stellar/gaussian_gradient.py
@@ -14,7 +14,7 @@ class GaussianGradient(Gaussian):
         mass_to_light_gradient: float = 0.0,
         mass_to_light_radius: float = 1.0,
     ):
-        """
+        r"""
         The elliptical Gaussian light profile with a gradient in its mass to light conversion.
 
         $\Psi (r) = \Psi_{o} \frac{(\sigma + 0.01)}{R_{ref}}^{\Tau}$

--- a/autogalaxy/profiles/mass/total/isothermal.py
+++ b/autogalaxy/profiles/mass/total/isothermal.py
@@ -8,7 +8,7 @@ from autogalaxy.profiles.mass.total.power_law import PowerLaw
 
 
 def psi_from(grid, axis_ratio, core_radius, xp=np):
-    """
+    r"""
     Returns the $\Psi$ term in expressions for the calculation of the deflection of an elliptical isothermal mass
     distribution. This is used in the `Isothermal` and `Chameleon` `MassProfile`'s.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,7 @@ dev = ["pytest", "black"]
 
 [tool.pytest.ini_options]
 testpaths = ["test_autogalaxy"]
+filterwarnings = [
+    "ignore:cuda_plugin_extension:UserWarning",
+    "ignore::DeprecationWarning:jax",
+]


### PR DESCRIPTION
## Summary
Suppress CLI noise during test collection by converting docstrings containing LaTeX math to raw strings across profiles, convert, and ellipse modules. Added pytest warning filters for JAX CUDA plugin and deprecation warnings.

## API Changes
None — internal changes only.

## Test Plan
- [x] All 834 unit tests pass
- [x] `pytest --co` produces zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)