### PR TITLE
docs: migrate HowToGalaxy URLs/prose to PyAutoLabs/HowToGalaxy repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,10 +199,11 @@ The `autogalaxy_workspace` at `/mnt/c/Users/Jammy/Code/PyAutoLabs/autogalaxy_wor
 - `start_here.ipynb` / `start_here.py` – entry point overview of the API
 - `scripts/imaging/` – end-to-end scripts: `simulator.py`, `fit.py`, `modeling.py`, `likelihood_function.py`, `features/`
 - `scripts/interferometer/`, `scripts/ellipse/`, `scripts/multi/` – same structure for other dataset types
-- `scripts/howtogalaxy/` – chapter-by-chapter tutorial scripts (chapters 1–4 + optional)
 - `notebooks/` – Jupyter notebook equivalents of all `scripts/`
 - `scripts/guides/` – topic guides (e.g. linear profiles, pixelizations, chaining)
 - `config/` – workspace-level config that overrides package defaults when running workspace scripts
+
+The **HowToGalaxy** tutorial series lives in its own repository at `PyAutoLabs/HowToGalaxy` (no longer under the workspace).
 
 ### Namespace Conventions
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ PyAutoGalaxy: Open-Source Multi Wavelength Galaxy Structure & Morphology
 
 `Installation Guide <https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html>`_ |
 `readthedocs <https://pyautogalaxy.readthedocs.io/en/latest/index.html>`_ |
-`Introduction on Colab <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb>`_
+`Introduction on Colab <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb>`_ |
 `HowToGalaxy <https://pyautogalaxy.readthedocs.io/en/latest/howtogalaxy/howtogalaxy.html>`_
 
 **PyAutoGalaxy** is software for analysing the morphologies and structures of galaxies:
@@ -56,7 +56,9 @@ The following links are useful for new starters:
 
 - `The introduction Jupyter Notebook on Google Colab <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb>`_, where you can try **PyAutoGalaxy** in a web browser (without installation).
 
-- `The autogalaxy_workspace GitHub repository <https://github.com/Jammy2211/autogalaxy_workspace>`_, which includes example scripts and the `HowToGalaxy Jupyter notebook lectures <https://github.com/Jammy2211/autogalaxy_workspace/tree/main/notebooks/howtogalaxy>`_ which give new users a step-by-step introduction to **PyAutoGalaxy**.
+- `The autogalaxy_workspace GitHub repository <https://github.com/PyAutoLabs/autogalaxy_workspace>`_: example scripts covering every **PyAutoGalaxy** use case.
+
+- `The HowToGalaxy GitHub repository <https://github.com/PyAutoLabs/HowToGalaxy>`_: a Jupyter notebook lecture series teaching galaxy modeling from the ground up.
 
 Core Aims
 ---------
@@ -81,8 +83,6 @@ Slack is invitation-only. If you’d like to join, please send an email requesti
 
 For installation issues, bug reports, or feature requests, please raise an issue on the `GitHub issues page <https://github.com/Jammy2211/PyAutoGalaxy/issues>`_.
 
-Here’s a clean, **AutoGalaxy**-appropriate rewrite, keeping the same structure and tone but removing lensing-specific language:
-
 HowToGalaxy
 -----------
 
@@ -90,7 +90,7 @@ For users less familiar with galaxy analysis, Bayesian inference, and scientific
 the **HowToGalaxy** lectures. These introduce the basic principles of galaxy modeling and Bayesian inference, with
 the material pitched at undergraduate level and above.
 
-A complete overview of the lectures is provided on the `HowToGalaxy readthedocs page <https://pyautogalaxy.readthedocs.io/en/latest/howtogalaxy/howtogalaxy.html>`_
+A complete overview of the lectures `is provided on the HowToGalaxy readthedocs page <https://pyautogalaxy.readthedocs.io/en/latest/howtogalaxy/howtogalaxy.html>`_, and the notebooks themselves live in the `PyAutoLabs/HowToGalaxy <https://github.com/PyAutoLabs/HowToGalaxy>`_ repository.
 
 Citations
 ---------

