### PR TITLE
feat: re-export TransformerNUFFTPyNUFFT (legacy pynufft NUFFT)

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -26,6 +26,7 @@ from autoarray.mask.mask_2d import Mask2D  # noqa
 from autoarray.mask.derive.zoom_2d import Zoom2D
 from autoarray.operators.transformer import TransformerDFT  # noqa
 from autoarray.operators.transformer import TransformerNUFFT  # noqa
+from autoarray.operators.transformer import TransformerNUFFTPyNUFFT  # noqa
 from autoarray.layout.layout import Layout2D  # noqa
 from autoarray.structures.arrays.uniform_1d import Array1D  # noqa
 from autoarray.structures.arrays.uniform_2d import Array2D  # noqa


### PR DESCRIPTION
## Summary

Companion to **PyAutoArray PR https://github.com/PyAutoLabs/PyAutoArray/pull/303**, which replaces `TransformerNUFFT` with a JAX-native nufftax-backed default and preserves the pynufft variant as `TransformerNUFFTPyNUFFT`.

This re-export makes the legacy class accessible as `ag.TransformerNUFFTPyNUFFT` so users can opt back to the legacy gridding behaviour without reaching into autoarray directly.

One line change in `autogalaxy/__init__.py`.

## Merge order

This PR depends on PyAutoArray PR #303 being merged first. Until that is merged, the import here will fail.

## Test plan

- [x] `pytest test_autogalaxy/` — 843 / 843 passed
- [x] `import autogalaxy as ag; ag.TransformerNUFFTPyNUFFT` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)