### PR TITLE
Pin jax_zero_contour >=2.0.0,<3.0.0 in [jax] extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ local_scheme = "no-local-version"
 [project.optional-dependencies]
 jax = [
     "autoconf[jax]",
-    "jax_zero_contour; python_version >= '3.11'"
+    "jax_zero_contour>=2.0.0,<3.0.0; python_version >= '3.11'"
 ]
 optional = [
     "autogalaxy[jax]",


### PR DESCRIPTION
## Summary

Replaces the unpinned `jax_zero_contour` entry in the `[jax]` extra with a versioned pin matching the current PyPI line (2.0.0).

## Why

Sweeping the JAX ecosystem pins as part of the JAX 0.7.0 floor bump. The unpinned form would let a future major release silently break the JAX install path during routine `pip install autogalaxy[jax]`.

## Test plan

- [x] Resolver test: `jax_zero_contour 2.0.0` resolves against JAX 0.7.0 and 0.10.1
- [x] PyAutoGalaxy light-profile unit tests pass on JAX 0.9.2 (92 passed)
- [ ] CI green

## Depends on

PyAutoConf and PyAutoArray companion PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)