### PR TITLE
feat: add Kaplinghat SIDM cored NFW profile

### DIFF
--- a/autogalaxy/config/priors/mass/dark/kaplinghat.yaml
+++ b/autogalaxy/config/priors/mass/dark/kaplinghat.yaml
@@ -1,0 +1,71 @@
+KaplinghatCoredNFWSph:
+  centre_0:
+    type: Gaussian
+    mean: 0.0
+    sigma: 0.1
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  centre_1:
+    type: Gaussian
+    mean: 0.0
+    sigma: 0.1
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  kappa_s:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  scale_radius:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  sigma_over_m:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  t_age:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 13.8
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  interaction_radius:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 30.0
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf

--- a/autogalaxy/config/priors/mass/dark/kaplinghat_mcr.yaml
+++ b/autogalaxy/config/priors/mass/dark/kaplinghat_mcr.yaml
@@ -1,0 +1,71 @@
+KaplinghatCoredNFWMCRLudlowSph:
+  centre_0:
+    type: Gaussian
+    mean: 0.0
+    sigma: 0.1
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  centre_1:
+    type: Gaussian
+    mean: 0.0
+    sigma: 0.1
+    width_modifier:
+      type: Absolute
+      value: 0.05
+    limits:
+      lower: -inf
+      upper: inf
+  mass_at_200:
+    type: LogUniform
+    lower_limit: 100000000.0
+    upper_limit: 1000000000000000.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  sigma_over_m:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 10.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  t_age:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 13.8
+    width_modifier:
+      type: Relative
+      value: 0.2
+    limits:
+      lower: 0.0
+      upper: inf
+  redshift_object:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf
+  redshift_source:
+    type: Uniform
+    lower_limit: 0.0
+    upper_limit: 1.0
+    width_modifier:
+      type: Relative
+      value: 0.5
+    limits:
+      lower: 0.0
+      upper: inf

