### PR TITLE
fix(jax): defensive pytree dedup in imaging/interferometer analyses

### DIFF
--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -27,6 +27,9 @@ from autogalaxy.imaging.model.visualizer import VisualizerImaging
 from autogalaxy.imaging.fit_imaging import FitImaging
 
 
+_FIT_IMAGING_PYTREES_REGISTERED = False
+
+
 class AnalysisImaging(AnalysisDataset):
     Result = ResultImaging
     Visualizer = VisualizerImaging
@@ -209,10 +212,37 @@ class AnalysisImaging(AnalysisDataset):
         analysis — ride as aux so JAX does not recurse into them. Everything
         else (``galaxies``, ``dataset_model`` and the autoarray wrappers they
         carry) is dynamic per fit.
+
+        Idempotent — guarded by the module-level
+        ``_FIT_IMAGING_PYTREES_REGISTERED`` flag so repeated calls from each
+        ``fit_from`` invocation are cheap. ``DatasetModel`` may already be
+        registered by ``autofit.jax.pytrees.register_model`` (its
+        ``_REGISTERED_INSTANCE_CLASSES`` set is independent of autoarray's
+        ``_pytree_registered_classes``); cross-populate so
+        ``register_instance_pytree`` short-circuits instead of asking JAX to
+        register it twice. Mirrors the defense in
+        ``autogalaxy/ellipse/model/analysis.py``.
         """
-        from autoarray.abstract_ndarray import register_instance_pytree
+        global _FIT_IMAGING_PYTREES_REGISTERED
+        if _FIT_IMAGING_PYTREES_REGISTERED:
+            return
+
+        from autoarray.abstract_ndarray import (
+            register_instance_pytree,
+            _pytree_registered_classes,
+        )
         from autoarray.dataset.dataset_model import DatasetModel
         from autogalaxy.analysis.jax_pytrees import register_galaxies_pytree
+
+        try:
+            from autofit.jax.pytrees import (
+                _REGISTERED_INSTANCE_CLASSES as _af_registered,
+            )
+        except ImportError:
+            _af_registered = set()
+
+        if DatasetModel in _af_registered:
+            _pytree_registered_classes.add(DatasetModel)
 
         register_instance_pytree(
             FitImaging,
@@ -220,6 +250,8 @@ class AnalysisImaging(AnalysisDataset):
         )
         register_instance_pytree(DatasetModel)
         register_galaxies_pytree()
+
+        _FIT_IMAGING_PYTREES_REGISTERED = True
 
     def save_attributes(self, paths: af.DirectoryPaths):
         """

--- a/autogalaxy/interferometer/model/analysis.py
+++ b/autogalaxy/interferometer/model/analysis.py
@@ -30,6 +30,9 @@ logger = logging.getLogger(__name__)
 logger.setLevel(level="INFO")
 
 
+_FIT_INTERFEROMETER_PYTREES_REGISTERED = False
+
+
 class AnalysisInterferometer(AnalysisDataset):
     Result = ResultInterferometer
     Visualizer = VisualizerInterferometer
@@ -173,10 +176,32 @@ class AnalysisInterferometer(AnalysisDataset):
         analysis — ride as aux so JAX does not recurse into them. Everything
         else (``galaxies`` and the autoarray wrappers it carries) is dynamic
         per fit.
+
+        Idempotent — guarded by the module-level
+        ``_FIT_INTERFEROMETER_PYTREES_REGISTERED`` flag. See
+        ``autogalaxy/imaging/model/analysis.py`` for the cross-registration
+        rationale.
         """
-        from autoarray.abstract_ndarray import register_instance_pytree
+        global _FIT_INTERFEROMETER_PYTREES_REGISTERED
+        if _FIT_INTERFEROMETER_PYTREES_REGISTERED:
+            return
+
+        from autoarray.abstract_ndarray import (
+            register_instance_pytree,
+            _pytree_registered_classes,
+        )
         from autoarray.dataset.dataset_model import DatasetModel
         from autogalaxy.analysis.jax_pytrees import register_galaxies_pytree
+
+        try:
+            from autofit.jax.pytrees import (
+                _REGISTERED_INSTANCE_CLASSES as _af_registered,
+            )
+        except ImportError:
+            _af_registered = set()
+
+        if DatasetModel in _af_registered:
+            _pytree_registered_classes.add(DatasetModel)
 
         register_instance_pytree(
             FitInterferometer,
@@ -184,6 +209,8 @@ class AnalysisInterferometer(AnalysisDataset):
         )
         register_instance_pytree(DatasetModel)
         register_galaxies_pytree()
+
+        _FIT_INTERFEROMETER_PYTREES_REGISTERED = True
 
     def save_attributes(self, paths: af.DirectoryPaths):
         """


### PR DESCRIPTION
## Summary

Ports the existing defensive registration pattern from \`autogalaxy/ellipse/model/analysis.py\` to \`imaging\` and \`interferometer\` analyses. Without this, \`AnalysisImaging.fit_from\` re-registers \`DatasetModel\` with JAX every call, and crashes when a prior code path (PyAutoFit's pytree walker on a graphical / multi-dataset model) has already registered \`DatasetModel\` via an independent dedup set.

## Repro

Discovered on \`multi/start_here.py\` in autogalaxy_workspace during the 2026.5.29.2 release run:

\`\`\`
File "autogalaxy/imaging/model/analysis.py", line 152, in fit_from
    self._register_fit_imaging_pytrees()
File "autogalaxy/imaging/model/analysis.py", line 221, in _register_fit_imaging_pytrees
    register_instance_pytree(DatasetModel)
File "autoarray/abstract_ndarray.py", line 136, in register_instance_pytree
    register_pytree_node(cls, flatten, unflatten)
ValueError: Duplicate custom PyTreeDef type registration for <class 'autoarray.dataset.dataset_model.DatasetModel'>.
\`\`\`

## Fix

For both \`imaging/model/analysis.py\` and \`interferometer/model/analysis.py\`:

1. Module-level \`_FIT_*_PYTREES_REGISTERED = False\` flag — short-circuits re-entry after the first successful registration.
2. Try-import \`autofit.jax.pytrees._REGISTERED_INSTANCE_CLASSES\` and cross-populate autoarray's \`_pytree_registered_classes\` for \`DatasetModel\`. This makes \`register_instance_pytree\`'s existing idempotency guard work across both dedup sets.
3. Set the flag at the end of the function.

Mirrors the defense in \`autogalaxy/ellipse/model/analysis.py\` (which solved the same problem for ellipse fits).

## Paired with

- PyAutoLens companion PR (same fix for autolens imaging/interferometer)
- PyAutoBuild PR (release.yml \`run_scripts\` env block)

## Test plan

- [x] \`pytest test_autogalaxy/imaging/model test_autogalaxy/interferometer/model\` — 13 passed (unit tests don't exercise the JAX path — real validation comes from CI run_smoke_tests \`multi/start_here.py\`)
- [ ] CI on this PR
- [ ] Next \`autobuild pre_build\` dispatch — \`run_smoke_tests autogalaxy_workspace\` no longer crashes in \`multi/start_here.py\` with duplicate-registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)