--- a/docs/general/workspace.rst
+++ b/docs/general/workspace.rst
@@ -50,9 +50,10 @@ The folder where  modeling results are stored.
 HowToGalaxy
 -----------
 
-The **HowToGalaxy** lecture series are a collection of Jupyter notebooks describing how to build a **PyAutoGalaxy** model
-fitting project and giving illustrations of different statistical methods and techniques.
+The **HowToGalaxy** lecture series is a collection of Jupyter notebooks describing how to build a **PyAutoGalaxy** model
+fitting project and giving illustrations of different statistical methods and techniques. It ships as a standalone
+repository at `PyAutoLabs/HowToGalaxy <https://github.com/PyAutoLabs/HowToGalaxy>`_ (separate from the workspace).
 
 Checkout the
-`tutorials section <file:///Users/Jammy/Code/PyAutoLabs/PyAutoGalaxy/docs/_build/howtogalaxy/howtogalaxy.html>`_ for a
+`tutorials section <https://pyautogalaxy.readthedocs.io/en/latest/howtogalaxy/howtogalaxy.html>`_ for a
 full description of the lectures and online examples of every notebook.

--- a/docs/howtogalaxy/chapter_1_introduction.rst
+++ b/docs/howtogalaxy/chapter_1_introduction.rst
@@ -7,20 +7,20 @@ In chapter 1, we introduce you to galaxy morphology, structure and the core **Py
 
 The chapter contains the following tutorials:
 
-`Tutorial 0: Visualization <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_0_visualization.ipynb>`_
+`Tutorial 0: Visualization <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_0_visualization.ipynb>`_
 - Setting up **PyAutoGalaxy**'s visualization library.
 
-`Tutorial 1: Grids And Galaxies <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb>`_
+`Tutorial 1: Grids And Galaxies <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb>`_
 - Using grids of (y,x) coordinates with galaxies made up of light profiles.
 
-`Tutorial 2: Data <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_2_data.ipynb>`_
+`Tutorial 2: Data <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_2_data.ipynb>`_
 - Simulating and inspecting telescope imaging data of a galaxy.
 
-`Tutorial 3: Fitting <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_3_fitting.ipynb>`_
+`Tutorial 3: Fitting <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_3_fitting.ipynb>`_
 - Fitting data with a galaxy model.
 
-`Tutorial 4: Methods <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_4_methods.ipynb>`_
+`Tutorial 4: Methods <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_4_methods.ipynb>`_
 - An overview of the different methods used to fit galaxies with.
 
-`Tutorial 5: Summary <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_1_introduction/tutorial_5_summary.ipynb>`_
+`Tutorial 5: Summary <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_5_summary.ipynb>`_
 - A summary of the chapter.

