### PR TITLE
refactor: rename aa.grid_dec to aa.decorators

### DIFF
--- a/autogalaxy/galaxy/galaxies.py
+++ b/autogalaxy/galaxy/galaxies.py
@@ -109,7 +109,7 @@ class Galaxies(List, OperateImageGalaxies):
             for galaxy in self
         ]
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def image_2d_from(
         self, grid: aa.type.Grid2DLike, xp=np, operated_only: Optional[bool] = None
     ) -> aa.Array2D:
@@ -175,7 +175,7 @@ class Galaxies(List, OperateImageGalaxies):
 
         return galaxy_image_2d_dict
 
-    @aa.grid_dec.to_vector_yx
+    @aa.decorators.to_vector_yx
     def deflections_yx_2d_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> np.ndarray:
@@ -201,7 +201,7 @@ class Galaxies(List, OperateImageGalaxies):
         """
         return sum(map(lambda g: g.deflections_yx_2d_from(grid=grid, xp=xp), self))
 
-    @aa.grid_dec.to_grid
+    @aa.decorators.to_grid
     def traced_grid_2d_from(
         self, grid: aa.type.Grid2DLike, xp=np
     ) -> aa.type.Grid2DLike:
@@ -210,7 +210,7 @@ class Galaxies(List, OperateImageGalaxies):
         """
         return grid - self.deflections_yx_2d_from(grid=grid, xp=xp)
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def convergence_2d_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> np.ndarray:
@@ -236,7 +236,7 @@ class Galaxies(List, OperateImageGalaxies):
         """
         return sum(map(lambda g: g.convergence_2d_from(grid=grid, xp=xp), self))
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> np.ndarray:

--- a/autogalaxy/galaxy/galaxy.py
+++ b/autogalaxy/galaxy/galaxy.py
@@ -210,7 +210,7 @@ class Galaxy(af.ModelObject, OperateImageList):
             )
         ]
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def image_2d_from(
         self,
         grid: aa.type.Grid2DLike,
@@ -246,7 +246,7 @@ class Galaxy(af.ModelObject, OperateImageList):
             )
         return xp.zeros((grid.shape[0],))
 
-    @aa.grid_dec.to_vector_yx
+    @aa.decorators.to_vector_yx
     def deflections_yx_2d_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> np.ndarray:
@@ -277,7 +277,7 @@ class Galaxy(af.ModelObject, OperateImageList):
 
         return xp.zeros((grid.shape[0], 2))
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def convergence_2d_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> np.ndarray:
@@ -318,7 +318,7 @@ class Galaxy(af.ModelObject, OperateImageList):
         """
         return None
 
-    @aa.grid_dec.to_grid
+    @aa.decorators.to_grid
     def traced_grid_2d_from(
         self, grid: aa.type.Grid2DLike, xp=np
     ) -> aa.type.Grid2DLike:
@@ -355,7 +355,7 @@ class Galaxy(af.ModelObject, OperateImageList):
 
         return grid - self.deflections_yx_2d_from(grid=grid, xp=xp)
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> np.ndarray:

--- a/autogalaxy/galaxy/mock/mock_galaxy.py
+++ b/autogalaxy/galaxy/mock/mock_galaxy.py
@@ -8,18 +8,18 @@ class MockGalaxy:
         self.value = value
         self.shape = shape
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def image_2d_from(self, grid):
         return np.full(shape=self.shape, fill_value=self.value)
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def convergence_2d_from(self, grid):
         return np.full(shape=self.shape, fill_value=self.value)
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid):
         return np.full(shape=self.shape, fill_value=self.value)
 
-    @aa.grid_dec.to_vector_yx
+    @aa.decorators.to_vector_yx
     def deflections_yx_2d_from(self, grid):
         return np.full(shape=(self.shape, 2), fill_value=self.value)

--- a/autogalaxy/profiles/geometry_profiles.py
+++ b/autogalaxy/profiles/geometry_profiles.py
@@ -99,7 +99,7 @@ class SphProfile(GeometryProfile):
     def __init__(self, centre: Tuple[float, float] = (0.0, 0.0)):
         super().__init__(centre=centre)
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def radial_grid_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs) -> np.ndarray:
         """
         Convert a grid of (y, x) coordinates, to their radial distances from the profile
@@ -126,7 +126,7 @@ class SphProfile(GeometryProfile):
         """
         return xp.cos(grid_angles), xp.sin(grid_angles)
 
