### PR TITLE
docs: audit-driven URL fixes across docs, READMEs, and docstrings

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -1,9 +1,9 @@
 # Citations & References
 
 The bibtex entries for **PyAutoGalaxy** and its affiliated software packages can be found
-[here](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/files/citations.bib), with example text for citing **PyAutoGalaxy**
-in [.tex format here](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/files/citations.tex) format here and
-[.md format here](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/files/citations.md).
+[here](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/files/citations.bib), with example text for citing **PyAutoGalaxy**
+in [.tex format here](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/files/citations.tex) format here and
+[.md format here](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/files/citations.md).
 
 As shown in the examples, we would greatly appreciate it if you mention **PyAutoGalaxy** by name and include a link to
 our GitHub page!

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -301,7 +301,7 @@ the situation is not yet resolved.
 
 ## License
 
-This code of conduct has been adapted from [*NUMFOCUS code of conduct*](https://github.com/numfocus/numfocus/blob/main/manual/numfocus-coc.md#the-short-version),
-which is adapted from numerous sources, including the [*Geek Feminism wiki, created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license*](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), the [*Contributor Covenant version 1.2.0*](http://contributor-covenant.org/version/1/2/0/), the [*Bokeh Code of Conduct*](https://github.com/bokeh/bokeh/blob/main/CODE_OF_CONDUCT.md), the [*SciPy Code of Conduct*](https://github.com/jupyter/governance/blob/main/conduct/enforcement.md), the [*Carpentries Code of Conduct*](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual), and the [*NeurIPS Code of Conduct*](https://neurips.cc/public/CodeOfConduct).
+This code of conduct has been adapted from [*NUMFOCUS code of conduct*](https://numfocus.org/code-of-conduct),
+which is adapted from numerous sources, including the [*Geek Feminism wiki, created by the Ada Initiative and other volunteers, which is under a Creative Commons Zero license*](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), the [*Contributor Covenant version 1.2.0*](http://contributor-covenant.org/version/1/2/0/), the [*Bokeh Code of Conduct*](https://github.com/bokeh/bokeh/blob/main/docs/CODE_OF_CONDUCT.md), the [*SciPy Code of Conduct*](https://github.com/jupyter/governance/blob/main/conduct/enforcement.md), the [*Carpentries Code of Conduct*](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual), and the [*NeurIPS Code of Conduct*](https://neurips.cc/public/CodeOfConduct).
 
 **PyAutoGalaxy Code of Conduct is licensed under the [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Contributions are welcome and greatly appreciated!
 
 ### Report Bugs
 
-Report bugs at https://github.com/Jammy2211/PyAutoGalaxy/issues
+Report bugs at https://github.com/PyAutoLabs/PyAutoGalaxy/issues
 
 If you are playing with the PyAutoGalaxy library and find a bug, please
 reporting it including:
@@ -86,7 +86,7 @@ reporting it including:
 ### Propose New Features
 
 The best way to send feedback is to open an issue at
-https://github.com/Jammy2211/PyAutoGalaxy
+https://github.com/PyAutoLabs/PyAutoGalaxy
 with tag *enhancement*.
 
 If you are proposing a nnew feature:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PyAutoGalaxy: Open-Source Multi Wavelength Galaxy Structure & Morphology
 
-[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.5.14.2/start_here.ipynb)
+[![Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.5.14.2/notebooks/imaging/start_here.ipynb)
 [![Documentation Status](https://readthedocs.org/projects/pyautogalaxy/badge/?version=latest)](https://pyautogalaxy.readthedocs.io/en/latest/?badge=latest)
-[![Tests](https://github.com/Jammy2211/PyAutoGalaxy/actions/workflows/main.yml/badge.svg)](https://github.com/Jammy2211/PyAutoGalaxy/actions)
+[![Tests](https://github.com/PyAutoLabs/PyAutoGalaxy/actions/workflows/main.yml/badge.svg)](https://github.com/PyAutoLabs/PyAutoGalaxy/actions)
 [![Build](https://github.com/Jammy2211/PyAutoBuild/actions/workflows/release.yml/badge.svg)](https://github.com/Jammy2211/PyAutoBuild/actions)
 [![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![JOSS](https://joss.theoj.org/papers/10.21105/joss.04475/status.svg)](https://doi.org/10.21105/joss.04475)
@@ -14,23 +14,23 @@
 
 [Installation Guide](https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html) |
 [readthedocs](https://pyautogalaxy.readthedocs.io/en/latest/index.html) |
-[Introduction on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.5.14.2/start_here.ipynb) |
+[Introduction on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.5.14.2/notebooks/imaging/start_here.ipynb) |
 [HowToGalaxy](https://pyautogalaxy.readthedocs.io/en/latest/howtogalaxy/howtogalaxy.html)
 
 **PyAutoGalaxy** is software for analysing the morphologies and structures of galaxies:
 
-[![HST Combined](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/paper/hstcombined.png?raw=true)](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/paper/hstcombined.png)
+[![HST Combined](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/paper/hstcombined.png?raw=true)](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/paper/hstcombined.png)
 
 **PyAutoGalaxy** also fits interferometer data from observatories such as ALMA:
 
-[![ALMA Combined](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/paper/almacombined.png?raw=true)](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/paper/almacombined.png)
+[![ALMA Combined](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/paper/almacombined.png?raw=true)](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/paper/almacombined.png)
 
 ## Getting Started
 
 The following links are useful for new starters:
 
 - [The PyAutoGalaxy readthedocs](https://pyautogalaxy.readthedocs.io/en/latest), which includes [an overview of PyAutoGalaxy's core features](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html).
-- [The introduction Jupyter Notebook on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.5.14.2/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).
+- [The introduction Jupyter Notebook on Google Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.5.14.2/notebooks/imaging/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).
 - [The autogalaxy_workspace GitHub repository](https://github.com/PyAutoLabs/autogalaxy_workspace): example scripts covering every **PyAutoGalaxy** use case.
 - [The HowToGalaxy GitHub repository](https://github.com/PyAutoLabs/HowToGalaxy): a Jupyter notebook lecture series teaching galaxy modeling from the ground up.
 
@@ -51,7 +51,7 @@ galaxy modeling and analysis, and helps troubleshoot problems.
 
 Slack is invitation-only. If you'd like to join, please send an email requesting an invite.
 
-For installation issues, bug reports, or feature requests, please raise an issue on the [GitHub issues page](https://github.com/Jammy2211/PyAutoGalaxy/issues).
+For installation issues, bug reports, or feature requests, please raise an issue on the [GitHub issues page](https://github.com/PyAutoLabs/PyAutoGalaxy/issues).
 
 ## HowToGalaxy
 
@@ -63,10 +63,10 @@ A complete overview of the lectures [is provided on the HowToGalaxy readthedocs 
 
 ## Citations
 
-Information on how to cite **PyAutoGalaxy** in publications can be found [on the citations page](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/CITATIONS.md).
+Information on how to cite **PyAutoGalaxy** in publications can be found [on the citations page](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/CITATIONS.md).
 
 ## Contributing
 
-Information on how to contribute to **PyAutoGalaxy** can be found [on the contributing page](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/CONTRIBUTING.md).
+Information on how to contribute to **PyAutoGalaxy** can be found [on the contributing page](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/CONTRIBUTING.md).
 
 Hands on support for contributions is available via our Slack workspace, again please email to request an invite.

--- a/docs/api/plot.rst
+++ b/docs/api/plot.rst
@@ -5,12 +5,12 @@ Plotting
 **PyAutoGalaxy** custom visualization library.
 
 Step-by-step Juypter notebook guides illustrating all objects listed on this page are
-provided on the `autogalaxy_workspace: plot tutorials <https://github.com/Jammy2211/autogalaxy_workspace/tree/release/notebooks/plot>`_ and
+provided on the `autogalaxy_workspace: plot tutorials <https://github.com/PyAutoLabs/autogalaxy_workspace/tree/main/notebooks/guides/plot>`_ and
 it is strongly recommended you use those to learn plot customization.
 
 **Examples / Tutorials:**
 
-- `autogalaxy_workspace: plot tutorials <https://github.com/Jammy2211/autogalaxy_workspace/tree/release/notebooks/plot>`_
+- `autogalaxy_workspace: plot tutorials <https://github.com/PyAutoLabs/autogalaxy_workspace/tree/main/notebooks/guides/plot>`_
 
 Plotters [aplt]
 ---------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import datetime
 #
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
-# https://www.sphinx-doc.org/en/main/usage/configuration.html
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
 
@@ -65,7 +65,7 @@ extlinks = {"pypi": ("https://pypi.org/project/%s/", "")}
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "sphinx": ("https://www.sphinx-doc.org/en/main", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
 }
 
 # -- Options for TODOs -------------------------------------------------------

--- a/docs/general/citations.md
+++ b/docs/general/citations.md
@@ -3,9 +3,9 @@
 # Citations & References
 
 The bibtex entries for **PyAutoGalaxy** and its affiliated software packages can be found
-[here](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/files/citations.bib), with example text for citing **PyAutoGalaxy**
-in [.tex format here](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/files/citations.tex) format here and
-[.md format here](https://github.com/Jammy2211/PyAutoGalaxy/blob/main/files/citations.md).
+[here](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/files/citations.bib), with example text for citing **PyAutoGalaxy**
+in [.tex format here](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/files/citations.tex) format here and
+[.md format here](https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/files/citations.md).
 
 **PyAutoGalaxy** is published in the [Journal of Open Source Software](https://joss.theoj.org/papers/10.21105/joss.04475#) and its
 entry in the above .bib file is under the citation key `pyautogalaxy`.

--- a/docs/general/configs.md
+++ b/docs/general/configs.md
@@ -4,7 +4,7 @@
 visualization and other aspects of **PyAutoGalaxy**.
 
 Descriptions of every configuration file and their input parameters are provided in the `README.md` in
-the [config directory of the workspace](https://github.com/Jammy2211/autogalaxy_workspace/tree/release/config)
+the [config directory of the workspace](https://github.com/PyAutoLabs/autogalaxy_workspace/tree/main/config)
 
 ## Setup
 

--- a/docs/general/credits.md
+++ b/docs/general/credits.md
@@ -6,7 +6,7 @@
 
 [James Nightingale](https://github.com/Jammy2211): Lead developer & PyAutoGalaxy guru.
 
-[Richard Hayes](https://github.com/rhayes777): Lead developer & [PyAutoFit](https://github.com/rhayes777/PyAutoFit) guru.
+[Richard Hayes](https://github.com/rhayes777): Lead developer & [PyAutoFit](https://github.com/PyAutoLabs/PyAutoFit) guru.
 
 [Aristeidis Amvrosiadis](https://github.com/Sketos): Interferometer Analysis.
 

--- a/docs/general/model_cookbook.md
+++ b/docs/general/model_cookbook.md
@@ -224,8 +224,8 @@ profiles.
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/Jammy2211/autogalaxy_workspace/blob/release/notebooks/modeling/imaging/features/multi_gaussian_expansion.ipynb>
-<https://github.com/Jammy2211/autogalaxy_workspace/blob/release/notebooks/modeling/imaging/features/shapelets.ipynb>
+<https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/imaging/features/multi_gaussian_expansion/modeling.ipynb>
+<https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/imaging/features/shapelets/modeling.ipynb>
 
 ## Model Linking (Advanced)
 
@@ -233,7 +233,7 @@ When performing non-linear search chaining, the inferred model of one phase can 
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/Jammy2211/autogalaxy_workspace/blob/release/notebooks/imaging/advanced/chaining/start_here.ipynb>
+<https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/imaging/advanced/chaining/start_here.ipynb>
 
 ## Across Datasets (Advanced)
 
@@ -242,7 +242,7 @@ but certain parameters are free to vary across the datasets.
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/Jammy2211/autogalaxy_workspace/blob/release/notebooks/multi/modeling/start_here.ipynb>
+<https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/multi/start_here.ipynb>
 
 ## Relations (Advanced)
 
@@ -251,7 +251,7 @@ We can compose models where the free parameter(s) vary according to a user-speci
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/Jammy2211/autogalaxy_workspace/blob/release/notebooks/multi/modeling/features/wavelength_dependence.ipynb>
+<https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/multi/features/wavelength_dependence/modeling.ipynb>
 
 ## PyAutoFit API
 

--- a/docs/general/workspace.md
+++ b/docs/general/workspace.md
@@ -2,7 +2,7 @@
 
 # Workspace Tour
 
-You should have downloaded and configured the [autogalaxy workspace](https://github.com/Jammy2211/autogalaxy_workspace)
+You should have downloaded and configured the [autogalaxy workspace](https://github.com/PyAutoLabs/autogalaxy_workspace)
 when you installed **PyAutoGalaxy**. If you didn't, checkout the
 [installation instructions](https://pyautogalaxy.readthedocs.io/en/latest/general/installation.html#installation-with-pip)
 for how to downloaded and configure the workspace.
@@ -18,7 +18,7 @@ There are numerous example describing how to perform calculations, galaxy modeli
 **PyAutoGalaxy** features. All examples are provided as Python scripts and Jupyter notebooks.
 
 A full description of the scripts available is given on
-the [autogalaxy workspace GitHub page](https://github.com/Jammy2211/autogalaxy_workspace).
+the [autogalaxy workspace GitHub page](https://github.com/PyAutoLabs/autogalaxy_workspace).
 
 ## Config
 
@@ -31,7 +31,7 @@ Here, you'll find the configuration files which customize:
 > - The generaltrue config which customizes other aspects of **PyAutoGalaxy**.
 
 Descriptions of every configuration file and their input parameters are provided in the `README.md` in
-the [config directory of the workspace](https://github.com/Jammy2211/autogalaxy_workspace/tree/release/config)
+the [config directory of the workspace](https://github.com/PyAutoLabs/autogalaxy_workspace/tree/main/config)
 
 ## Dataset
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 ---
 substitutions:
   pic1: |-
-    ```{image} https://github.com/Jammy2211/PyAutoGalaxy/blob/main/paper/hstcombined.png?raw=true
+    ```{image} https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/paper/hstcombined.png?raw=true
     ```
   pic2: |-
-    ```{image} https://github.com/Jammy2211/PyAutoGalaxy/blob/main/paper/almacombined.png?raw=true
+    ```{image} https://github.com/PyAutoLabs/PyAutoGalaxy/blob/main/paper/almacombined.png?raw=true
     ```
 ---
 
@@ -23,7 +23,7 @@ substitutions:
 The following links are useful for new starters:
 
 - [The PyAutoGalaxy readthedocs](https://pyautogalaxy.readthedocs.io/en/latest/), which includes [an overview of PyAutoGalaxy's core features](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_1_start_here.html), [a new user starting guide](https://pyautogalaxy.readthedocs.io/en/latest/overview/overview_2_new_user_guide.html) and [an installation guide](https://pyautogalaxy.readthedocs.io/en/latest/installation/overview.html).
-- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.5.14.2/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).
+- [The introduction Jupyter Notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.5.14.2/notebooks/imaging/start_here.ipynb), where you can try **PyAutoGalaxy** in a web browser (without installation).
 - [The autogalaxy_workspace GitHub repository](https://github.com/PyAutoLabs/autogalaxy_workspace): example scripts covering every **PyAutoGalaxy** use case.
 - [The HowToGalaxy GitHub repository](https://github.com/PyAutoLabs/HowToGalaxy): a Jupyter notebook lecture series teaching galaxy modeling from the ground up.
 
@@ -134,7 +134,7 @@ galaxies_plotter.figures_2d(image=True)
 ```
 
 To perform model-fitting, `PyAutoGalaxy` adopts the probabilistic programming
-language `PyAutoFit` (<https://github.com/rhayes777/PyAutoFit>). `PyAutoFit` allows users to compose a
+language `PyAutoFit` (<https://github.com/PyAutoLabs/PyAutoFit>). `PyAutoFit` allows users to compose a
 model from `LightProfile` and `Galaxy` objects, customize the model parameterization and fit it to data via a
 non-linear search (e.g., `dynesty` [@dynesty], `emcee` [@emcee], `PySwarms` [@pyswarms]). By composing a model with
 `Pixelization` objects, the galaxy's light is reconstructed using a non-parametric rectangular

--- a/docs/installation/conda.md
+++ b/docs/installation/conda.md
@@ -54,7 +54,7 @@ the `autogalaxy_workspace`, reducing the download size):
 
 ```bash
 cd /path/on/your/computer/you/want/to/put/the/autogalaxy_workspace
-git clone https://github.com/Jammy2211/autogalaxy_workspace --depth 1
+git clone https://github.com/PyAutoLabs/autogalaxy_workspace --depth 1
 cd autogalaxy_workspace
 ```
 

--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -22,11 +22,11 @@ our [building from source installation guide](https://pyautogalaxy.readthedocs.i
 
 **PyAutoGalaxy** has the following dependencies:
 
-**PyAutoConf** <https://github.com/rhayes777/PyAutoConf>
+**PyAutoConf** <https://github.com/PyAutoLabs/PyAutoConf>
 
-**PyAutoFit** <https://github.com/rhayes777/PyAutoFit>
+**PyAutoFit** <https://github.com/PyAutoLabs/PyAutoFit>
 
-**PyAutoArray** <https://github.com/Jammy2211/PyAutoArray>
+**PyAutoArray** <https://github.com/PyAutoLabs/PyAutoArray>
 
 **dynesty** <https://github.com/joshspeagle/dynesty>
 

--- a/docs/installation/pip.md
+++ b/docs/installation/pip.md
@@ -41,7 +41,7 @@ the `autogalaxy_workspace`, reducing the download size):
 
 ```bash
 cd /path/on/your/computer/you/want/to/put/the/autogalaxy_workspace
-git clone https://github.com/Jammy2211/autogalaxy_workspace --depth 1
+git clone https://github.com/PyAutoLabs/autogalaxy_workspace --depth 1
 cd autogalaxy_workspace
 ```
 

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -8,9 +8,9 @@ contribute the development **PyAutoGalaxy** or experiment with yourself!
 
 A large amount of **PyAutoGalaxy** functionality is contained in its parent projects:
 
-**PyAutoFit** <https://github.com/rhayes777/PyAutoFit>
+**PyAutoFit** <https://github.com/PyAutoLabs/PyAutoFit>
 
-**PyAutoArray** <https://github.com/Jammy2211/PyAutoArray>
+**PyAutoArray** <https://github.com/PyAutoLabs/PyAutoArray>
 
 If you wish to build from source all code you may need to build from source these 3 additional
 projects. We include below instructions for building just **PyAutoGalaxy** from source or building all projects.
@@ -26,7 +26,7 @@ pip install --upgrade pip
 First, clone (or fork) the **PyAutoGalaxy** GitHub repository:
 
 ```bash
-git clone https://github.com/Jammy2211/PyAutoGalaxy
+git clone https://github.com/PyAutoLabs/PyAutoGalaxy
 ```
 
 Next, install the **PyAuto** parent projects via pip:
@@ -88,9 +88,9 @@ pip install --upgrade pip
 First, clone (or fork) all 4 GitHub repositories:
 
 ```bash
-git clone https://github.com/rhayes777/PyAutoFit
-git clone https://github.com/Jammy2211/PyAutoArray
-git clone https://github.com/Jammy2211/PyAutoGalaxy
+git clone https://github.com/PyAutoLabs/PyAutoFit
+git clone https://github.com/PyAutoLabs/PyAutoArray
+git clone https://github.com/PyAutoLabs/PyAutoGalaxy
 ```
 
 Next, install **PyAutoConf** via pip:

--- a/docs/installation/troubleshooting.md
+++ b/docs/installation/troubleshooting.md
@@ -21,7 +21,7 @@ instead, or visa versa.
 ## Support
 
 If you are still having issues with installation, please raise an issue on the
-[PyAutoGalaxy issues page](https://github.com/Jammy2211/PyAutoGalaxy/issues) with a description of the
+[PyAutoGalaxy issues page](https://github.com/PyAutoLabs/PyAutoGalaxy/issues) with a description of the
 problem and your system setup (operating system, Python version, etc.).
 
 ## Current Working Directory

--- a/docs/overview/overview_1_start_here.md
+++ b/docs/overview/overview_1_start_here.md
@@ -4,7 +4,7 @@
 
 **PyAutoGalaxy** is software for analysing the morphologies and structures of galaxies:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/paper/hstcombined.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/paper/hstcombined.png
 :alt: Alternative text
 :width: 400
 ```
@@ -51,7 +51,7 @@ aplt.plot_grid(grid=grid, title="Uniform Grid")
 
 The `Grid2D` looks like this:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/docs/overview/images/overview_1/0_grid.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/docs/overview/images/overview_1/0_grid.png
 :alt: Alternative text
 :width: 600
 ```
@@ -102,7 +102,7 @@ aplt.plot_array(array=sersic_light_profile.image_2d_from(grid=grid), title="Sers
 
 The light profile appears as follows:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/docs/overview/images/overview_1/1_image_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/docs/overview/images/overview_1/1_image_2d.png
 :alt: Alternative text
 :width: 600
 ```
@@ -134,7 +134,7 @@ aplt.plot_array(array=galaxy.image_2d_from(grid=grid), title="Galaxy Image")
 
 The galaxy, with both a bulge and disk, appears as follows:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/docs/overview/images/overview_1/2_image_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/docs/overview/images/overview_1/2_image_2d.png
 :alt: Alternative text
 :width: 600
 ```
@@ -147,7 +147,7 @@ aplt.subplot_galaxy_light_profiles(galaxy=galaxy, grid=grid)
 
 The light profiles appear as follows:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/docs/overview/images/overview_1/3_subplot_image.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/docs/overview/images/overview_1/3_subplot_image.png
 :alt: Alternative text
 :width: 600
 ```
@@ -176,7 +176,7 @@ galaxies = ag.Galaxies(
 aplt.plot_array(array=galaxies.image_2d_from(grid=grid), title="Galaxies Image")
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/docs/overview/images/overview_1/4_image_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/docs/overview/images/overview_1/4_image_2d.png
 :alt: Alternative text
 :width: 600
 ```
@@ -242,7 +242,7 @@ aplt.plot_array(array=galaxies.image_2d_from(grid=grid), title="Galaxies Image")
 
 The image of the merging galaxy system appears as follows:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/docs/overview/images/overview_1/5_image_2d.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/docs/overview/images/overview_1/5_image_2d.png
 :alt: Alternative text
 :width: 600
 ```

--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -12,9 +12,9 @@ the most appropriate starting point, answer one simple question:
 
 You now need to decide what type of data you are interested in:
 
-- **CDD Imaging**: For image data from telescopes like Hubble and James Webb, go to [imaging/start_here.ipynb](https://github.com/Jammy2211/autogalaxy_workspace/blob/release/notebooks/imaging/start_here.ipynb).
-- **Interferometer**: For radio / sub-mm interferometer from instruments like ALMA, go to [interferometer/start_here.ipynb](https://github.com/Jammy2211/autogalaxy_workspace/blob/release/notebooks/interferometer/start_here.ipynb).
-- **Multi-Band Imaging**: For galaxies observed in multiple wavebands go to [multi_band//start_here.ipynb](hhttps://github.com/Jammy2211/autogalaxy_workspace/blob/release/notebooks/point_source/start_here.ipynb).
+- **CDD Imaging**: For image data from telescopes like Hubble and James Webb, go to [imaging/start_here.ipynb](https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/imaging/start_here.ipynb).
+- **Interferometer**: For radio / sub-mm interferometer from instruments like ALMA, go to [interferometer/start_here.ipynb](https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/interferometer/start_here.ipynb).
+- **Multi-Band Imaging**: For galaxies observed in multiple wavebands go to [multi/start_here.ipynb](https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/multi/start_here.ipynb).
 
 ## Google Colab
 

--- a/docs/overview/overview_3_features.md
+++ b/docs/overview/overview_3_features.md
@@ -27,7 +27,7 @@ links to the relevant workspace examples.
 
 Modeling interferometer data from submillimeter (e.g. ALMA) and radio (e.g. LOFAR) observatories:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/paper/almacombined.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/paper/almacombined.png
 :alt: Alternative text
 :width: 600
 ```
@@ -43,12 +43,12 @@ Checkout the `autogalaxy_workspace/*/interferometer` package to get started.
 Modeling imaging datasets observed at different wavelengths (e.g. HST F814W and F150W) simultaneously or simultaneously
 analysing imaging and interferometer data:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/docs/overview/images/overview_3/g_image.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/docs/overview/images/overview_3/g_image.png
 :alt: Alternative text
 :width: 400
 ```
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/docs/overview/images/overview_3/r_image.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/docs/overview/images/overview_3/r_image.png
 :alt: Alternative text
 :width: 400
 ```
@@ -65,7 +65,7 @@ feature and it is recommended you first get to grips with the core API.
 Ellipse fitting is a technique which fits many ellipses to a galaxy's emission to determine its ellipticity, position
 angle and centre, without assuming a parametric form for its light (e.g. a Sersic profile):
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/docs/overview/images/overview_3/ellipse.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/docs/overview/images/overview_3/ellipse.png
 :alt: Alternative text
 :width: 600
 ```
@@ -84,7 +84,7 @@ Checkout `autogalaxy_workspace/notebooks/features/ellipse_fitting.ipynb` to lear
 
 An MGE decomposes the light of a galaxy into tens or hundreds of two dimensional Gaussians:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/docs/overview/images/overview_3/mge.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/docs/overview/images/overview_3/mge.png
 :alt: Alternative text
 :width: 600
 ```
@@ -102,7 +102,7 @@ Checkout `autogalaxy_workspace/notebooks/features/multi_gaussian_expansion.ipynb
 
 Shapelets are a set of orthogonal basis functions that can be combined the represent galaxy structures:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoLens/main/docs/overview/images/overview_3/shapelets.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoLens/main/docs/overview/images/overview_3/shapelets.png
 :alt: Alternative text
 :width: 600
 ```
@@ -145,7 +145,7 @@ The image below shows a non parametric of a galaxy observed in the Hubble Ultra 
 fitted accurately using light profiles, whereas its asymmetric and irregular spiral arm features are accurately
 captured using a rectangular mesh:
 
-```{image} https://raw.githubusercontent.com/Jammy2211/PyAutoGalaxy/main/paper/hstcombined.png
+```{image} https://raw.githubusercontent.com/PyAutoLabs/PyAutoGalaxy/main/paper/hstcombined.png
 :alt: Alternative text
 :width: 600
 ```

--- a/files/citations.md
+++ b/files/citations.md
@@ -1,6 +1,6 @@
 **Insert in the main body of the paper:**
 
-We use the lens modeling software `PyAutoLens` https://github.com/Jammy2211/PyAutoLens) [@pyautolens] [@Nightingale2015] [@Nightingale2018] to...
+We use the lens modeling software `PyAutoLens` https://github.com/PyAutoLabs/PyAutoLens) [@pyautolens] [@Nightingale2015] [@Nightingale2018] to...
 
 **At the end of the paper (delete as appropriate, see https://pyautofit.readthedocs.io/en/latest/general/citations.html):**
 
@@ -16,8 +16,8 @@ This work uses the following software packages:
 - `matplotlib` https://github.com/matplotlib/matplotlib [@matplotlib]
 - `numba` https://github.com/numba/numba [@numba]
 - `NumPy` https://github.com/numpy/numpy [@numpy]
-- `PyAutoFit` https://github.com/rhayes777/PyAutoFit [@pyautofit]
-- `PyAutoGalaxy` https://github.com/Jammy2211/PyAutoGalaxy [@Nightingale2018] [@pyautogalaxy]
+- `PyAutoFit` https://github.com/PyAutoLabs/PyAutoFit [@pyautofit]
+- `PyAutoGalaxy` https://github.com/PyAutoLabs/PyAutoGalaxy [@Nightingale2018] [@pyautogalaxy]
 - `PyNUFFT` https://github.com/jyhmiinlin/pynufft [@pynufft]
 - `PySwarms` https://github.com/ljvmiranda921/pyswarms [@pyswarms]
 - `Python` https://www.python.org/ [@python]

--- a/paper/README.md
+++ b/paper/README.md
@@ -1,5 +1,5 @@
 PyAutoGalaxy JOSS Paper
 =====================
 
-Paper accompanying [PyAutoGalaxy](https://github.com/Jammy2211/PyAutoGalaxy) for submission to the Journal of Open Source 
+Paper accompanying [PyAutoGalaxy](https://github.com/PyAutoLabs/PyAutoGalaxy) for submission to the Journal of Open Source 
 Software (JOSS).

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -56,7 +56,7 @@ affiliations:
     index: 4
 
 date: 12 May 2022
-codeRepository: https://github.com/Jammy2211/PyAutoGalaxy
+codeRepository: https://github.com/PyAutoLabs/PyAutoGalaxy
 license: MIT
 bibliography: paper.bib
 ---
@@ -75,7 +75,7 @@ massively parallel model-fitting and an SQLite3 database that allows large suite
 queried and analysed. Accompanying `PyAutoGalaxy` is the [autogalaxy workspace](https://github.com/PyAutoLabs/autogalaxy_workspace),
 which includes example scripts and galaxy datasets covering every use case. The [`HowToGalaxy`](https://github.com/PyAutoLabs/HowToGalaxy)
 repository provides a separate Jupyter notebook lecture series which introduces non-experts to galaxy morphology studies using `PyAutoGalaxy`. Readers can try `PyAutoGalaxy` right now by going 
-to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.5.14.2/start_here.ipynb) or 
+to [the introduction Jupyter notebook on Colab](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.5.14.2/notebooks/imaging/start_here.ipynb) or 
 checkout the [readthedocs](https://pyautogalaxy.readthedocs.io/en/latest/) for a complete overview of `PyAutoGalaxy`'s 
 features.
 
@@ -130,7 +130,7 @@ handles unit conversions and calculations are optimized using the packages `NumP
 and `PyNUFFT` [@pynufft].
 
 To perform model-fitting, `PyAutoGalaxy` adopts the probabilistic programming  
-language `PyAutoFit` (https://github.com/rhayes777/PyAutoFit). `PyAutoFit` allows users to compose a 
+language `PyAutoFit` (https://github.com/PyAutoLabs/PyAutoFit). `PyAutoFit` allows users to compose a 
 model from `LightProfile` and `Galaxy` objects, customize the model parameterization and fit it to data via a 
 non-linear search, for example, `dynesty` [@dynesty], `emcee` [@emcee] or `PySwarms` [@pyswarms]. By composing a model with 
 `Pixelization` objects, the galaxy's light is reconstructed using a non-parametric rectangular 
@@ -144,7 +144,7 @@ Automated fitting of complex galaxy models is possible using `PyAutoFit`'s searc
 a galaxy into a chained sequence of non-linear searches. These fits pass information gained about simpler models 
 fitted by earlier searches to subsequent searches, which fit progressively more complex models. By granularizing the 
 model-fitting procedure, automated pipelines that fit complex galaxy models without human intervention can be carefully 
-crafted, with example pipelines found on the [autogalaxy workspace](https://github.com/Jammy2211/autogalaxy_workspace). 
+crafted, with example pipelines found on the [autogalaxy workspace](https://github.com/PyAutoLabs/autogalaxy_workspace). 
 To ensure the analysis and interpretation of fits to large galaxy datasets is feasible, `PyAutoFit`'s database tools 
 write modeling results to a relational database which can be queried from a storage drive to a Python script or Jupyter 
 notebook. This uses memory-light `Python` generators, ensuring it is practical for results containing hundreds of thousands of galaxies.


### PR DESCRIPTION
## Summary

Doc-only URL cleanup driven by the new `admin_jammy/software/url_check/` audit tool (Jammy2211/admin_jammy#21). Fixes the user-reported `hhttps://` typo in `overview_2_new_user_guide.md` plus ~20 mechanical URL rewrites covering:

- Renamed GitHub orgs: `Jammy2211/<workspace>` → `PyAutoLabs/<workspace>`; `Jammy2211|rhayes777/<library>` → `PyAutoLabs/<library>`
- Removed `release` branch on workspaces: `/blob/release/` → `/blob/main/`, `/tree/release/` → `/tree/main/`
- nautilus sampler moved orgs: `joshspeagle/nautilus` → `johannesulf/nautilus`
- PyAutoBuild moved orgs: `rhayes777/PyAutoBuild` → `PyAutoLabs/PyAutoBuild`
- Dead Code of Conduct links: bokeh CoC → `/docs/CODE_OF_CONDUCT.md`; numfocus → `numfocus.org/code-of-conduct`
- Sphinx-doc: `/en/main` → `/en/master`
- pyautofit.readthedocs.io renames: `cookbook_1_basics` → `cookbooks/model`, `overview/model_fit` → `overview/the_basics`, `overview/result` → `cookbooks/result`, etc.
- Workspace notebook reorganisations: `overview/simple/fit.ipynb` → `overview/overview_1_the_basics.ipynb`, `modeling/imaging/features/<x>.ipynb` → `imaging/features/<x>/modeling.ipynb`, etc.
- Colab badge URL: workspace-root `start_here.ipynb` → `notebooks/<type>/start_here.ipynb` (the bare-root file never existed)

No source-code behaviour changes — only docstring and `.md / .rst / Python-comment` text. CRLF line endings preserved (no whitespace churn).

## Test plan

- [x] `python -m pytest test_<library>` passes
- [x] `python -c "import <library>"` succeeds (verifies docstring edits don't break parsing)
- [ ] Audit re-run after this PR + paired PRs merge

## Related

- Tool PR: Jammy2211/admin_jammy#21
- Issue: PyAutoLabs/PyAutoLens#508
- Workspace-phase follow-up: HowToFit, HowToGalaxy, HowToLens, autofit_workspace, autogalaxy_workspace, autolens_workspace (URLs in symlinked workspace files were SCANNED but not FIXED in this phase)