--- a/autogalaxy/profiles/mass/__init__.py
+++ b/autogalaxy/profiles/mass/__init__.py
@@ -43,6 +43,8 @@ from .dark import (
     cNFWMCRLudlowSph,
     cNFWMCRScatterLudlow,
     cNFWMCRScatterLudlowSph,
+    KaplinghatCoredNFWSph,
+    KaplinghatCoredNFWMCRLudlowSph,
 )
 from .stellar import (
     Gaussian,

--- a/autogalaxy/profiles/mass/dark/__init__.py
+++ b/autogalaxy/profiles/mass/dark/__init__.py
@@ -12,3 +12,5 @@ from .nfw_virial_mass_conc import NFWVirialMassConcSph
 from .cnfw import cNFW, cNFWSph
 from .cnfw_mcr import cNFWMCRLudlow, cNFWMCRLudlowSph
 from .cnfw_mcr_scatter import cNFWMCRScatterLudlow, cNFWMCRScatterLudlowSph
+from .kaplinghat import KaplinghatCoredNFWSph
+from .kaplinghat_mcr import KaplinghatCoredNFWMCRLudlowSph

--- a/autogalaxy/profiles/mass/dark/kaplinghat.py
+++ b/autogalaxy/profiles/mass/dark/kaplinghat.py
@@ -65,6 +65,62 @@ def _nfw_mass_3d_within_radius_from(r, kappa_s, scale_radius):
     return 4.0 * np.pi * (kappa_s / scale_radius) * scale_radius**3 * mass_factor
 
 
+def _trapezoid_from(y, x, axis, xp):
+    if hasattr(xp, "trapezoid"):
+        return xp.trapezoid(y, x=x, axis=axis)
+    return xp.trapz(y, x=x, axis=axis)
+
+
+def _interp_lane_emden_xp(x, xp):
+    x_table, h_table, _ = _isothermal_lane_emden_table()
+    return xp.interp(x, xp.asarray(x_table), xp.asarray(h_table))
+
+
+def _nfw_radial_deflection_from(r, kappa_s, scale_radius, xp):
+    x = xp.maximum(r / scale_radius, 1.0e-8)
+
+    below = x < 1.0
+    above = x > 1.0
+    x_below = xp.minimum(x, 1.0 - 1.0e-8)
+    x_above = xp.maximum(x, 1.0 + 1.0e-8)
+
+    f_below = xp.arccosh(1.0 / x_below) / xp.sqrt(1.0 - x_below**2)
+    f_above = xp.arccos(1.0 / x_above) / xp.sqrt(x_above**2 - 1.0)
+    f_at_one = 1.0
+    f = xp.where(below, f_below, xp.where(above, f_above, f_at_one))
+
+    g = xp.log(x / 2.0) + f
+    return 4.0 * kappa_s * scale_radius * g / x
+
+
+def _kaplinghat_density_3d_from_radius(
+    radii,
+    kappa_s,
+    scale_radius,
+    interaction_radius,
+    central_density,
+    isothermal_radius,
+    xp,
+):
+    x_nfw = xp.maximum(radii / scale_radius, 1.0e-12)
+    nfw_density = (kappa_s / scale_radius) / (x_nfw * (1.0 + x_nfw) ** 2)
+
+    safe_isothermal_radius = xp.maximum(isothermal_radius, 1.0e-12)
+    x_iso = xp.maximum(radii / safe_isothermal_radius, 1.0e-5)
+    h = _interp_lane_emden_xp(x_iso, xp=xp)
+    safe_central_density = xp.where(xp.isfinite(central_density), central_density, 0.0)
+    iso_density = safe_central_density * xp.exp(-h)
+
+    use_iso = (
+        (interaction_radius > 0.0)
+        & (isothermal_radius > 0.0)
+        & xp.isfinite(central_density)
+        & (radii < interaction_radius)
+    )
+
+    return xp.where(use_iso, iso_density, nfw_density)
+
+
 def _matched_isothermal_parameters_from(interaction_radius, kappa_s, scale_radius):
     rho_1 = _nfw_density_from(
         r=interaction_radius,
@@ -242,6 +298,57 @@ class KaplinghatCoredNFWSph(MassProfile, DarkProfile):
             limit=100,
         )[0]
         return 2.0 * mass_2d / radius
+
+    @staticmethod
+    def radial_deflection_from(r, params, xp):
+        kappa_s = params[0]
+        scale_radius = params[1]
+        interaction_radius = params[2]
+        central_density = params[3]
+        isothermal_radius = params[4]
+
+        r = xp.asarray(r)
+        r_safe = xp.maximum(r, 1.0e-8)
+
+        z_max = xp.maximum(500.0 * scale_radius, 50.0 * interaction_radius)
+        z_unit = xp.linspace(1.0e-5, 1.0, 160)
+        z = z_max * z_unit**3
+        u = xp.linspace(0.0, 1.0, 64)
+
+        projected_radii = xp.maximum(r_safe[:, None] * u[None, :], 1.0e-6)
+        three_d_radii = xp.sqrt(
+            projected_radii[:, :, None] ** 2 + z[None, None, :] ** 2
+        )
+
+        density = _kaplinghat_density_3d_from_radius(
+            radii=three_d_radii,
+            kappa_s=kappa_s,
+            scale_radius=scale_radius,
+            interaction_radius=interaction_radius,
+            central_density=central_density,
+            isothermal_radius=isothermal_radius,
+            xp=xp,
+        )
+        convergence = 2.0 * _trapezoid_from(density, x=z, axis=-1, xp=xp)
+
+        mass_integral = r_safe**2 * _trapezoid_from(
+            convergence * u[None, :], x=u, axis=-1, xp=xp
+        )
+        numerical = 2.0 * mass_integral / r_safe
+        analytic_nfw = _nfw_radial_deflection_from(
+            r=r_safe,
+            kappa_s=kappa_s,
+            scale_radius=scale_radius,
+            xp=xp,
+        )
+
+        radial_deflection = xp.where(
+            interaction_radius > 0.0,
+            numerical,
+            analytic_nfw,
+        )
+
+        return xp.where(r > 1.0e-8, radial_deflection, 0.0)
 
     @aa.decorators.to_vector_yx
     @aa.decorators.transform

--- a/autogalaxy/profiles/mass/dark/kaplinghat.py
+++ b/autogalaxy/profiles/mass/dark/kaplinghat.py
@@ -1,0 +1,280 @@
+import functools
+from typing import Tuple
+
+import numpy as np
+from scipy.integrate import quad, solve_ivp
+from scipy.optimize import brentq
+
+import autoarray as aa
+
+from autogalaxy.profiles.mass.dark.abstract import DarkProfile
+from autogalaxy.profiles.mass.dark.nfw import NFWSph
+from autogalaxy.profiles.mass.abstract.abstract import MassProfile
+
+
+@functools.lru_cache(maxsize=1)
+def _isothermal_lane_emden_table():
+    x_min = 1.0e-5
+    x_max = 200.0
+
+    def ode(x, y):
+        h, dh_dx, m = y
+        density = np.exp(-h)
+        return [dh_dx, density - 2.0 * dh_dx / x, x**2 * density]
+
+    h0 = x_min**2 / 6.0
+    dh0 = x_min / 3.0
+    m0 = x_min**3 / 3.0
+
+    x_eval = np.geomspace(x_min, x_max, 4096)
+    sol = solve_ivp(
+        ode,
+        (x_min, x_max),
+        (h0, dh0, m0),
+        t_eval=x_eval,
+        rtol=1.0e-9,
+        atol=1.0e-11,
+    )
+
+    if not sol.success:
+        raise RuntimeError("Could not tabulate the isothermal Lane-Emden solution.")
+
+    return sol.t, sol.y[0], sol.y[2]
+
+
+def _interp_lane_emden(x):
+    x_table, h_table, m_table = _isothermal_lane_emden_table()
+    x = np.asarray(x, dtype=float)
+    h = np.interp(x, x_table, h_table)
+    m = np.interp(x, x_table, m_table)
+    return h, m
+
+
+def _nfw_density_from(r, kappa_s, scale_radius):
+    x = np.maximum(r / scale_radius, 1.0e-12)
+    return (kappa_s / scale_radius) / (x * (1.0 + x) ** 2)
+
+
+def _nfw_mass_3d_within_radius_from(r, kappa_s, scale_radius):
+    x = np.maximum(r / scale_radius, 1.0e-12)
+    mass_factor = np.where(
+        x < 1.0e-4,
+        0.5 * x**2 - (2.0 / 3.0) * x**3,
+        np.log1p(x) - x / (1.0 + x),
+    )
+    return 4.0 * np.pi * (kappa_s / scale_radius) * scale_radius**3 * mass_factor
+
+
+def _matched_isothermal_parameters_from(interaction_radius, kappa_s, scale_radius):
+    rho_1 = _nfw_density_from(
+        r=interaction_radius,
+        kappa_s=kappa_s,
+        scale_radius=scale_radius,
+    )
+    mass_1 = _nfw_mass_3d_within_radius_from(
+        r=interaction_radius,
+        kappa_s=kappa_s,
+        scale_radius=scale_radius,
+    )
+
+    target = mass_1 / (4.0 * np.pi * rho_1 * interaction_radius**3)
+
+    x_table, h_table, m_table = _isothermal_lane_emden_table()
+    ratio = m_table * np.exp(h_table) / x_table**3
+
+    if target <= ratio[0]:
+        x_1 = x_table[0]
+    elif target >= ratio[-1]:
+        x_1 = x_table[-1]
+    else:
+        x_1 = brentq(
+            lambda x: (
+                np.interp(x, x_table, m_table)
+                * np.exp(np.interp(x, x_table, h_table))
+                / x**3
+                - target
+            ),
+            x_table[0],
+            x_table[-1],
+        )
+
+    h_1 = np.interp(x_1, x_table, h_table)
+    central_density = rho_1 * np.exp(h_1)
+    isothermal_radius = interaction_radius / x_1
+
+    return central_density, isothermal_radius
+
+
+class KaplinghatCoredNFWSph(MassProfile, DarkProfile):
+    r"""
+    Spherical SIDM-motivated cored-NFW halo following the Kaplinghat, Tulin
+    and Yu (2016) isothermal-Jeans construction.
+
+    The profile is NFW outside ``interaction_radius``. Inside that radius it
+    uses the self-gravitating isothermal solution of the spherical Jeans-Poisson
+    equation, matched to the NFW envelope in both density and enclosed mass.
+    """
+
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        kappa_s: float = 0.05,
+        scale_radius: float = 1.0,
+        sigma_over_m: float = 1.0,
+        t_age: float = 10.0,
+        interaction_radius: float = None,
+    ):
+        super().__init__(centre=centre, ell_comps=(0.0, 0.0))
+
+        self.kappa_s = kappa_s
+        self.scale_radius = scale_radius
+        self.sigma_over_m = sigma_over_m
+        self.t_age = t_age
+
+        if interaction_radius is None:
+            strength = max(float(sigma_over_m) * float(t_age), 0.0)
+            interaction_radius = scale_radius * strength / (100.0 + strength)
+
+        self.interaction_radius = max(float(interaction_radius), 0.0)
+
+        if self.interaction_radius > 0.0:
+            (
+                self.central_density,
+                self.isothermal_radius,
+            ) = _matched_isothermal_parameters_from(
+                interaction_radius=self.interaction_radius,
+                kappa_s=self.kappa_s,
+                scale_radius=self.scale_radius,
+            )
+        else:
+            self.central_density = np.inf
+            self.isothermal_radius = 0.0
+
+        self._nfw = NFWSph(
+            centre=(0.0, 0.0),
+            kappa_s=kappa_s,
+            scale_radius=scale_radius,
+        )
+
+    def _density_3d_from_radius(self, radii):
+        radii = np.asarray(radii, dtype=float)
+
+        nfw_density = _nfw_density_from(
+            r=radii,
+            kappa_s=self.kappa_s,
+            scale_radius=self.scale_radius,
+        )
+
+        if self.interaction_radius <= 0.0:
+            return nfw_density
+
+        x = np.maximum(radii / self.isothermal_radius, 1.0e-5)
+        h, _ = _interp_lane_emden(x)
+        iso_density = self.central_density * np.exp(-h)
+
+        return np.where(radii < self.interaction_radius, iso_density, nfw_density)
+
+    def density_3d_func(self, r, xp=np):
+        radii = r.array if hasattr(r, "array") else r
+        if xp is not np:
+            radii = np.asarray(radii)
+        return self._density_3d_from_radius(radii)
+
+    def convergence_func(self, grid_radius, xp=np):
+        radii = (
+            grid_radius.array
+            if hasattr(grid_radius, "array")
+            else np.asarray(grid_radius)
+        )
+        scalar_input = np.ndim(radii) == 0
+        radii = np.atleast_1d(np.asarray(radii, dtype=float))
+
+        if self.interaction_radius <= 0.0:
+            values = self._nfw.convergence_func(aa.ArrayIrregular(radii), xp=np)
+            return values[0] if scalar_input else values
+
+        z_max = max(500.0 * self.scale_radius, 50.0 * self.interaction_radius)
+
+        def convergence_at_radius(radius):
+            radius = float(max(radius, 1.0e-8))
+            integral = quad(
+                lambda z: self._density_3d_from_radius(np.sqrt(radius**2 + z**2)),
+                0.0,
+                z_max,
+                epsrel=1.0e-5,
+                limit=100,
+            )[0]
+            return 2.0 * integral
+
+        convergence = np.array([convergence_at_radius(radius) for radius in radii])
+        return convergence[0] if scalar_input else convergence
+
+    @aa.over_sample
+    @aa.decorators.to_array
+    @aa.decorators.transform
+    def convergence_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
+        radii = self.radial_grid_from(grid=grid, xp=np, **kwargs)
+        return self.convergence_func(grid_radius=radii, xp=np)
+
+    def radial_deflection_from_radius(self, radius):
+        radius = float(radius)
+
+        if radius <= 1.0e-8:
+            return 0.0
+
+        if self.interaction_radius <= 0.0:
+            return float(
+                np.sqrt(
+                    np.sum(
+                        self._nfw.deflections_yx_2d_from(
+                            grid=aa.Grid2DIrregular([[radius, 0.0]])
+                        ).array[0]
+                        ** 2.0
+                    )
+                )
+            )
+
+        mass_2d = quad(
+            lambda r: self.convergence_func(aa.ArrayIrregular([r]))[0] * r,
+            0.0,
+            radius,
+            epsrel=1.0e-4,
+            limit=100,
+        )[0]
+        return 2.0 * mass_2d / radius
+
+    @aa.decorators.to_vector_yx
+    @aa.decorators.transform
+    def deflections_yx_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
+        theta = self.radial_grid_from(grid=grid, xp=np, **kwargs).array
+        deflection_r = np.array(
+            [self.radial_deflection_from_radius(radius) for radius in theta]
+        )
+
+        return self._cartesian_grid_via_radial_from(
+            grid=grid,
+            radius=deflection_r,
+            xp=np,
+            **kwargs,
+        )
+
+    @aa.over_sample
+    @aa.decorators.to_array
+    @aa.decorators.transform
+    def potential_2d_from(self, grid: aa.type.Grid2DLike, xp=np, **kwargs):
+        theta = self.radial_grid_from(grid=grid, xp=np, **kwargs).array
+
+        potential = np.array(
+            [
+                quad(
+                    self.radial_deflection_from_radius,
+                    0.0,
+                    max(float(radius), 1.0e-8),
+                    epsrel=1.0e-4,
+                    limit=100,
+                )[0]
+                for radius in theta
+            ]
+        )
+
+        return potential

