### PR TITLE
fix: handle r=0 in NFWSph deflections

### DIFF
--- a/autogalaxy/profiles/mass/dark/nfw.py
+++ b/autogalaxy/profiles/mass/dark/nfw.py
@@ -317,9 +317,18 @@ class NFWSph(NFW):
             self.radial_grid_from(grid=grid, xp=xp, **kwargs).array,
         )
 
-        deflection_grid = xp.multiply(
-            (4.0 * self.kappa_s * self.scale_radius / eta),
-            self.deflection_func_sph(grid_radius=eta, xp=xp),
+        # Guard r=0: the deflection at the centre of a spherical profile is exactly
+        # zero by symmetry, but the analytic form here divides by eta and calls
+        # arccosh(1/r) which both blow up at the origin.
+        eta_safe = xp.where(eta < 1e-6, 1e-6, eta)
+
+        deflection_grid = xp.where(
+            eta < 1e-6,
+            0.0,
+            xp.multiply(
+                (4.0 * self.kappa_s * self.scale_radius / eta_safe),
+                self.deflection_func_sph(grid_radius=eta_safe, xp=xp),
+            ),
         )
 
         return self._cartesian_grid_via_radial_from(


### PR DESCRIPTION
## Summary

- `NFWSph.deflections_2d_via_analytic_from` produced NaN at the profile centre. The analytic form divides by `eta = r/scale_radius` and evaluates `arccosh(1/r)` inside `coord_func_h`, both of which blow up at r=0.
- Any grid that included the origin pixel (e.g. an odd-sized image-plane grid centred on a lens at (0, 0)) propagated NaNs through every subsequent ray-trace.
- Added an `xp.where(eta < 1e-6, ...)` guard so r=0 returns 0 (the symmetry-required value), matching the existing 1e-6 / 1e-24 guards already used by the elliptical `NFW` path (`convergence_2d_from`, `shear_yx_2d_from`, `deflections_2d_via_analytic_from`). No public API change.

## Why now

Surfaced by two scripts in `autolens_workspace/scripts/imaging/features/advanced/mass_stellar_dark/` (`fit.py`, `likelihood_function.py`) where a manual stellar + dark + shear deflection sum is compared against the `Tracer`'s total. Both sides got NaN at the origin pixel, and `np.allclose(NaN, NaN) == False` made the comparison fail despite the math being correct everywhere else.

## API Changes

None. `NFWSph.deflections_yx_2d_from(grid)` signature and return type unchanged; only the behaviour at r=0 changes (NaN → 0).

## Test plan

- [x] `pytest test_autogalaxy/profiles/mass/dark/test_nfw.py` — 25 passed
- [x] Reproduction snippet: `NaN in dark/sum/lens == 0`, `allclose(sum, lens) == True`, `allclose(grid_manual, grid_tracer) == True`, origin deflection now `[-0., 0.]`
- [x] Both `mass_stellar_dark` workspace scripts run end-to-end with no `RuntimeWarning: divide by zero` and no `AssertionError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)