-    @aa.grid_dec.to_grid
+    @aa.decorators.to_grid
     def _cartesian_grid_via_radial_from(
         self,
         grid: aa.type.Grid2DLike,
@@ -153,7 +153,7 @@ class SphProfile(GeometryProfile):
 
         return xp.multiply(radius[:, None], xp.vstack((sin_theta, cos_theta)).T)
 
-    @aa.grid_dec.to_grid
+    @aa.decorators.to_grid
     def transformed_to_reference_frame_grid_from(self, grid, xp=np, **kwargs):
         """
         Transform a grid of (y,x) coordinates to the reference frame of the profile.
@@ -167,7 +167,7 @@ class SphProfile(GeometryProfile):
         """
         return xp.subtract(grid.array, xp.array(self.centre))
 
-    @aa.grid_dec.to_grid
+    @aa.decorators.to_grid
     def transformed_from_reference_frame_grid_from(self, grid, xp=np, **kwargs):
         """
         Transform a grid of (y,x) coordinates from the reference frame of the profile to the original observer
@@ -282,7 +282,7 @@ class EllProfile(SphProfile):
         theta_coordinate_to_profile = xp.add(grid_angles, -self.angle_radians(xp=xp))
         return xp.cos(theta_coordinate_to_profile), xp.sin(theta_coordinate_to_profile)
 
-    @aa.grid_dec.to_grid
+    @aa.decorators.to_grid
     def rotated_grid_from_reference_frame_from(
         self, grid, xp=np, angle: Optional[float] = None, **kwargs
     ):
@@ -313,7 +313,7 @@ class EllProfile(SphProfile):
             grid_2d=grid, centre=(0.0, 0.0), angle=angle, xp=xp
         )
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def elliptical_radii_grid_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> np.ndarray:
@@ -332,7 +332,7 @@ class EllProfile(SphProfile):
             )
         )
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def eccentric_radii_grid_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> np.ndarray:
@@ -354,7 +354,7 @@ class EllProfile(SphProfile):
 
         return xp.multiply(xp.sqrt(self.axis_ratio(xp)), grid_radii.array)
 
-    @aa.grid_dec.to_grid
+    @aa.decorators.to_grid
     def transformed_to_reference_frame_grid_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> np.ndarray:
@@ -374,7 +374,7 @@ class EllProfile(SphProfile):
             grid_2d=grid.array, centre=self.centre, angle=self.angle(xp), xp=xp
         )
 
-    @aa.grid_dec.to_grid
+    @aa.decorators.to_grid
     def transformed_from_reference_frame_grid_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> aa.type.Grid2DLike:

--- a/autogalaxy/profiles/light/mock/mock_light_profile.py
+++ b/autogalaxy/profiles/light/mock/mock_light_profile.py
@@ -27,7 +27,7 @@ class MockLightProfile(ag.LightProfile):
         self.value = value
         self.value1 = value1
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     @check_operated_only
     def image_2d_from(
         self, grid, xp=np, operated_only: Optional[bool] = None, **kwargs

--- a/autogalaxy/profiles/light/standard/chameleon.py
+++ b/autogalaxy/profiles/light/standard/chameleon.py
@@ -90,9 +90,9 @@ class Chameleon(LightProfile):
         )
 
     @aa.over_sample
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     @check_operated_only
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def image_2d_from(
         self,
         grid: aa.type.Grid2DLike,

--- a/autogalaxy/profiles/light/standard/eff.py
+++ b/autogalaxy/profiles/light/standard/eff.py
@@ -58,9 +58,9 @@ class ElsonFreeFall(LightProfile):
         )
 
     @aa.over_sample
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     @check_operated_only
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def image_2d_from(
         self,
         grid: aa.type.Grid2DLike,

--- a/autogalaxy/profiles/light/standard/gaussian.py
+++ b/autogalaxy/profiles/light/standard/gaussian.py
@@ -72,9 +72,9 @@ class Gaussian(LightProfile):
         )
 
     @aa.over_sample
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     @check_operated_only
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def image_2d_from(
         self,
         grid: aa.type.Grid2DLike,

--- a/autogalaxy/profiles/light/standard/moffat.py
+++ b/autogalaxy/profiles/light/standard/moffat.py
@@ -71,9 +71,9 @@ class Moffat(LightProfile):
         )
 
     @aa.over_sample
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     @check_operated_only
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def image_2d_from(
         self,
         grid: aa.type.Grid2DLike,

--- a/autogalaxy/profiles/light/standard/sersic.py
+++ b/autogalaxy/profiles/light/standard/sersic.py
@@ -164,9 +164,9 @@ class Sersic(AbstractSersic, LightProfile):
         )
 
     @aa.over_sample
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     @check_operated_only
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def image_2d_from(
         self,
         grid: aa.type.Grid2DLike,

--- a/autogalaxy/profiles/light/standard/shapelets/cartesian.py
+++ b/autogalaxy/profiles/light/standard/shapelets/cartesian.py
@@ -87,9 +87,9 @@ class ShapeletCartesian(AbstractShapelet):
         return f"n_y_{self.n_y}_n_x_{self.n_x}"
 
     @aa.over_sample
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     @check_operated_only
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def image_2d_from(
         self,
         grid: aa.type.Grid2DLike,

--- a/autogalaxy/profiles/light/standard/shapelets/exponential.py
+++ b/autogalaxy/profiles/light/standard/shapelets/exponential.py
@@ -60,9 +60,9 @@ class ShapeletExponential(AbstractShapelet):
         return f"n_{self.n}_m_{self.m}"
 
     @aa.over_sample
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     @check_operated_only
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def image_2d_from(
         self,
         grid: aa.type.Grid2DLike,

--- a/autogalaxy/profiles/light/standard/shapelets/polar.py
+++ b/autogalaxy/profiles/light/standard/shapelets/polar.py
@@ -122,9 +122,9 @@ class ShapeletPolar(AbstractShapelet):
         return f"n_{self.n}_m_{self.m}"
 
     @aa.over_sample
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     @check_operated_only
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def image_2d_from(
         self,
         grid: aa.type.Grid2DLike,

--- a/autogalaxy/profiles/mass/abstract/mge.py
+++ b/autogalaxy/profiles/mass/abstract/mge.py
@@ -147,8 +147,8 @@ class MGEDecomposer:
 
         return w
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_2d_via_mge_from(
         self,
         grid: aa.type.Grid2DLike,
@@ -298,8 +298,8 @@ class MGEDecomposer:
         return xp.where(ind_pos_y[None, :], core, xp.conj(core))
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_via_mge_from(
         self,
         grid: aa.type.Grid2DLike,

--- a/autogalaxy/profiles/mass/dark/abstract.py
+++ b/autogalaxy/profiles/mass/dark/abstract.py
@@ -51,8 +51,8 @@ class AbstractgNFW(MassProfile, DarkProfile):
         self.inner_slope = inner_slope
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """Calculate the projected convergence at a given set of arc-second gridded coordinates.
 

--- a/autogalaxy/profiles/mass/dark/cnfw.py
+++ b/autogalaxy/profiles/mass/dark/cnfw.py
@@ -75,7 +75,7 @@ class cNFW(AbstractgNFW):
             * (r.array + self.scale_radius) ** (-2.0)
         )
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Convergence (dimensionless surface mass density) for the cored NFW profile.
@@ -83,7 +83,7 @@ class cNFW(AbstractgNFW):
         """
         return xp.zeros(shape=grid.shape[0])
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Lensing potential for the cored NFW profile.
@@ -122,8 +122,8 @@ class cNFWSph(cNFW):
         self.scale_radius = scale_radius
         self.core_radius = core_radius
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.
@@ -235,7 +235,7 @@ class cNFWSph(cNFW):
 
         return 2 * dev_F
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Convergence (dimensionless surface mass density) for the cored NFW profile.
@@ -243,7 +243,7 @@ class cNFWSph(cNFW):
         """
         return xp.zeros(shape=grid.shape[0])
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Lensing potential for the cored NFW profile.

