### PR TITLE
fix(light/linear): mark pytree_token as ephemeral via __getstate__/__setstate__

### DIFF
--- a/autogalaxy/profiles/light/linear/abstract.py
+++ b/autogalaxy/profiles/light/linear/abstract.py
@@ -62,6 +62,19 @@ class LightProfileLinear(LightProfile):
             and self.pytree_token == other.pytree_token
         )
 
+    def __getstate__(self):
+        # pytree_token is a process-local counter increment used only as a
+        # stable hash/eq identity for jax.jit flatten/unflatten round-trips.
+        # Persisting it would copy a number from one process's counter into
+        # another's — the JAX path uses register_model's attr_const which
+        # reads vars(self) directly and is unaffected by __getstate__.
+        return {k: v for k, v in self.__dict__.items() if k != "pytree_token"}
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        if "pytree_token" not in state:
+            self.pytree_token = next(LightProfileLinear._pytree_token_counter)
+
     @property
     def regularization(self):
         return None

--- a/test_autogalaxy/profiles/light/linear/test_abstract.py
+++ b/test_autogalaxy/profiles/light/linear/test_abstract.py
@@ -98,3 +98,56 @@ def test__lp_instance_from__returns_instance_with_correct_intensity():
     )
 
     assert lp_non_linear.intensity == 3.0
+
+
+def test__pytree_token_is_int_and_unique():
+    lp_0 = ag.lp_linear.Sersic()
+    lp_1 = ag.lp_linear.Sersic()
+
+    assert isinstance(lp_0.pytree_token, int)
+    assert isinstance(lp_1.pytree_token, int)
+    assert lp_0.pytree_token != lp_1.pytree_token
+
+    assert isinstance(hash(lp_0), int)
+    assert hash(lp_0) == hash(lp_0)
+    assert hash(lp_0) != hash(lp_1)
+
+
+def test__getstate__omits_pytree_token():
+    lp = ag.lp_linear.Sersic()
+    state = lp.__getstate__()
+
+    assert "pytree_token" not in state
+    assert "effective_radius" in state
+
+
+def test__setstate__assigns_fresh_pytree_token_when_missing():
+    lp = ag.lp_linear.Sersic()
+    state = lp.__getstate__()
+
+    restored = ag.lp_linear.Sersic.__new__(ag.lp_linear.Sersic)
+    restored.__setstate__(state)
+
+    assert isinstance(restored.pytree_token, int)
+    assert isinstance(hash(restored), int)
+
+
+def test__pickle_roundtrip_preserves_int_hash():
+    import pickle
+
+    lp = ag.lp_linear.Sersic()
+    restored = pickle.loads(pickle.dumps(lp))
+
+    assert isinstance(hash(restored), int)
+    assert isinstance(restored.pytree_token, int)
+    assert restored.effective_radius == lp.effective_radius
+
+
+def test__setstate__preserves_pytree_token_when_present():
+    lp = ag.lp_linear.Sersic()
+    state_with_token = dict(lp.__dict__)
+
+    restored = ag.lp_linear.Sersic.__new__(ag.lp_linear.Sersic)
+    restored.__setstate__(state_with_token)
+
+    assert restored.pytree_token == lp.pytree_token


### PR DESCRIPTION
## Summary

Mark `LightProfileLinear.pytree_token` as runtime-only via Python's standard `__getstate__` / `__setstate__` protocol, so it doesn't get lossy-int-to-float persisted through PyAutoFit's database round-trip.

## Why

The CI `Smoke Tests` jobs on `autolens_workspace_test/main` (both 3.12 and 3.13) have been failing with:

```
TypeError: __hash__ method should return an integer
  File "autogalaxy/abstract_fit.py", line 133, in linear_light_profile_intensity_dict
    linear_light_profile_intensity_dict[light_profile] = float(reconstruction[i])
```

Root cause: `pytree_token` (added in `29b16b47` to give a stable identity across `jax.jit` flatten/unflatten) is set in `__init__` to `next(itertools.count())` — an `int`. When a fit is loaded back via `FitImagingAgg`, PyAutoFit's database deserializer routes every numeric attribute through the `Value` SQL row (`sa.Float` column in `instance.py:96`), so the saved int comes back as a float (`0.0` / `1.0` observed in live trace). Python ≥3.12 strictly rejects non-`int` returns from `__hash__`.

## What this PR does

`pytree_token` is a process-local counter increment — not meaningful state to persist (copying a number from one process's counter into another's preserves nothing). Adding `__getstate__` / `__setstate__` is the canonical Python idiom for marking an attribute as ephemeral.

```python
def __getstate__(self):
    return {k: v for k, v in self.__dict__.items() if k != "pytree_token"}

def __setstate__(self, state):
    self.__dict__.update(state)
    if "pytree_token" not in state:
        self.pytree_token = next(LightProfileLinear._pytree_token_counter)
```

PyAutoFit's `Instance._from_object` (at `instance.py:73`) and `Object.__call__` (at `model.py:189`) already honour these methods. **No PyAutoFit changes required.** The JAX path uses `register_model`'s `attr_const` which reads `vars(self)` directly and is unaffected by `__getstate__`.

## Why not patch PyAutoFit's database serializer

A library-wide fix in PyAutoFit (e.g. an `IntValue` SQL table) would preserve every persisted int — but `pytree_token` is the **only** known consumer of int-typed persisted state whose `__hash__` breaks. `Galaxy.__hash__` already does `int(self.id)`, `GeometryProfile.__hash__` returns `id(self)`. The conceptually-correct fix lives at the layer where the attribute is defined: this attribute should never have been persisted.

## Tests added

5 new unit tests in `test_autogalaxy/profiles/light/linear/test_abstract.py`:

- `test__pytree_token_is_int_and_unique`
- `test__getstate__omits_pytree_token`
- `test__setstate__assigns_fresh_pytree_token_when_missing`
- `test__pickle_roundtrip_preserves_int_hash`
- `test__setstate__preserves_pytree_token_when_present`

All pure-numpy (no JAX imports), per the project's library-test policy.

## Verified locally

- `pytest test_autogalaxy/` → **845 passed** (was 840 + 5 new)
- `python autolens_workspace_test/scripts/database/scrape/general.py` → exit 0, prints "FitImagingAgg Checked" with no traceback

## Out of scope

- The `AssertionError` failures in `autolens_workspace_test/scripts/jax_likelihood_functions/...` smoke tests — separate root cause, separate PR.

## Test plan

- [ ] PyAutoGalaxy CI `Tests` workflow goes green on this PR
- [ ] After merge: re-trigger `autolens_workspace_test` Smoke Tests on `main` and confirm `TypeError: __hash__ method should return an integer` is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)