### PR TITLE
docs: update workspace prose refs from README.rst to README.md

### DIFF
--- a/docs/general/configs.md
+++ b/docs/general/configs.md
@@ -3,7 +3,7 @@
 **PyAutoGalaxy** uses a number of configuration files that customize the default behaviour of the non-linear searches,
 visualization and other aspects of **PyAutoGalaxy**.
 
-Descriptions of every configuration file and their input parameters are provided in the `README.rst` in
+Descriptions of every configuration file and their input parameters are provided in the `README.md` in
 the [config directory of the workspace](https://github.com/Jammy2211/autogalaxy_workspace/tree/release/config)
 
 ## Setup

--- a/docs/general/workspace.md
+++ b/docs/general/workspace.md
@@ -7,7 +7,7 @@ when you installed **PyAutoGalaxy**. If you didn't, checkout the
 [installation instructions](https://pyautogalaxy.readthedocs.io/en/latest/general/installation.html#installation-with-pip)
 for how to downloaded and configure the workspace.
 
-The `README.rst` files distributed throughout the workspace describe every folder and file, and specify if
+The `README.md` files distributed throughout the workspace describe every folder and file, and specify if
 examples are for beginner or advanced users.
 
 New users should begin by checking out the following parts of the workspace.
@@ -30,7 +30,7 @@ Here, you'll find the configuration files which customize:
 > - The behaviour of different (y,x) Cartesian grids used to perform lens calculations.
 > - The generaltrue config which customizes other aspects of **PyAutoGalaxy**.
 
-Descriptions of every configuration file and their input parameters are provided in the `README.rst` in
+Descriptions of every configuration file and their input parameters are provided in the `README.md` in
 the [config directory of the workspace](https://github.com/Jammy2211/autogalaxy_workspace/tree/release/config)
 
 ## Dataset


### PR DESCRIPTION
## Summary
Followup to the rst→md migration. The `autogalaxy_workspace`'s READMEs are being converted to `.md` in the same pass (parallel PR), so the prose references to "README.rst" in this library's docs need to flip too.

Single-line text changes; no API or content impact.

Affects:
- `docs/general/configs.md`
- `docs/general/workspace.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)