### PR TITLE
fix: xp-gate jax.scipy.special.factorial in shapelets/exponential.py

### DIFF
--- a/autogalaxy/profiles/light/standard/shapelets/exponential.py
+++ b/autogalaxy/profiles/light/standard/shapelets/exponential.py
@@ -87,7 +87,12 @@ class ShapeletExponential(AbstractShapelet):
             The image of the Exponential Shapelet evaluated at every (y,x) coordinate on the transformed grid.
         """
         from scipy.special import genlaguerre
-        from jax.scipy.special import factorial
+
+        # factorial backend switch
+        if xp is np:
+            from scipy.special import factorial
+        else:
+            from jax.scipy.special import factorial
 
         radial = (grid.array[:, 0] ** 2 + grid.array[:, 1] ** 2) / self.beta
         theta = xp.arctan(grid.array[:, 1] / grid.array[:, 0])


### PR DESCRIPTION
## Summary

- `autogalaxy/profiles/light/standard/shapelets/exponential.py:90` did an unconditional `from jax.scipy.special import factorial` inside `image_2d_from`, breaking library CI with `ModuleNotFoundError: No module named 'jax'` (failing test: `test_autogalaxy/profiles/light/shapelets/test_exponential.py::test__image_2d_from__elliptical__ell_comps_0p1_0p2__correct_values`).
- Applies the same `if xp is np` gate that already exists in sibling modules `cartesian.py` (lines 104-108) and `polar.py` (lines 152-157). NumPy path uses `scipy.special.factorial`, JAX path uses `jax.scipy.special.factorial`.

## Test plan

- [x] `pytest test_autogalaxy/profiles/light/shapelets/test_exponential.py` — 4 passed.
- [ ] PyAutoBuild CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)