--- a/autogalaxy/profiles/mass/dark/nfw.py
+++ b/autogalaxy/profiles/mass/dark/nfw.py
@@ -45,8 +45,8 @@ class NFW(gNFW, MassProfileCSE):
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return self.deflections_2d_via_analytic_from(grid=grid, xp=xp, **kwargs)
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_2d_via_analytic_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ):
@@ -105,14 +105,14 @@ class NFW(gNFW, MassProfileCSE):
 
         return xp.multiply(self.scale_radius, xp.vstack((deflection_y, deflection_x)).T)
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_2d_via_cse_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return self._deflections_2d_via_cse_from(grid=grid, **kwargs)
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_via_cse_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the projected 2D convergence from a grid of (y,x) arc second coordinates, by computing and summing
@@ -185,8 +185,8 @@ class NFW(gNFW, MassProfileCSE):
             sample_points=sample_points,
         )
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def shear_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Analytic calculation shear from Heyrovský & Karamazov 2024
@@ -227,8 +227,8 @@ class NFW(gNFW, MassProfileCSE):
 
         return aa.VectorYX2DIrregular(values=shear_field, grid=grid)
 
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Analytic calculation convergence from Heyrovský & Karamazov 2024
@@ -298,8 +298,8 @@ class NFWSph(NFW):
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return self.deflections_2d_via_analytic_from(grid=grid, xp=xp, **kwargs)
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_2d_via_analytic_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ):
@@ -331,8 +331,8 @@ class NFWSph(NFW):
         return xp.real(self.coord_func_h(grid_radius=grid_radius, xp=xp))
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the potential at a given set of arc-second gridded coordinates.

