### PR TITLE
fix(mass): wire convergence_func on dPIE family for MGE decomposition

### DIFF
--- a/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_mass.py
+++ b/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_mass.py
@@ -501,6 +501,9 @@ class dPIEMass(MassProfile):
             * (1 / xp.sqrt(a**2 + radsq) - 1 / xp.sqrt(s**2 + radsq))
         )
 
+    def convergence_func(self, grid_radius, xp=np):
+        return self._convergence(grid_radius, xp=xp)
+
     @aa.decorators.to_array
     @aa.decorators.transform
     def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):

--- a/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_potential.py
+++ b/autogalaxy/profiles/mass/total/dual_pseudo_isothermal_potential.py
@@ -129,6 +129,9 @@ class dPIEPotential(MassProfile):
             * (1 / xp.sqrt(a**2 + radsq) - 1 / xp.sqrt(s**2 + radsq))
         )
 
+    def convergence_func(self, grid_radius, xp=np):
+        return self._convergence(grid_radius, xp=xp)
+
     @aa.decorators.to_vector_yx
     @aa.decorators.transform(rotate_back=True)
     def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):

--- a/test_autogalaxy/profiles/mass/total/test_dual_pseudo_isothermal_mass.py
+++ b/test_autogalaxy/profiles/mass/total/test_dual_pseudo_isothermal_mass.py
@@ -45,3 +45,30 @@ def test__deflections_yx_2d_from__elliptical_vs_spherical():
     assert elliptical.deflections_yx_2d_from(grid=grid).array == pytest.approx(
         spherical.deflections_yx_2d_from(grid=grid).array, 1e-1
     )
+
+
+def test__convergence_func__matches_private_helper():
+    """Regression: dPIEMass must override the abstract `convergence_func`
+    so MGEDecomposer.decompose_convergence_via_mge (which walks the
+    convergence radially during MGE potential decomposition) doesn't
+    fall through to the abstract NotImplementedError. The shim delegates
+    to the existing `_convergence` radial helper that `convergence_2d_from`
+    already uses."""
+
+    import numpy as np
+
+    mp = ag.mp.dPIEMass(centre=(0.0, 0.0), b0=5.2, ra=2.0, rs=3.0)
+
+    # Scalar radius: equals the _convergence formula directly.
+    assert mp.convergence_func(1.5) == pytest.approx(mp._convergence(1.5), 1e-12)
+
+    # 1-D array of radii: shape preserved, element-wise equality.
+    radii = np.array([0.1, 0.5, 1.0, 2.5, 5.0])
+    expected = mp._convergence(radii)
+    actual = mp.convergence_func(radii)
+    assert actual.shape == radii.shape
+    assert actual == pytest.approx(expected, 1e-12)
+
+    # dPIEMassSph inherits the override from dPIEMass.
+    sph = ag.mp.dPIEMassSph(centre=(0.0, 0.0), b0=5.2, ra=2.0, rs=3.0)
+    assert sph.convergence_func(1.5) == pytest.approx(sph._convergence(1.5), 1e-12)

--- a/test_autogalaxy/profiles/mass/total/test_dual_pseudo_isothermal_potential.py
+++ b/test_autogalaxy/profiles/mass/total/test_dual_pseudo_isothermal_potential.py
@@ -108,3 +108,25 @@ def test__convergence_2d_from__elliptical_vs_spherical():
     assert elliptical.convergence_2d_from(grid=grid).array == pytest.approx(
         spherical.convergence_2d_from(grid=grid).array, 1e-4
     )
+
+
+def test__convergence_func__matches_private_helper():
+    """Regression: dPIEPotential must override the abstract `convergence_func`
+    so MGEDecomposer.decompose_convergence_via_mge doesn't fall through to the
+    abstract NotImplementedError. The shim delegates to the existing
+    `_convergence` radial helper that `convergence_2d_from` already uses."""
+
+    import numpy as np
+
+    mp = ag.mp.dPIEPotential(centre=(0.0, 0.0), b0=5.2, ra=2.0, rs=3.0)
+
+    assert mp.convergence_func(1.5) == pytest.approx(mp._convergence(1.5), 1e-12)
+
+    radii = np.array([0.1, 0.5, 1.0, 2.5, 5.0])
+    expected = mp._convergence(radii)
+    actual = mp.convergence_func(radii)
+    assert actual.shape == radii.shape
+    assert actual == pytest.approx(expected, 1e-12)
+
+    sph = ag.mp.dPIEPotentialSph(centre=(0.0, 0.0), b0=5.2, ra=2.0, rs=3.0)
+    assert sph.convergence_func(1.5) == pytest.approx(sph._convergence(1.5), 1e-12)


### PR DESCRIPTION
## Summary

Restores cluster-scale workspace scripts that build `al.mp.dPIEMassSph` profiles. C3 cluster of the 2026-05-28 release-prep triage (3 scripts in `autolens_workspace/scripts/cluster/`).

`dPIEMass` / `dPIEMassSph` / `dPIEPotential` / `dPIEPotentialSph` override `convergence_2d_from` via a private `_convergence(radii, xp=np)` radial helper but never override the abstract `convergence_func(grid_radius, xp=np)` hook. `MGEDecomposer.decompose_convergence_via_mge` (`mge.py:274`) walks the convergence radially during MGE potential decomposition and calls `convergence_func`, which fell through to the abstract base and raised `NotImplementedError`.

Add 3-line shims on each base class that delegate to the existing `_convergence` helper. Spherical variants inherit the override. `_convergence` is already broadcast-safe and is the same code path `convergence_2d_from` already uses.

## Test plan

- [x] `pytest test_autogalaxy/profiles/mass/total/test_dual_pseudo_isothermal_{mass,potential}.py -v` — both files pass including 2 new `test__convergence_func__matches_private_helper` cases (scalar + array, asserts equality with `_convergence`, plus a `Sph` inheritance check).
- [x] `pytest test_autogalaxy/profiles/mass -q` — 408/408 mass-profile tests pass.
- [x] `autolens_workspace/scripts/cluster/simulator.py` no longer hits `NotImplementedError` in `convergence_func` (runs through to real cluster simulation; the previous fast-fail at 9.14s gave way to genuine model-fitting work).
- [ ] Reviewer to confirm the shim signature matches existing override patterns in `sersic.py:208`, `nfw.py:169`, etc.

## Follow-up

A wider audit during planning surfaced 6-12 more mass profile classes with the same latent `convergence_func` gap:
- `PowerLawBroken` + `PowerLawBrokenSph`
- `PowerLawMultipole`
- `cNFW` family (8+ classes)
- `DevVaucouleurs`, `Exponential`, `GaussianGradient`

None are in current triage failures, but each is a landmine for any future workspace that exercises them via MGE potential decomposition or Einstein-radius integration. A separate `fix(mass): audit convergence_func coverage across all mass profiles` issue/PR will sweep them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)