--- a/docs/howtogalaxy/chapter_2_modeling.rst
+++ b/docs/howtogalaxy/chapter_2_modeling.rst
@@ -5,27 +5,27 @@ In chapter 2, we'll take you through how to model galaxies using a non-linear se
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Non-linear Search <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_1_non_linear_search.ipynb>`_
+`Tutorial 1: Non-linear Search <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_2_modeling/tutorial_1_non_linear_search.ipynb>`_
 - How a non-linear search is used to fit a model and the concepts of a parameter space and priors.
 
-`Tutorial 2: Practicalities <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_2_practicalities.ipynb>`_
+`Tutorial 2: Practicalities <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_2_modeling/tutorial_2_practicalities.ipynb>`_
 - Practicalities of performing model-fitting, like how to inspect the results on your hard-disk.
 
-`Tutorial 3: Realism and Complexity <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_3_realism_and_complexity.ipynb>`_
+`Tutorial 3: Realism and Complexity <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_2_modeling/tutorial_3_realism_and_complexity.ipynb>`_
 - Finding a balance between realism and complexity when composing and fitting a model.
 
-`Tutorial 4: Dealing with Failure <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_4_dealing_with_failure.ipynb>`_
+`Tutorial 4: Dealing with Failure <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_2_modeling/tutorial_4_dealing_with_failure.ipynb>`_
 - What to do when PyAutoGalaxy finds an inaccurate model.
 
-`Tutorial 5: Linear Profiles <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_5_linear_profiles.ipynb>`_
+`Tutorial 5: Linear Profiles <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_2_modeling/tutorial_5_linear_profiles.ipynb>`_
 - Light profiles which capture complex morphologies in a reduced number of non-linear parameters.
 
-`Tutorial 6: Masking <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_6_masking.ipynb>`_
+`Tutorial 6: Masking <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_2_modeling/tutorial_6_masking.ipynb>`_
 - How to mask your data to improve the model.
 
-`Tutorial 7: Results <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_7_results.ipynb>`_
+`Tutorial 7: Results <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_2_modeling/tutorial_7_results.ipynb>`_
 - Overview of the results available after successfully fitting a model.
 
-`Tutorial 8: Need for Speed <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_2_modeling/tutorial_8_need_for_speed.ipynb>`_
+`Tutorial 8: Need for Speed <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_2_modeling/tutorial_8_need_for_speed.ipynb>`_
 - How to fit complex models whilst balancing efficiency and run-time.
 

--- a/docs/howtogalaxy/chapter_3_search_chaining.rst
+++ b/docs/howtogalaxy/chapter_3_search_chaining.rst
@@ -6,11 +6,11 @@ robust modeling of large galaxy samples.
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Search Chaining <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_3_search_chaining/tutorial_1_search_chaining.ipynb>`_
+`Tutorial 1: Search Chaining <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_3_search_chaining/tutorial_1_search_chaining.ipynb>`_
 - Breaking the modeling procedure into a chained sequence of model-fits.
 
-`Tutorial 2: Prior Passing <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_3_search_chaining/tutorial_2_prior_passing.ipynb>`_
+`Tutorial 2: Prior Passing <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_3_search_chaining/tutorial_2_prior_passing.ipynb>`_
 - How the results of earlier searches are passed to later searches.
 
-`Tutorial 3: x2 Galaxies <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_3_search_chaining/tutorial_3_x2_galaxies.ipynb>`_
+`Tutorial 3: x2 Galaxies <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_3_search_chaining/tutorial_3_x2_galaxies.ipynb>`_
 - Modeling a dataset with two galaxies using chained searches.

--- a/docs/howtogalaxy/chapter_4_pixelizations.rst
+++ b/docs/howtogalaxy/chapter_4_pixelizations.rst
@@ -5,17 +5,17 @@ In chapter 4, we use **Pixelizations** to reconstruct complex galaxies on pixeli
 
 The chapter contains the following tutorials:
 
-`Tutorial 1: Pixelizations <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_1_pixelizations.ipynb>`_
+`Tutorial 1: Pixelizations <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_1_pixelizations.ipynb>`_
 - Creating a pixel-grid which will reconstruct a galaxy's light.
 
-`Tutorial 2: Mappers <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_2_mappers.ipynb>`_
+`Tutorial 2: Mappers <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_2_mappers.ipynb>`_
 - How a pixelization maps between the data and pixelization.
 
-`Tutorial 3: Inversions <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_3_inversions.ipynb>`_
+`Tutorial 3: Inversions <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_3_inversions.ipynb>`_
 - Inverting the mappings to reconstruct the galaxy's light.
 
-`Tutorial 4: Bayesian Regularization <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_4_bayesian_regularization.ipynb>`_
+`Tutorial 4: Bayesian Regularization <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_4_bayesian_regularization.ipynb>`_
 - Smoothing the source within a Bayesian framework.
 
-`Tutorial 6: Model Fit <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_4_pixelizations/tutorial_6_model_fit.ipynb>`_
+`Tutorial 6: Model Fit <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_4_pixelizations/tutorial_6_model_fit.ipynb>`_
 - An example modeling pipeline which uses an inversion.

--- a/docs/howtogalaxy/chapter_optional.rst
+++ b/docs/howtogalaxy/chapter_optional.rst
@@ -5,12 +5,12 @@ This chapter contains optional tutorials expanding on different aspects of how *
 
 The chapter contains the following tutorials:
 