--- a/autogalaxy/profiles/mass/dark/nfw_truncated.py
+++ b/autogalaxy/profiles/mass/dark/nfw_truncated.py
@@ -26,8 +26,8 @@ class NFWTruncatedSph(AbstractgNFW):
         self.truncation_radius = truncation_radius
         self.tau = self.truncation_radius / self.scale_radius
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles at a given set of arc-second gridded coordinates.
@@ -62,7 +62,7 @@ class NFWTruncatedSph(AbstractgNFW):
             2.0 * self.kappa_s * self.coord_func_l(grid_radius=grid_radius.array, xp=xp)
         )
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return xp.zeros(shape=grid.shape[0])
 

--- a/autogalaxy/profiles/mass/point/point.py
+++ b/autogalaxy/profiles/mass/point/point.py
@@ -34,12 +34,12 @@ class PointMass(MassProfile):
         #    convergence[central_pixel] = np.pi * self.einstein_radius ** 2.0
         return convergence
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return np.zeros(shape=grid.shape[0])
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         grid_radii = self.radial_grid_from(grid=grid, xp=xp, **kwargs)
         return self._cartesian_grid_via_radial_from(

--- a/autogalaxy/profiles/mass/sheets/external_shear.py
+++ b/autogalaxy/profiles/mass/sheets/external_shear.py
@@ -40,11 +40,11 @@ class ExternalShear(MassProfile):
     def average_convergence_of_1_radius(self):
         return 0.0
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return xp.zeros(shape=grid.shape[0])
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         shear_angle = (
             self.angle(xp) - 90
@@ -56,8 +56,8 @@ class ExternalShear(MassProfile):
 
         return -0.5 * shear_amp * rcoord**2 * xp.cos(2 * (phicoord - phig))
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles at a given set of arc-second gridded coordinates.

--- a/autogalaxy/profiles/mass/sheets/mass_sheet.py
+++ b/autogalaxy/profiles/mass/sheets/mass_sheet.py
@@ -24,16 +24,16 @@ class MassSheet(MassProfile):
     def convergence_func(self, grid_radius: float) -> float:
         return 0.0
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return xp.full(shape=grid.shape[0], fill_value=self.kappa)
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return xp.zeros(shape=grid.shape[0])
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         grid_radii = self.radial_grid_from(grid=grid, xp=xp, **kwargs)
         return self._cartesian_grid_via_radial_from(

--- a/autogalaxy/profiles/mass/stellar/chameleon.py
+++ b/autogalaxy/profiles/mass/stellar/chameleon.py
@@ -50,8 +50,8 @@ class Chameleon(MassProfile, StellarProfile):
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return self.deflections_2d_via_analytic_from(grid=grid, xp=xp, **kwargs)
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_2d_via_analytic_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ):
@@ -131,8 +131,8 @@ class Chameleon(MassProfile, StellarProfile):
         return xp.multiply(factor, xp.vstack((deflection_y, deflection_x)).T)
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """Calculate the projected convergence at a given set of arc-second gridded coordinates.
         Parameters
@@ -149,7 +149,7 @@ class Chameleon(MassProfile, StellarProfile):
             grid_radius, xp=xp
         )
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return xp.zeros(shape=grid.shape[0])
 

--- a/autogalaxy/profiles/mass/stellar/gaussian.py
+++ b/autogalaxy/profiles/mass/stellar/gaussian.py
@@ -50,8 +50,8 @@ class Gaussian(MassProfile, StellarProfile):
         """
         return self.deflections_2d_via_analytic_from(grid=grid, xp=xp, **kwargs)
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_2d_via_analytic_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ):
@@ -76,8 +76,8 @@ class Gaussian(MassProfile, StellarProfile):
         return xp.vstack((-1.0 * xp.imag(deflections), xp.real(deflections))).T
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """Calculate the projected convergence at a given set of arc-second gridded coordinates.
 
@@ -96,7 +96,7 @@ class Gaussian(MassProfile, StellarProfile):
             grid_radius, xp=xp
         )
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return xp.zeros(shape=grid.shape[0])
 

--- a/autogalaxy/profiles/mass/stellar/sersic.py
+++ b/autogalaxy/profiles/mass/stellar/sersic.py
@@ -122,8 +122,8 @@ class AbstractSersic(MassProfile, MassProfileCSE, StellarProfile):
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return self.deflections_2d_via_cse_from(grid=grid, xp=xp, **kwargs)
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_2d_via_cse_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the projected 2D deflection angles from a grid of (y,x) arc second coordinates, by computing and
@@ -141,8 +141,8 @@ class AbstractSersic(MassProfile, MassProfileCSE, StellarProfile):
         return self._deflections_2d_via_cse_from(grid=grid, xp=xp, **kwargs)
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """Calculate the projected convergence at a given set of arc-second gridded coordinates.
 
@@ -157,8 +157,8 @@ class AbstractSersic(MassProfile, MassProfileCSE, StellarProfile):
         )
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_via_cse_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the projected 2D convergence from a grid of (y,x) arc second coordinates, by computing and summing
@@ -183,7 +183,7 @@ class AbstractSersic(MassProfile, MassProfileCSE, StellarProfile):
             grid_radius, xp=xp
         )
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return np.zeros(shape=grid.shape[0])
 

