### PR TITLE
ci: add live URL audit (weekly cron) + grandfather current broken URLs

### DIFF
--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -4,9 +4,16 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    - cron: '0 4 * * 1'  # Mondays 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  url_check:
+  url_check_patterns:
+    name: Offline regex guard
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -21,3 +28,68 @@ jobs:
           path: PyAutoBuild
       - name: Run url_check.sh
         run: bash PyAutoBuild/autobuild/url_check.sh repo
+
+  url_check_live:
+    name: Live HTTP audit (weekly)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          path: repo
+      - name: Checkout PyAutoBuild
+        uses: actions/checkout@v4
+        with:
+          repository: PyAutoLabs/PyAutoBuild
+          ref: main
+          path: PyAutoBuild
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install requests
+        run: pip install --quiet requests
+      - name: Run live URL audit
+        id: audit
+        run: |
+          set +e
+          body=$(bash PyAutoBuild/autobuild/url_check_live.sh repo)
+          rc=$?
+          printf '%s\n' "$body" > /tmp/url_audit_body.md
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          cat /tmp/url_audit_body.md
+          exit 0
+      - name: Open or update [url-check] tracking issue
+        if: steps.audit.outputs.rc != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd repo
+          existing=$(gh issue list --search '"[url-check]"' --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "Updating existing tracking issue #$existing"
+            gh issue comment "$existing" --body-file /tmp/url_audit_body.md
+          else
+            echo "Opening new tracking issue"
+            gh issue create \
+              --title "[url-check] New broken URLs detected" \
+              --body-file /tmp/url_audit_body.md \
+              --label url-check 2>/dev/null \
+              || gh issue create \
+                --title "[url-check] New broken URLs detected" \
+                --body-file /tmp/url_audit_body.md
+          fi
+      - name: Close stale tracking issue if audit is clean
+        if: steps.audit.outputs.rc == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd repo
+          for n in $(gh issue list --search '"[url-check]"' --state open --json number --jq '.[].number'); do
+            echo "Closing now-clean tracking issue #$n"
+            gh issue close "$n" --comment "Weekly URL audit is clean — closing automatically."
+          done

--- a/.url_check_allowlist.txt
+++ b/.url_check_allowlist.txt
@@ -1,0 +1,30 @@
+# Known broken URLs grandfathered for url_check_live.sh.
+# Format: one URL per line. Lines starting with '#' and blank lines are ignored.
+# Sample location follows each URL as a trailing comment.
+#
+# This file is referenced by .github/workflows/url_check.yml (weekly cron).
+# url_check_live.sh fails CI when a URL is broken AND not in this file.
+# To accept new breakage: append the URL here. To force a fix: leave it out.
+
+# Academic citations (paywall / DOI / journal)
+https://academic.oup.com/mnras/article/488/1/1387/5526256  # autogalaxy/profiles/mass/abstract/mge.py:12
+
+# Code of Conduct boilerplate
+http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy  # CODE_OF_CONDUCT.md:305
+
+# Colab refs to notebooks no longer in HowTo/workspace
+https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.5.14.2/notebooks/chapter_4_pixelizations/tutorial_6_model_fit.ipynb  # docs/howtogalaxy/chapter_4_pixelizations.md:19
+https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.5.14.2/notebooks/chapter_optional/tutorial_mass_profiles.ipynb  # docs/howtogalaxy/chapter_optional.md:7
+https://colab.research.google.com/github/PyAutoLabs/HowToGalaxy/blob/2026.5.14.2/notebooks/chapter_optional/tutorial_sub_grids.ipynb  # docs/howtogalaxy/chapter_optional.md:10
+
+# External dead / paywalled / departmental pages
+http://www.astro.uvic.ca/~simard/GIM2D/  # paper/paper.md:188
+https://bitbucket.org/bdiemer/colossus/src/main/  # files/citations.md:12
+
+# GitHub refs (workspaces / removed tutorials)
+https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/imaging/advanced/chaining/start_here.ipynb  # docs/general/model_cookbook.md:236
+
+# Internal PyAuto docs — pages renamed, need editorial fix
+https://pyautogalaxy.readthedocs.io/en/latest/api/mass.html  # docs/general/model_cookbook.md:190
+https://pyautogalaxy.readthedocs.io/en/latest/general/installation.html#installation-with-pip  # docs/general/workspace.md:7
+https://pyautogalaxy.readthedocs.io/en/latest/overview/lensing.html  # docs/index.md:53


### PR DESCRIPTION
## Summary

Add the live URL-audit CI infrastructure described in PyAutoLabs/PyAutoBuild#87 to **PyAutoGalaxy**.

- **`.url_check_allowlist.txt`** at repo root — 11 URLs the audit currently flags as broken in this repo. Mostly external paywalled / dead links and internal docs renames. Each is grouped by category with the originating file:line as an inline comment.
- **`.github/workflows/url_check.yml`** — extended:
  - **Offline regex guard** (existing job, expanded to ~17 patterns) — runs on every PR + push. Fast, no network. Catches typos like `hhttps://`, stale `Jammy2211/` refs, etc.
  - **Live HTTP audit (NEW)** — runs on `schedule` (Monday 04:00 UTC) and `workflow_dispatch`. Validates every URL in the repo's docs against the allowlist. On new breakage, opens or appends to a tracking issue titled `[url-check] New broken URLs detected`. On a clean run, automatically closes any prior open tracking issue.

No code changes. Doc / CI-only.

## Test plan

- [x] Workflow YAML parses
- [x] `url_check_live.sh PyAutoGalaxy` exits 0 against the current allowlist (post-merge cron run will be a no-op until something new breaks)
- [ ] First weekly cron run after merge confirms the issue-create path works end-to-end

## Related

- Tool PR: PyAutoLabs/PyAutoBuild#87 (must merge first — provides the new live tool and the extended regex patterns)