-`Tutorial: Mass Profiles  <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_optional/tutorial_mass_profiles.ipynb>`_
+`Tutorial: Mass Profiles  <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_optional/tutorial_mass_profiles.ipynb>`_
 - A description of mass profiles implemented in PyAutoGalaxy, which are currently only used by its child project PyAutoLens.
 
-`Tutorial: Sub-grids  <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_optional/tutorial_sub_grids.ipynb>`_
+`Tutorial: Sub-grids  <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_optional/tutorial_sub_grids.ipynb>`_
 - Use sub-grids to perform more accurate and precise calculations.
 
-`Tutorial: Searches  <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/notebooks/howtogalaxy/chapter_optional/tutorial_searches.ipynb>`_
+`Tutorial: Searches  <https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_optional/tutorial_searches.ipynb>`_
 - Alternative non-linear searches to sample parameter space.
 

--- a/docs/howtogalaxy/howtogalaxy.rst
+++ b/docs/howtogalaxy/howtogalaxy.rst
@@ -3,8 +3,8 @@
 HowToGalaxy Lectures
 ====================
 
-The best way to learn **PyAutoGalaxy** is by going through the **HowToGalaxy** lecture series on the
-`autogalaxy workspace <https://github.com/Jammy2211/autogalaxy_workspace>`_.
+The best way to learn **PyAutoGalaxy** is by going through the **HowToGalaxy** lecture series, which lives in its own
+repository at `PyAutoLabs/HowToGalaxy <https://github.com/PyAutoLabs/HowToGalaxy>`_.
 
 The lectures are provided as Jupyter notebooks (and Python scripts), and they are linked to via this readthedocs. The
 lectures are composed of five chapters
@@ -23,7 +23,8 @@ in the later chapters are pretty challenging, and familiarity and modeling is de
 you tackle them.
 
 Therefore, we recommend that you complete chapters 1 & 2 and then apply what you've learnt to the modeling of simulated
-and real galaxy data, using the scripts found in the 'autogalaxy_workspace'. Once you're happy
+and real galaxy data, using the scripts found in the
+`autogalaxy_workspace <https://github.com/PyAutoLabs/autogalaxy_workspace>`_. Once you're happy
 with the results and confident with your use of **PyAutoGalaxy**, you can then begin to cover the advanced functionality
 covered in chapters 3 & 4.
 