--- a/autogalaxy/profiles/mass/stellar/sersic_gradient.py
+++ b/autogalaxy/profiles/mass/stellar/sersic_gradient.py
@@ -50,8 +50,8 @@ class SersicGradient(AbstractSersic):
         self.mass_to_light_gradient = mass_to_light_gradient
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """Calculate the projected convergence at a given set of arc-second gridded coordinates.
 

--- a/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_mass.py
+++ b/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_mass.py
@@ -262,8 +262,8 @@ class PIEMass(MassProfile):
         MAX_ELLIP = 0.99999
         return xp.min(xp.array([ellip, MAX_ELLIP]))
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.
@@ -292,8 +292,8 @@ class PIEMass(MassProfile):
 
         return self.b0 / 2 * (1 / xp.sqrt(a**2 + radsq))
 
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Returns the two-dimensional projected convergence on a grid of (y,x)
@@ -317,7 +317,7 @@ class PIEMass(MassProfile):
 
         return kappa
 
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def analytical_hessian_2d_from(self, grid: "aa.type.Grid2DLike", xp=np, **kwargs):
         """
         Calculate the hessian matrix on a grid of (y,x) arc-second coordinates.
@@ -412,8 +412,8 @@ class dPIEMass(MassProfile):
         MAX_ELLIP = 0.99999
         return xp.min(xp.array([ellip, MAX_ELLIP]))
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.
@@ -453,8 +453,8 @@ class dPIEMass(MassProfile):
             * (1 / xp.sqrt(a**2 + radsq) - 1 / xp.sqrt(s**2 + radsq))
         )
 
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Returns the two dimensional projected convergence on a grid of (y,x) arc-second coordinates.
@@ -475,7 +475,7 @@ class dPIEMass(MassProfile):
         kappa = self._convergence(grid_radii, xp)
         return kappa
 
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def analytical_hessian_2d_from(self, grid: "aa.type.Grid2DLike", xp=np, **kwargs):
         """
         Calculate the hessian matrix on a grid of (y,x) arc-second coordinates.
@@ -529,7 +529,7 @@ class dPIEMass(MassProfile):
 
         return aa.Array2D(values=1.0 / det_A, mask=grid.mask)
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return xp.zeros(shape=grid.shape[0])
 
@@ -583,8 +583,8 @@ class dPIEMassSph(dPIEMass):
         self.rs = rs
         self.b0 = b0
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.
@@ -619,8 +619,8 @@ class dPIEMassSph(dPIEMass):
 
         return xp.vstack((deflection_y, deflection_x)).T
 
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Returns the two dimensional projected convergence on a grid of (y,x) arc-second coordinates.
@@ -638,7 +638,7 @@ class dPIEMassSph(dPIEMass):
 
         return self._convergence(xp.sqrt(radsq), xp)
 
-    @aa.grid_dec.transform
+    @aa.decorators.transform
     def analytical_hessian_2d_from(self, grid: "aa.type.Grid2DLike", xp=np, **kwargs):
         """
         Calculate the hessian matrix on a grid of (y,x) arc-second coordinates.

