### PR TITLE
fix: restore jax.tree_util.Partial in omega() for PowerLaw+JAX

### DIFF
--- a/autogalaxy/profiles/mass/total/jax_utils.py
+++ b/autogalaxy/profiles/mass/total/jax_utils.py
@@ -32,7 +32,7 @@ def omega(eiphi, slope, factor, n_terms=20, xp=np):
         be sufficient most of the time)
     """
 
-    from functools import partial
+    from jax.tree_util import Partial as partial
     import jax
 
     scan = jax.jit(jax.lax.scan, static_argnames=("length", "reverse", "unroll"))


### PR DESCRIPTION
## Summary

Fix a regression in `omega()` introduced by commit 632ae829, which replaced `jax.tree_util.Partial` with `functools.partial`, breaking `PowerLaw` deflection calculations under JAX.

`scan` inside `omega()` is wrapped in `jax.jit`, so its first argument (the body function) is traced as a pytree. `functools.partial` is not a registered pytree and fails with:

\`\`\`
TypeError: Error interpreting argument to <function scan> as an abstract
array. The problematic value is of type <class 'functools.partial'>
\`\`\`

`jax.tree_util.Partial` is still present in JAX 0.9.2, so the "0.5+ compat" rationale in 632ae829 was incorrect. This PR reverts that single-line change.

## Reproducer

`autolens_workspace_test/scripts/jax_likelihood_functions/imaging/lp.py` (which uses `al.mp.PowerLaw` + a JAX-vmap'd `Fitness`) is a direct reproducer. It fails on `main` and passes after this fix.

The bug also blocks all `mass_total` stages of the group SLaM pipelines in `autolens_workspace/scripts/group/features/` that use `PowerLaw`.

## Test Plan
- [x] \`python autolens_workspace_test/scripts/jax_likelihood_functions/imaging/lp.py\` — passes numerical assertion \`-1.34797827e+09\`
- [x] Group SLaM MGE + linear_light_profiles mass_total stages pass under \`PYAUTO_TEST_MODE=2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)