@@ -40,8 +41,8 @@ Notebooks are a different way to write, view and use Python code. Compared to th
 This makes them an ideal way for us to present the HowToFit lecture series, therefore I recommend you get yourself
 a Jupyter notebook viewer (https://jupyter.org/) if you havent done so already.
 
-If you *really* want to use Python scripts, all tutorials are supplied a .py python files in the 'scripts' folder of
-the workspace.
+If you *really* want to use Python scripts, all tutorials are also supplied as ``.py`` files in the ``scripts`` folder
+of the `HowToGalaxy repository <https://github.com/PyAutoLabs/HowToGalaxy>`_.
 
 Visualization
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,9 @@ The following links are useful for new starters:
 
 - `The introduction Jupyter Notebook on Colab <https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb>`_, where you can try **PyAutoGalaxy** in a web browser (without installation).
 
-- `The autogalaxy_workspace GitHub repository <https://github.com/Jammy2211/autogalaxy_workspace>`_, which includes example scripts and the `HowToGalaxy Jupyter notebook lectures <https://github.com/Jammy2211/autogalaxy_workspace/tree/main/notebooks/howtogalaxy>`_ which give new users a step-by-step introduction to **PyAutoGalaxy**.
+- `The autogalaxy_workspace GitHub repository <https://github.com/PyAutoLabs/autogalaxy_workspace>`_: example scripts covering every **PyAutoGalaxy** use case.
+
+- `The HowToGalaxy GitHub repository <https://github.com/PyAutoLabs/HowToGalaxy>`_: a Jupyter notebook lecture series teaching galaxy modeling from the ground up.
 
 Core Aims
 =========
@@ -45,8 +47,9 @@ places a focus on **big data** analysis, including support for hierarchical mode
 galaxies, massively parallel model-fitting and an SQLite3 database that allows large suites of modeling results to be
 loaded, queried and analysed.
 
-The software comes distributed with the **HowToGalaxy** Jupyter notebook lectures, which are written assuming no
-previous knowledge about galaxy structure and teach a new user theory and statistics required to analyse
+The **HowToGalaxy** Jupyter notebook lectures, which live in their own
+`PyAutoLabs/HowToGalaxy <https://github.com/PyAutoLabs/HowToGalaxy>`_ repository, are written assuming no
+previous knowledge about galaxy structure and teach a new user the theory and statistics required to analyse
 galaxy data. Checkout `the howtogalaxy section of
 the readthedocs <https://pyautogalaxy.readthedocs.io/en/latest/howtogalaxy/howtogalaxy.html>`_.
 

--- a/docs/overview/overview_2_new_user_guide.rst
+++ b/docs/overview/overview_2_new_user_guide.rst
@@ -54,12 +54,11 @@ morphology were already familiar and the statistical techniques used for fitting
 For those less familiar with these concepts (e.g. undergraduate students, new PhD students or interested members of the
 public), things may have been less clear and a slower more detailed explanation of each concept would be beneficial.
 
-The **HowToGalaxy** Jupyter Notebook lectures are provide exactly this They are a 3+ chapter guide which thoroughly
-take you through the core concepts of galaxy light profiles, teach you the principles ofthe  statistical techniques
-used in modeling and ultimately will allow you to undertake scientific research like a professional astronomer.
+The **HowToGalaxy** Jupyter Notebook lectures provide exactly this. They are a 3+ chapter guide which thoroughly
+takes you through the core concepts of galaxy light profiles, teaches you the principles of the statistical
+techniques used in modeling and ultimately will allow you to undertake scientific research like a professional astronomer.
 
-If this sounds like it suits you, checkout the ``autogalaxy_workspace/notebooks/howtogalaxy`` package now, its it
-recommended you go here before anywhere else!
+If this sounds like it suits you, checkout the `HowToGalaxy <https://github.com/PyAutoLabs/HowToGalaxy>`_ repository now.
 
 Wrap Up
 -------

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -72,9 +72,9 @@ fully automated Bayesian model-fitting of galaxy two-dimensional surface brightn
 interferometer datasets and comprehensive tools for simulating galaxy images. The software places a focus 
 on big data analysis, including support for hierarchical models that simultaneously fit thousands of galaxies, 
 massively parallel model-fitting and an SQLite3 database that allows large suites of modeling results to be loaded, 
-queried and analysed. Accompanying `PyAutoGalaxy` is the [autogalaxy workspace](https://github.com/Jammy2211/autogalaxy_workspace), 
-which includes example scripts, datasets and the `HowToGalaxy` lectures in Jupyter notebook format which introduce 
-non-experts to studies of galaxy morphology using `PyAutoGalaxy`. Readers can try `PyAutoGalaxy` right now by going 
+queried and analysed. Accompanying `PyAutoGalaxy` is the [autogalaxy workspace](https://github.com/PyAutoLabs/autogalaxy_workspace),
+which includes example scripts and galaxy datasets covering every use case. The [`HowToGalaxy`](https://github.com/PyAutoLabs/HowToGalaxy)
+repository provides a separate Jupyter notebook lecture series which introduces non-experts to galaxy morphology studies using `PyAutoGalaxy`. Readers can try `PyAutoGalaxy` right now by going 
 to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb) or 
 checkout the [readthedocs](https://pyautogalaxy.readthedocs.io/en/latest/) for a complete overview of `PyAutoGalaxy`'s 
 features.
@@ -151,13 +151,14 @@ notebook. This uses memory-light `Python` generators, ensuring it is practical f
 
 # Workspace and HowToGalaxy Tutorials
 
-`PyAutoGalaxy` is distributed with the [autogalaxy workspace](https://github.com/Jammy2211/autogalaxy_workspace>), which 
-contains example scripts for modeling and simulating galaxies and tutorials on how to preprocess imaging and 
-interferometer datasets before a `PyAutoGalaxy` analysis. Also included are the `HowToGalaxy` tutorials, a four-chapter 
-lecture series composed of over 20 Jupyter notebooks aimed at non-experts, introducing them to galaxy morphology 
-analysis, Bayesian inference and teaching them how to use `PyAutoGalaxy` for scientific study. The lectures 
-are available on [Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.4.13.6/start_here.ipynb) and may therefore be 
-taken without a local `PyAutoGalaxy` installation.
+`PyAutoGalaxy` is distributed with the [autogalaxy workspace](https://github.com/PyAutoLabs/autogalaxy_workspace), which
+contains example scripts for modeling and simulating galaxies and tutorials on how to preprocess imaging and
+interferometer datasets before a `PyAutoGalaxy` analysis. The [`HowToGalaxy`](https://github.com/PyAutoLabs/HowToGalaxy)
+tutorials — a standalone repository separate from the workspace — are a four-chapter lecture series composed of over
+20 Jupyter notebooks aimed at non-experts, introducing them to galaxy morphology analysis, Bayesian inference and
+teaching them how to use `PyAutoGalaxy` for scientific study. The lectures are available on
+[Colab](https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.4.13.6/notebooks/chapter_1_introduction/tutorial_1_grids_and_galaxies.ipynb)
+and may therefore be taken without a local `PyAutoGalaxy` installation.
 
 # Software Citations
 


### PR DESCRIPTION
## Summary

Sub-task 3 of 3 of the HowToGalaxy extraction (tracking issue: #362).

The HowToGalaxy tutorial series now lives in its own repository at https://github.com/PyAutoLabs/HowToGalaxy. Sub-task 1 (PyAutoLabs/HowToGalaxy#1) imported the content there; sub-task 2 (PyAutoLabs/autogalaxy_workspace#37) removed it from the workspace. This PR is the final piece: it points every HowToGalaxy reference in PyAutoGalaxy at the new location, at tag `2026.4.13.6` (matches autogalaxy_workspace version at extraction).

## Changes

- Rewrite Colab URLs across `docs/howtogalaxy/chapter_{1..4,optional}.rst` from `autogalaxy_workspace/blob/.../notebooks/howtogalaxy/chapter_X/` to `HowToGalaxy/blob/.../notebooks/chapter_X/` (drops the redundant `howtogalaxy/` segment since the new repo root *is* the tutorial series).
- Reword the README, `docs/index.rst` and `docs/overview/overview_2_new_user_guide.rst` new-starter/"HowToGalaxy" sections to frame HowToGalaxy as a standalone repo alongside `autogalaxy_workspace`.
- Rewrite `docs/howtogalaxy/howtogalaxy.rst`, `docs/general/workspace.rst` and `paper/paper.md` with the same framing; fix the broken local `file:///Users/...` readthedocs path in `workspace.rst`.
- Remove the `scripts/howtogalaxy/` bullet from `CLAUDE.md`'s workspace overview and add a short note that HowToGalaxy now lives externally.
- Restore missing `|` separator between "Introduction on Colab" and "HowToGalaxy" links at the top of `README.rst` (pre-existing drift).

## Test plan

- [x] `grep "autogalaxy_workspace.*howtogalaxy\|notebooks/howtogalaxy"` returns zero matches across the repo.
- [x] All remaining `howtogalaxy` occurrences are either HowToGalaxy repo links, readthedocs paths (`howtogalaxy/howtogalaxy.html`), or references to the local `docs/howtogalaxy/` sphinx directory.
- [ ] CI on this PR.

## Follow-up

Register HowToGalaxy in PyAutoBuild so `/pre_build` can auto-tag future HowToGalaxy versions in lockstep with `autogalaxy_workspace` (matches the HowToLens follow-up from the analogous sub-3 PR PyAutoLabs/PyAutoLens#468).

## Related

- Umbrella issue: https://github.com/PyAutoLabs/autogalaxy_workspace/issues/35
- Sub-task 1 (extract): https://github.com/PyAutoLabs/HowToGalaxy/pull/1
- Sub-task 2 (remove from workspace): https://github.com/PyAutoLabs/autogalaxy_workspace/pull/37
- Template precedent: https://github.com/PyAutoLabs/PyAutoLens/pull/468 (HowToLens sub-task 3)

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)