--- a/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_potential.py
+++ b/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_potential.py
@@ -93,8 +93,8 @@ class dPIEPotential(MassProfile):
             * (1 / xp.sqrt(a**2 + radsq) - 1 / xp.sqrt(s**2 + radsq))
         )
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.
@@ -118,8 +118,8 @@ class dPIEPotential(MassProfile):
 
         return xp.vstack((deflection_y, deflection_x)).T
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Returns the two dimensional projected convergence on a grid of (y,x) arc-second coordinates.
@@ -151,7 +151,7 @@ class dPIEPotential(MassProfile):
         # zero over all space
         return kappa_circ * (1 - asymm_term) + (alpha_circ / grid_radii) * asymm_term
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return xp.zeros(shape=grid.shape[0])
 
@@ -209,8 +209,8 @@ class dPIEPotentialSph(dPIEPotential):
         self.rs = rs
         self.b0 = b0
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.
@@ -230,8 +230,8 @@ class dPIEPotentialSph(dPIEPotential):
 
         return aa.Grid2DIrregular.from_yx_1d(defl_y, defl_x)
 
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Returns the two dimensional projected convergence on a grid of (y,x) arc-second coordinates.
@@ -249,6 +249,6 @@ class dPIEPotentialSph(dPIEPotential):
 
         return self._convergence(xp.sqrt(radsq), xp)
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return xp.zeros(shape=grid.shape[0])

--- a/autogalaxy/profiles/mass/total/isothermal.py
+++ b/autogalaxy/profiles/mass/total/isothermal.py
@@ -70,8 +70,8 @@ class Isothermal(PowerLaw):
         axis_ratio = super().axis_ratio(xp=xp)
         return xp.minimum(axis_ratio, 0.99999)
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.
@@ -107,8 +107,8 @@ class Isothermal(PowerLaw):
         )
         return xp.multiply(factor, xp.vstack((deflection_y, deflection_x)).T)
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def shear_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the (gamma_y, gamma_x) shear vector field on a grid of (y,x) arc-second coordinates.
@@ -174,8 +174,8 @@ class IsothermalSph(Isothermal):
         return 1.0
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the potential on a grid of (y,x) arc-second coordinates.
@@ -188,8 +188,8 @@ class IsothermalSph(Isothermal):
         eta = self.elliptical_radii_grid_from(grid=grid, xp=xp, **kwargs)
         return 2.0 * self.einstein_radius_rescaled(xp) * eta
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.

