### PR TITLE
docs: add signpost llms.txt + consolidate agent instructions into AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,28 +1,9 @@
 # Copilot Coding Agent Instructions
 
-You are working on **PyAutoGalaxy**, a Bayesian galaxy morphology fitting library.
+You are working on **PyAutoGalaxy**, a Bayesian galaxy-morphology fitting library
+(package `autogalaxy`).
 
-## Key Rules
-
-- Run tests after every change: `python -m pytest test_autogalaxy/`
-- Format code with `black autogalaxy/`
-- All files must use Unix line endings (LF, `\n`)
-- Decorated functions (`@to_array`, `@to_grid`, `@to_vector_yx`) must return **raw arrays**, not autoarray wrappers
-- The `xp` parameter controls NumPy (`xp=np`) vs JAX (`xp=jnp`) — never import JAX at module level
-- Functions called inside `jax.jit` must guard autoarray wrapping with `if xp is np:`
-- Use `grid.array[:, 0]` to access grid coordinates (not `grid[:, 0]`)
-- If changing public API, clearly document what changed in your PR description — downstream packages depend on this
-
-## Architecture
-
-- `autogalaxy/profiles/` — Light profiles (`lp.*`), mass profiles (`mp.*`), linear profiles (`lp_linear.*`)
-- `autogalaxy/galaxy/` — `Galaxy`, `Galaxies` classes
-- `autogalaxy/imaging/`, `interferometer/`, `ellipse/` — Dataset-specific fit and analysis classes
-- `autogalaxy/operate/` — `OperateImage`, `OperateDeflections`, `LensCalc` mixins
-- `test_autogalaxy/` — Test suite
-
-## Sandboxed runs
-
-```bash
-NUMBA_CACHE_DIR=/tmp/numba_cache MPLCONFIGDIR=/tmp/matplotlib python -m pytest test_autogalaxy/
-```
+The canonical, agent-agnostic instructions for this repo live in **`AGENTS.md`** at
+the repository root — build and test commands, architecture, and the JAX / `xp` and
+grid-decorator conventions. Read it directly (Copilot does not process `@`-imports)
+and treat it as the single source of truth.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,20 @@
+# PyAutoGalaxy
+
+> PyAutoGalaxy (package `autogalaxy`) is a Bayesian galaxy-morphology fitting library — light/mass profiles, `Galaxy`/`Galaxies`, per-dataset `Fit`/`Analysis` classes, and inversions for linear profiles and pixelizations. This file is a signpost: it points you to the right resource by intent — use the API, learn it, or work on the library itself.
+
+## Use it (examples & tutorials)
+
+- [autogalaxy_workspace navigator](https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/llms.txt): end-to-end example scripts and notebooks per science case — the paste-friendly task router. Send any "how do I model / simulate / analyse X?" question here.
+- [HowToGalaxy](https://github.com/PyAutoLabs/HowToGalaxy): from-first-principles lecture series on galaxy morphology and Bayesian fitting.
+
+## API reference & docs
+
+- [PyAutoGalaxy documentation (ReadTheDocs)](https://pyautogalaxy.readthedocs.io/en/latest/): API reference, feature overviews, and the installation guide.
+
+## Work on it (contributors / coding agents)
+
+- [AGENTS.md](./AGENTS.md): build, tests, architecture, and the JAX / decorator conventions.
+
+## Ecosystem
+
+- Built on PyAutoArray (data structures) + PyAutoFit (inference) + PyAutoConf (config); used by PyAutoLens, which builds multi-plane lensing on it.


### PR DESCRIPTION
## Summary

Two docs-only changes, mirroring the PyAutoLens treatment:

1. **Consolidate agent instructions into canonical `AGENTS.md`** — reduce `.github/copilot-instructions.md` to a thin pointer to `AGENTS.md` (the single source of truth; `CLAUDE.md` already `@`-imports it), dropping content duplicated in or superseded by `AGENTS.md` (including stale decorator names / module maps where present).
2. **Add a signpost `llms.txt`** at the repo root — a thin front door (llms.txt convention: H1 + blockquote, then sections of one-line links) routing an LLM by intent. It only points; no source-tree catalogue, no AGENTS.md/docs duplication.

All links verified live (PyAutoLabs org; workspace `llms.txt` on `origin/main`; docs URLs from README / `.readthedocs.yaml`).

## Scripts Changed
None — docs only.

## API Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)