--- a/autogalaxy/profiles/mass/dark/kaplinghat_mcr.py
+++ b/autogalaxy/profiles/mass/dark/kaplinghat_mcr.py
@@ -1,0 +1,135 @@
+from typing import Tuple
+
+import numpy as np
+from scipy.optimize import brentq
+
+from autogalaxy.profiles.mass.dark import mcr_util
+from autogalaxy.profiles.mass.dark.kaplinghat import KaplinghatCoredNFWSph
+
+
+MSUN_G = 1.98847e33
+KPC_CM = 3.0856775814913673e21
+GYR_S = 3.15576e16
+G_KPC_KM2_S2_MSUN = 4.30091727003628e-6
+
+
+def _nfw_physical_density_from(radius_kpc, rho_s, scale_radius_kpc):
+    x = np.maximum(radius_kpc / scale_radius_kpc, 1.0e-12)
+    return rho_s / (x * (1.0 + x) ** 2)
+
+
+def _nfw_physical_mass_from(radius_kpc, rho_s, scale_radius_kpc):
+    x = np.maximum(radius_kpc / scale_radius_kpc, 1.0e-12)
+    mass_factor = np.where(
+        x < 1.0e-4,
+        0.5 * x**2 - (2.0 / 3.0) * x**3,
+        np.log1p(x) - x / (1.0 + x),
+    )
+    return 4.0 * np.pi * rho_s * scale_radius_kpc**3 * mass_factor
+
+
+def _interaction_radius_kpc_from(
+    sigma_over_m,
+    t_age,
+    rho_s,
+    scale_radius_kpc,
+    radius_at_200,
+):
+    if sigma_over_m <= 0.0 or t_age <= 0.0:
+        return 0.0
+
+    t_seconds = t_age * GYR_S
+
+    def rate_times_age(radius_kpc):
+        density = _nfw_physical_density_from(
+            radius_kpc=radius_kpc,
+            rho_s=rho_s,
+            scale_radius_kpc=scale_radius_kpc,
+        )
+        mass = _nfw_physical_mass_from(
+            radius_kpc=radius_kpc,
+            rho_s=rho_s,
+            scale_radius_kpc=scale_radius_kpc,
+        )
+        velocity_km_s = np.sqrt(
+            G_KPC_KM2_S2_MSUN * mass / np.maximum(radius_kpc, 1.0e-12)
+        )
+        density_g_cm3 = density * MSUN_G / KPC_CM**3
+        velocity_cm_s = velocity_km_s * 1.0e5
+
+        return sigma_over_m * density_g_cm3 * velocity_cm_s * t_seconds
+
+    r_min = min(scale_radius_kpc * 1.0e-8, radius_at_200 * 1.0e-10)
+    r_max = radius_at_200
+
+    if rate_times_age(r_min) < 1.0:
+        return 0.0
+
+    if rate_times_age(r_max) > 1.0:
+        return r_max
+
+    return brentq(lambda r: rate_times_age(r) - 1.0, r_min, r_max)
+
+
+class KaplinghatCoredNFWMCRLudlowSph(KaplinghatCoredNFWSph):
+    def __init__(
+        self,
+        centre: Tuple[float, float] = (0.0, 0.0),
+        mass_at_200: float = 1e9,
+        sigma_over_m: float = 1.0,
+        t_age: float = 10.0,
+        redshift_object: float = 0.5,
+        redshift_source: float = 1.0,
+    ):
+        self.mass_at_200 = mass_at_200
+        self.sigma_over_m = sigma_over_m
+        self.t_age = t_age
+        self.redshift_object = redshift_object
+        self.redshift_source = redshift_source
+
+        (
+            concentration,
+            cosmic_average_density,
+            critical_surface_density,
+            kpc_per_arcsec,
+        ) = mcr_util.ludlow16_cosmology(
+            mass_at_200=mass_at_200,
+            redshift_object=redshift_object,
+            redshift_source=redshift_source,
+            xp=np,
+        )
+
+        radius_at_200 = (
+            mass_at_200 / (200.0 * cosmic_average_density * (4.0 * np.pi / 3.0))
+        ) ** (1.0 / 3.0)
+        scale_radius_kpc = radius_at_200 / concentration
+
+        de_c = (
+            200.0
+            / 3.0
+            * (
+                concentration**3
+                / (np.log(1.0 + concentration) - concentration / (1.0 + concentration))
+            )
+        )
+        rho_s = cosmic_average_density * de_c
+        kappa_s = rho_s * scale_radius_kpc / critical_surface_density
+        scale_radius = scale_radius_kpc / kpc_per_arcsec
+
+        interaction_radius_kpc = _interaction_radius_kpc_from(
+            sigma_over_m=sigma_over_m,
+            t_age=t_age,
+            rho_s=rho_s,
+            scale_radius_kpc=scale_radius_kpc,
+            radius_at_200=radius_at_200,
+        )
+        interaction_radius = interaction_radius_kpc / kpc_per_arcsec
+
+        super().__init__(
+            centre=centre,
+            kappa_s=kappa_s,
+            scale_radius=scale_radius,
+            sigma_over_m=sigma_over_m,
+            t_age=t_age,
+            interaction_radius=interaction_radius,
+        )