--- a/autogalaxy/profiles/mass/total/power_law.py
+++ b/autogalaxy/profiles/mass/total/power_law.py
@@ -37,7 +37,7 @@ class PowerLaw(PowerLawCore):
             core_radius=0.0,
         )
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
 
         alpha = self.deflections_yx_2d_from(
@@ -52,8 +52,8 @@ class PowerLaw(PowerLawCore):
 
         return (x * alpha_x + y * alpha_y) / (3 - self.slope)
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.
@@ -164,8 +164,8 @@ class PowerLawSph(PowerLaw):
             slope=slope,
         )
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         eta = self.radial_grid_from(grid=grid, xp=xp, **kwargs).array
         deflection_r = (

--- a/autogalaxy/profiles/mass/total/power_law_broken.py
+++ b/autogalaxy/profiles/mass/total/power_law_broken.py
@@ -49,8 +49,8 @@ class PowerLawBroken(MassProfile):
             self.kB = (2 - self.inner_slope) / (2 * self.nu**2)
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Returns the dimensionless density kappa=Sigma/Sigma_c (eq. 1)
@@ -69,12 +69,12 @@ class PowerLawBroken(MassProfile):
             radius > self.break_radius
         )
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         return xp.zeros(shape=grid.shape[0])
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid, xp=np, max_terms=20, **kwargs):
         """
         Returns the complex deflection angle from eq. 18 and 19

--- a/autogalaxy/profiles/mass/total/power_law_core.py
+++ b/autogalaxy/profiles/mass/total/power_law_core.py
@@ -47,8 +47,8 @@ class PowerLawCore(MassProfile):
         ) * self.einstein_radius ** (self.slope - 1)
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Returns the two dimensional projected convergence on a grid of (y,x) arc-second coordinates.
@@ -66,8 +66,8 @@ class PowerLawCore(MassProfile):
         return self.convergence_func(grid_radius=grid_eta)
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the potential on a grid of (y,x) arc-second coordinates.
@@ -97,8 +97,8 @@ class PowerLawCore(MassProfile):
 
         return self.einstein_radius_rescaled(xp) * self.axis_ratio(xp) * potential_grid
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform(rotate_back=True)
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.
@@ -204,8 +204,8 @@ class PowerLawCoreSph(PowerLawCore):
             core_radius=core_radius,
         )
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
         """
         Calculate the deflection angles on a grid of (y,x) arc-second coordinates.

--- a/autogalaxy/profiles/mass/total/power_law_multipole.py
+++ b/autogalaxy/profiles/mass/total/power_law_multipole.py
@@ -206,8 +206,8 @@ class PowerLawMultipole(MassProfile):
             a_r * xp.cos(polar_angle_grid) - a_angle * xp.sin(polar_angle_grid),
         )
 
-    @aa.grid_dec.to_vector_yx
-    @aa.grid_dec.transform
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
     def deflections_yx_2d_from(
         self, grid: aa.type.Grid1D2DLike, xp=np, **kwargs
     ) -> np.ndarray:
@@ -256,8 +256,8 @@ class PowerLawMultipole(MassProfile):
         )
 
     @aa.over_sample
-    @aa.grid_dec.to_array
-    @aa.grid_dec.transform
+    @aa.decorators.to_array
+    @aa.decorators.transform
     def convergence_2d_from(
         self, grid: aa.type.Grid1D2DLike, xp=np, **kwargs
     ) -> np.ndarray:
@@ -280,7 +280,7 @@ class PowerLawMultipole(MassProfile):
             * xp.cos(self.m * (angle - angle_m))
         )
 
-    @aa.grid_dec.to_array
+    @aa.decorators.to_array
     def potential_2d_from(
         self, grid: aa.type.Grid2DLike, xp=np, **kwargs
     ) -> np.ndarray:

--- a/test_autogalaxy/profiles/mass/test_transform_rotate_back.py
+++ b/test_autogalaxy/profiles/mass/test_transform_rotate_back.py
@@ -2,7 +2,7 @@
 Tests for the automatic back-rotation feature of the transform decorator (Phase 2).
 
 These tests capture the expected deflection values from the current manual back-rotation
-approach. After switching to automatic back-rotation via @aa.grid_dec.transform(rotate_back=True),
+approach. After switching to automatic back-rotation via @aa.decorators.transform(rotate_back=True),
 the same values must be produced.
 """
 import numpy as np


### PR DESCRIPTION
## Summary

Mechanical rename of all `aa.grid_dec.` references to `aa.decorators.` across 33 profile and galaxy files. Companion to PyAutoArray#277 which introduces `aa.decorators` as the canonical name.

## API Changes

None — internal changes only. All references updated from `aa.grid_dec.to_array` / `aa.grid_dec.transform` etc. to `aa.decorators.to_array` / `aa.decorators.transform`.

## Test Plan
- [x] All 834 PyAutoGalaxy tests pass
- [x] 157 lines changed across 33 files (pure rename, no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)