### PR TITLE
test: remove jax from unit tests (moved to autogalaxy_workspace_test)

### DIFF
--- a/test_autogalaxy/conftest.py
+++ b/test_autogalaxy/conftest.py
@@ -1,8 +1,3 @@
-def pytest_configure():
-    import jax.numpy as jnp
-
-    _ = jnp.sum(jnp.array([0.0]))  # Force backend init
-
 
 import os
 from os import path

--- a/test_autogalaxy/operate/test_deflections.py
+++ b/test_autogalaxy/operate/test_deflections.py
@@ -156,49 +156,6 @@ def test__magnification_2d_via_hessian_from():
     assert magnification.in_list[1] == pytest.approx(-2.575917, 1.0e-4)
 
 
-def test__hessian_from__np_richardson_matches_jax_jacfwd_to_float64():
-    import jax.numpy as jnp
-
-    grid = ag.Grid2DIrregular(values=[(0.5, 0.5), (1.0, 1.0), (0.7, -0.3)])
-
-    mp = ag.mp.Isothermal(
-        centre=(0.0, 0.0), ell_comps=(0.05, -0.111111), einstein_radius=1.5
-    )
-
-    od = LensCalc.from_mass_obj(mp)
-
-    np_hess = od.hessian_from(grid=grid, xp=np)
-    jnp_hess = od.hessian_from(grid=grid, xp=jnp)
-
-    for np_component, jnp_component in zip(np_hess, jnp_hess):
-        np.testing.assert_allclose(
-            np.asarray(np_component),
-            np.asarray(jnp_component),
-            rtol=1.0e-8,
-        )
-
-
-def test__magnification_2d_via_hessian_from__np_jnp_agree_to_float64():
-    import jax.numpy as jnp
-
-    grid = ag.Grid2DIrregular(values=[(0.5, 0.5), (1.0, 1.0), (0.7, -0.3)])
-
-    mp = ag.mp.Isothermal(
-        centre=(0.0, 0.0), ell_comps=(0.05, -0.111111), einstein_radius=1.5
-    )
-
-    od = LensCalc.from_mass_obj(mp)
-
-    np_mag = od.magnification_2d_via_hessian_from(grid=grid, xp=np)
-    jnp_mag = od.magnification_2d_via_hessian_from(grid=grid, xp=jnp)
-
-    np.testing.assert_allclose(
-        np.asarray(np_mag.array),
-        np.asarray(jnp_mag),
-        rtol=1.0e-7,
-    )
-
-
 def test__tangential_critical_curve_list_from__radius_matches_einstein_radius():
     grid = ag.Grid2D.uniform(shape_native=(15, 15), pixel_scales=0.3)
 


### PR DESCRIPTION
## Summary

Two changes to keep `test_autogalaxy/` numpy-only so the no-jax CI matrix stays green and local pytest runs don't pay the jax import cost.

## Changes

- `test_autogalaxy/conftest.py`: drop the `pytest_configure` hook that did `jnp.sum(jnp.array([0.0]))` to force JAX backend init at session start. This eagerly imported jax even when no jax tests would run.
- `test_autogalaxy/operate/test_deflections.py`: delete the two np-vs-jnp parity tests (`test__hessian_from__np_richardson_matches_jax_jacfwd_to_float64`, `test__magnification_2d_via_hessian_from__np_jnp_agree_to_float64`). Both moved to `scripts/jax_assertions/hessian_parity.py` in autogalaxy_workspace_test. The other 27 tests in this file are pure numpy and stay.

No library code changes.

## Merge dependency

Depends on [autogalaxy_workspace_test#23](https://github.com/PyAutoLabs/autogalaxy_workspace_test/pull/23) merging first, so the moved assertions exist on main before the source tests are removed.

## Test plan

- [x] Local pytest with jax installed: 843 passed (was 845, exactly 2 removed)
- [ ] CI on this PR