### PR TITLE
test: skip jax-backed unit tests when jax is absent (Python matrix)

### DIFF
--- a/test_autogalaxy/profiles/mass/dark/test_kaplinghat.py
+++ b/test_autogalaxy/profiles/mass/dark/test_kaplinghat.py
@@ -1,7 +1,17 @@
+import importlib.util
+
 import numpy as np
 import pytest
 
 import autogalaxy as ag
+
+# The `vmapped_deflections_from` path is jax-backed; these tests need jax
+# installed to run (it ships via the `[optional]` extras). The NumPy-only
+# Python-version matrix has no jax, so skip there rather than fail.
+requires_jax = pytest.mark.skipif(
+    importlib.util.find_spec("jax") is None,
+    reason="requires jax (installed via the [optional] extras; absent on the NumPy-only matrix env)",
+)
 
 
 def test__zero_interaction_limit_matches_nfw():
@@ -59,6 +69,7 @@ def test__lensing_quantities_are_finite_and_positive():
     assert deflections[0] == pytest.approx(np.array([0.0, 0.0]), abs=1.0e-8)
 
 
+@requires_jax
 def test__vmapped_deflections_match_instance_path_for_zero_interaction():
     profile = ag.mp.KaplinghatCoredNFWSph(
         centre=(0.1, -0.2),
@@ -97,6 +108,7 @@ def test__vmapped_deflections_match_instance_path_for_zero_interaction():
     )
 
 
+@requires_jax
 def test__vmapped_deflections_match_instance_path_for_sidm_core():
     profile = ag.mp.KaplinghatCoredNFWSph(
         centre=(0.1, -0.2),


### PR DESCRIPTION
## Summary

Part of getting the PyAutoBuild **Python Version Matrix** green. A set of unit tests exercise **jax-only code paths** (vmapped profiles, blackjax NUTS, the NUFFT sparse operator, `use_jax=True`) that need jax installed to run. jax ships via the `[optional]` extras and is present in the per-repo CI (3.12/3.13), so these pass there — but the Python Version Matrix installs the NumPy-only stack (and jax cannot install on 3.9 at all), so they failed with `ModuleNotFoundError: No module named 'jax'`.

Guards the affected tests with `pytest.mark.skipif(importlib.util.find_spec("jax") is None, ...)`. NumPy-only tests in the same files are untouched. Aligns with the repo doctrine "unit tests are NumPy-only; JAX validated in workspace_test".

## Verification
- **jax absent** (clean 2026.7.9.1 venv, no `[optional]`): guarded tests **skip**, all other tests pass.
- **jax present** (dev env): all files collect cleanly, nothing skipped.

Paired across PyAutoArray / PyAutoFit / PyAutoGalaxy / PyAutoLens (`feature/matrix-jax-skip`); test-only, no library source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)