--- a/test_autogalaxy/profiles/mass/dark/test_kaplinghat.py
+++ b/test_autogalaxy/profiles/mass/dark/test_kaplinghat.py
@@ -59,6 +59,82 @@ def test__lensing_quantities_are_finite_and_positive():
     assert deflections[0] == pytest.approx(np.array([0.0, 0.0]), abs=1.0e-8)
 
 
+def test__vmapped_deflections_match_instance_path_for_zero_interaction():
+    profile = ag.mp.KaplinghatCoredNFWSph(
+        centre=(0.1, -0.2),
+        kappa_s=0.2,
+        scale_radius=2.0,
+        interaction_radius=0.0,
+    )
+    grid = np.array([[0.5, 0.2], [1.0, -0.2], [2.0, 1.0]])
+
+    params = np.array(
+        [
+            [
+                profile.centre[0],
+                profile.centre[1],
+                profile.kappa_s,
+                profile.scale_radius,
+                profile.interaction_radius,
+                profile.central_density,
+                profile.isothermal_radius,
+            ]
+        ]
+    )
+    mask = np.array([True])
+
+    vmapped = ag.mp.KaplinghatCoredNFWSph.vmapped_deflections_from(
+        grid=grid,
+        params_batch=params,
+        mask=mask,
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(vmapped),
+        profile.deflections_yx_2d_from(grid=ag.Grid2DIrregular(grid)).array,
+        rtol=1.0e-6,
+        atol=1.0e-8,
+    )
+
+
+def test__vmapped_deflections_match_instance_path_for_sidm_core():
+    profile = ag.mp.KaplinghatCoredNFWSph(
+        centre=(0.1, -0.2),
+        kappa_s=0.2,
+        scale_radius=2.0,
+        interaction_radius=0.5,
+    )
+    grid = np.array([[0.5, 0.2], [1.0, -0.2], [2.0, 1.0]])
+
+    params = np.array(
+        [
+            [
+                profile.centre[0],
+                profile.centre[1],
+                profile.kappa_s,
+                profile.scale_radius,
+                profile.interaction_radius,
+                profile.central_density,
+                profile.isothermal_radius,
+            ]
+        ]
+    )
+    mask = np.array([True])
+
+    vmapped = ag.mp.KaplinghatCoredNFWSph.vmapped_deflections_from(
+        grid=grid,
+        params_batch=params,
+        mask=mask,
+    )
+
+    np.testing.assert_allclose(
+        np.asarray(vmapped),
+        profile.deflections_yx_2d_from(grid=ag.Grid2DIrregular(grid)).array,
+        rtol=5.0e-2,
+        atol=1.0e-3,
+    )
+
+
 def test__mcr_constructor_reduces_to_nfw_when_interaction_is_zero():
     kaplinghat = ag.mp.KaplinghatCoredNFWMCRLudlowSph(
         centre=(1.0, 2.0),

--- a/test_autogalaxy/profiles/mass/dark/test_kaplinghat.py
+++ b/test_autogalaxy/profiles/mass/dark/test_kaplinghat.py
@@ -1,0 +1,97 @@
+import numpy as np
+import pytest
+
+import autogalaxy as ag
+
+
+def test__zero_interaction_limit_matches_nfw():
+    kaplinghat = ag.mp.KaplinghatCoredNFWSph(
+        centre=(0.1, -0.2),
+        kappa_s=0.2,
+        scale_radius=2.0,
+        sigma_over_m=0.0,
+        t_age=10.0,
+    )
+    nfw = ag.mp.NFWSph(centre=(0.1, -0.2), kappa_s=0.2, scale_radius=2.0)
+
+    grid = ag.Grid2DIrregular([[0.5, 0.2], [1.0, -0.2], [2.0, 1.0]])
+
+    assert kaplinghat.convergence_2d_from(grid=grid) == pytest.approx(
+        nfw.convergence_2d_from(grid=grid).array,
+        rel=1.0e-8,
+    )
+    assert kaplinghat.deflections_yx_2d_from(grid=grid) == pytest.approx(
+        nfw.deflections_yx_2d_from(grid=grid).array,
+        rel=1.0e-8,
+    )
+
+
+def test__density_and_mass_match_nfw_at_interaction_radius():
+    profile = ag.mp.KaplinghatCoredNFWSph(
+        kappa_s=0.2,
+        scale_radius=2.0,
+        interaction_radius=0.4,
+    )
+
+    eps = 1.0e-5
+    density_inside = profile.density_3d_func(ag.ArrayIrregular([0.4 * (1.0 - eps)]))[0]
+    density_outside = profile.density_3d_func(ag.ArrayIrregular([0.4 * (1.0 + eps)]))[0]
+
+    assert density_inside == pytest.approx(density_outside, rel=1.0e-3)
+
+
+def test__lensing_quantities_are_finite_and_positive():
+    profile = ag.mp.KaplinghatCoredNFWSph(
+        kappa_s=0.2,
+        scale_radius=2.0,
+        interaction_radius=0.5,
+    )
+    grid = ag.Grid2DIrregular([[0.0, 0.0], [0.2, 0.0], [1.0, 0.0]])
+
+    convergence = np.asarray(profile.convergence_2d_from(grid=grid).array)
+    deflections = np.asarray(profile.deflections_yx_2d_from(grid=grid).array)
+    potential = np.asarray(profile.potential_2d_from(grid=grid).array)
+
+    assert np.isfinite(convergence).all()
+    assert np.isfinite(deflections).all()
+    assert np.isfinite(potential).all()
+    assert (convergence > 0.0).all()
+    assert deflections[0] == pytest.approx(np.array([0.0, 0.0]), abs=1.0e-8)
+
+
+def test__mcr_constructor_reduces_to_nfw_when_interaction_is_zero():
+    kaplinghat = ag.mp.KaplinghatCoredNFWMCRLudlowSph(
+        centre=(1.0, 2.0),
+        mass_at_200=1.0e9,
+        sigma_over_m=0.0,
+        t_age=10.0,
+        redshift_object=0.6,
+        redshift_source=2.5,
+    )
+    nfw = ag.mp.NFWSph(
+        centre=(1.0, 2.0),
+        kappa_s=kaplinghat.kappa_s,
+        scale_radius=kaplinghat.scale_radius,
+    )
+
+    grid = ag.Grid2DIrregular([[1.0, 1.0], [2.0, 2.0]])
+
+    assert kaplinghat.interaction_radius == 0.0
+    assert kaplinghat.deflections_yx_2d_from(grid=grid) == pytest.approx(
+        nfw.deflections_yx_2d_from(grid=grid).array,
+        rel=1.0e-8,
+    )
+
+
+def test__mcr_constructor_with_nonzero_scattering_sets_interaction_radius():
+    profile = ag.mp.KaplinghatCoredNFWMCRLudlowSph(
+        mass_at_200=1.0e9,
+        sigma_over_m=10.0,
+        t_age=10.0,
+        redshift_object=0.6,
+        redshift_source=2.5,
+    )
+
+    assert profile.interaction_radius > 0.0
+    assert profile.isothermal_radius > 0.0
+    assert np.isfinite(profile.central_density)


### PR DESCRIPTION
## Summary
Adds a spherical Kaplinghat, Tulin & Yu-style SIDM cored-NFW dark-matter profile to PyAutoGalaxy, including a Ludlow mass-concentration constructor. The profile matches an inner self-gravitating isothermal Jeans solution to an outer NFW envelope at an interaction radius, and exposes convergence, deflection, and potential methods through the standard mass-profile surface.

## API Changes
Adds two public dark-matter mass profiles, `ag.mp.KaplinghatCoredNFWSph` and `ag.mp.KaplinghatCoredNFWMCRLudlowSph`, plus default prior configs. Existing profile APIs are unchanged. See full details below.

## Test Plan
- [x] `NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest test_autogalaxy/profiles/mass/dark/test_kaplinghat.py -q -p no:cacheprovider`
- [x] `NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest test_autogalaxy/profiles/mass/dark/test_nfw.py test_autogalaxy/profiles/mass/dark/test_cnfw.py test_autogalaxy/profiles/mass/dark/test_nfw_mcr.py test_autogalaxy/profiles/mass/dark/test_kaplinghat.py -q -p no:cacheprovider`
- [x] `NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest test_autogalaxy/ -x -q -p no:cacheprovider`

<details>
<summary>Full API Changes (for automation & release notes)</summary>

### Added
- `autogalaxy.profiles.mass.dark.kaplinghat.KaplinghatCoredNFWSph` — spherical SIDM-motivated cored-NFW profile with an inner isothermal Jeans solution matched to an outer NFW envelope.
- `autogalaxy.profiles.mass.dark.kaplinghat_mcr.KaplinghatCoredNFWMCRLudlowSph` — Ludlow MCR constructor deriving NFW envelope parameters and the scattering interaction radius from `mass_at_200`, `sigma_over_m`, `t_age`, and redshifts.
- `ag.mp.KaplinghatCoredNFWSph` and `ag.mp.KaplinghatCoredNFWMCRLudlowSph` exports.
- Default prior config files for both new profiles under `autogalaxy/config/priors/mass/dark/`.

### Changed Behaviour
- None for existing profiles.

### Migration
- No migration needed. Existing NFW, cNFW, and MCR profile APIs are unchanged.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)