### PR TITLE
refactor!: depend on and import `autonerves` (renamed from autoconf)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ inversions for linear profiles/pixelizations, and adapt-image multi-stage
 fitting.
 
 Dependency direction: autogalaxy may import **autoarray** (data structures),
-**autofit** (model-fitting), and **autoconf** (config). It must **never**
+**autofit** (model-fitting), and **autonerves** (config). It must **never**
 import `autolens` — lensing lives one layer up.
 
 ## Related repos
@@ -52,7 +52,7 @@ is no black/ruff/flake8 gate — formatting is advisory. (`requires-python` in
 
 ## Configuration & defaults
 
-autoconf supplies the packaged defaults under `autogalaxy/config/`. Workspaces
+autonerves supplies the packaged defaults under `autogalaxy/config/`. Workspaces
 override them via their own `config/` directory; the test suite pushes a local
 config dir via `conf.instance.push(...)` in `test_autogalaxy/conftest.py`. When
 a change adds a new config key, mirror it into the packaged defaults so
@@ -91,7 +91,7 @@ Profiles are namespaced there (`ag.lp.*`, `ag.lp_linear.*`, `ag.mp.*`,
 
 ## Key rules / footguns
 
-- Import direction: autoarray / autofit / autoconf only — **never** `autolens`.
+- Import direction: autoarray / autofit / autonerves only — **never** `autolens`.
 - Operate mixins are `OperateImage` (`operate/image.py`) and `LensCalc`
   (`operate/lens_calc.py`). There is no `OperateDeflections` / `operate/
   deflections.py`.

--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -1,10 +1,10 @@
-from autoconf import jax_wrapper
-from autoconf.dictable import register_parser
+from autonerves import jax_wrapper
+from autonerves.dictable import register_parser
 from autofit import conf
 
 conf.instance.register(__file__)
 
-from autoconf.dictable import from_dict, from_json, output_to_json, to_dict
+from autonerves.dictable import from_dict, from_json, output_to_json, to_dict
 from autoarray.dataset import preprocess  # noqa
 
 from autoarray.dataset.imaging.dataset import Imaging  # noqa
@@ -121,16 +121,16 @@ from . import cosmology as cosmo
 from .gui.clicker import Clicker
 from .gui.scribbler import Scribbler
 
-from autoconf import conf
-from autoconf.fitsable import ndarray_via_hdu_from
-from autoconf.fitsable import ndarray_via_fits_from
-from autoconf.fitsable import header_obj_from
-from autoconf.fitsable import output_to_fits
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves import conf
+from autonerves.fitsable import ndarray_via_hdu_from
+from autonerves.fitsable import ndarray_via_fits_from
+from autonerves.fitsable import header_obj_from
+from autonerves.fitsable import output_to_fits
+from autonerves.fitsable import hdu_list_for_output_from
 
 __version__ = "2026.7.9.1"
 
-from autoconf import check_version
+from autonerves import check_version
 
 check_version(__version__)
 
@@ -150,28 +150,28 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 # ---------------------------------------------------------------------------
-# Public re-export of the autoconf configuration / serialization surface.
+# Public re-export of the autonerves configuration / serialization surface.
 #
 # Workspaces, tutorials and downstream code import these names from the science
 # library (e.g. ``from autolens import conf``) rather than depending on the
-# ``autoconf`` package directly, so the underlying configuration / serialization
+# ``autonerves`` package directly, so the underlying configuration / serialization
 # layer stays an implementation detail of the library.
 # ---------------------------------------------------------------------------
-from autoconf import conf
-from autoconf import jax_wrapper
-from autoconf import fitsable
-from autoconf import setup_colab
-from autoconf import setup_notebook
-from autoconf.conf import with_config
-from autoconf.dictable import from_dict, from_json, to_dict, output_to_json
-from autoconf.fitsable import (
+from autonerves import conf
+from autonerves import jax_wrapper
+from autonerves import fitsable
+from autonerves import setup_colab
+from autonerves import setup_notebook
+from autonerves.conf import with_config
+from autonerves.dictable import from_dict, from_json, to_dict, output_to_json
+from autonerves.fitsable import (
     output_to_fits,
     hdu_list_for_output_from,
     ndarray_via_fits_from,
     ndarray_via_hdu_from,
     header_obj_from,
 )
-from autoconf.test_mode import (
+from autonerves.test_mode import (
     with_test_mode_segment,
     skip_visualization,
     skip_fit_output,

--- a/autogalaxy/aggregator/agg_util.py
+++ b/autogalaxy/aggregator/agg_util.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import numpy as np
 from typing import List, Optional
 
-from autoconf.fitsable import ndarray_via_hdu_from
+from autonerves.fitsable import ndarray_via_hdu_from
 
 import autofit as af
 import autoarray as aa

--- a/autogalaxy/aggregator/imaging/imaging.py
+++ b/autogalaxy/aggregator/imaging/imaging.py
@@ -16,7 +16,7 @@ Two public objects are provided:
 from functools import partial
 from typing import List
 
-from autoconf.fitsable import ndarray_via_hdu_from
+from autonerves.fitsable import ndarray_via_hdu_from
 
 import autofit as af
 import autoarray as aa

--- a/autogalaxy/analysis/adapt_images/adapt_images.py
+++ b/autogalaxy/analysis/adapt_images/adapt_images.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 import numpy as np
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
-from autoconf import conf
-from autoconf import cached_property
+from autonerves import conf
+from autonerves import cached_property
 
 import autoarray as aa
 
@@ -41,7 +41,7 @@ def _galaxy_image_dict_from_cache(cache_path) -> Optional[Dict]:
     from astropy.io import fits as astropy_fits
 
     from autoarray.mask.mask_2d import Mask2DKeys
-    from autoconf.fitsable import ndarray_via_hdu_from
+    from autonerves.fitsable import ndarray_via_hdu_from
 
     if cache_path is None or not cache_path.exists():
         return None
@@ -82,7 +82,7 @@ def _galaxy_image_dict_to_cache(cache_path, galaxy_name_image_dict: Dict, paths)
     the same FITS layout ``_galaxy_image_dict_from_cache`` reads, and preserve
     it in the search's zip archive so later resumes keep it.
     """
-    from autoconf.fitsable import hdu_list_for_output_from
+    from autonerves.fitsable import hdu_list_for_output_from
 
     image_list = [
         galaxy_name_image_dict[name].native_for_fits

--- a/autogalaxy/analysis/analysis/dataset.py
+++ b/autogalaxy/analysis/analysis/dataset.py
@@ -2,7 +2,7 @@ import logging
 import numpy as np
 from typing import Optional, Union
 
-from autoconf.dictable import to_dict, output_to_json
+from autonerves.dictable import to_dict, output_to_json
 
 import autofit as af
 import autoarray as aa

--- a/autogalaxy/analysis/chaining_util.py
+++ b/autogalaxy/analysis/chaining_util.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 from pathlib import Path
 
-from autoconf import conf
-from autoconf.dictable import from_json, output_to_json
+from autonerves import conf
+from autonerves.dictable import from_json, output_to_json
 
 import autoarray as aa
 import autofit as af

--- a/autogalaxy/analysis/jax_pytrees.py
+++ b/autogalaxy/analysis/jax_pytrees.py
@@ -20,7 +20,7 @@ def register_galaxies_pytree() -> None:
     calls (e.g. from each ``Analysis*.fit_from``) are cheap.
     """
     from autoarray.abstract_ndarray import _pytree_registered_classes
-    from autoconf.jax_wrapper import register_pytree_node
+    from autonerves.jax_wrapper import register_pytree_node
     from autogalaxy.galaxy.galaxies import Galaxies
 
     if Galaxies in _pytree_registered_classes:

--- a/autogalaxy/analysis/plotter.py
+++ b/autogalaxy/analysis/plotter.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from autoarray.plot.output import Output
 
-from autoconf import conf
+from autonerves import conf
 
 import autoarray as aa
 

--- a/autogalaxy/analysis/result.py
+++ b/autogalaxy/analysis/result.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Tuple, Type, Union
 
 from typing import TYPE_CHECKING
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 import autofit as af
 import autoarray as aa

--- a/autogalaxy/ellipse/dataset_interp.py
+++ b/autogalaxy/ellipse/dataset_interp.py
@@ -1,7 +1,7 @@
 import numpy as np
 from typing import Tuple
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 import autoarray as aa
 

--- a/autogalaxy/ellipse/fit_ellipse.py
+++ b/autogalaxy/ellipse/fit_ellipse.py
@@ -19,7 +19,7 @@ type of `AnalysisEllipse.fit_from`, mirroring the single-object return of `Analy
 import numpy as np
 from typing import List, Optional
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 import autoarray as aa
 

--- a/autogalaxy/ellipse/model/plotter.py
+++ b/autogalaxy/ellipse/model/plotter.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 
 import autoarray as aa
 

--- a/autogalaxy/galaxy/galaxies.py
+++ b/autogalaxy/galaxy/galaxies.py
@@ -13,7 +13,7 @@ then passed to a `Fit*` class (e.g. `FitImaging`) for comparison against the obs
 import numpy as np
 from typing import Dict, List, Optional, Tuple, Type, Union
 
-from autoconf import conf
+from autonerves import conf
 import autoarray as aa
 
 from autogalaxy.galaxy.galaxy import Galaxy

--- a/autogalaxy/galaxy/galaxy.py
+++ b/autogalaxy/galaxy/galaxy.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional, Type, Union
 
 import numpy as np
 
-from autoconf.dictable import instance_as_dict, to_dict
+from autonerves.dictable import instance_as_dict, to_dict
 
 import autoarray as aa
 import autofit as af

--- a/autogalaxy/galaxy/galaxy_model_csv.py
+++ b/autogalaxy/galaxy/galaxy_model_csv.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
-from autoconf import csvable
+from autonerves import csvable
 
 from autogalaxy.galaxy.galaxy import Galaxy
 from autogalaxy.profiles import mass as _mp_module

--- a/autogalaxy/galaxy/galaxy_table.py
+++ b/autogalaxy/galaxy/galaxy_table.py
@@ -18,7 +18,7 @@ The ``redshift`` column is optional. Any further numeric columns (e.g. ``ellipti
 ``GalaxyTable.properties`` keyed by column name — nothing is silently dropped. Row order
 is preserved on read and on write.
 
-The actual CSV I/O is delegated to :mod:`autoconf.csvable`; this module only owns the
+The actual CSV I/O is delegated to :mod:`autonerves.csvable`; this module only owns the
 column-name conventions and the typed return value.
 
 The mirror schema for point-source datasets lives in :mod:`autolens.point.dataset` (see its
@@ -30,7 +30,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
-from autoconf import csvable
+from autonerves import csvable
 
 from autoarray.structures.grids.irregular_2d import Grid2DIrregular
 

--- a/autogalaxy/galaxy/plot/adapt_plots.py
+++ b/autogalaxy/galaxy/plot/adapt_plots.py
@@ -86,7 +86,7 @@ def fits_adapt_images(adapt_images, output_path) -> None:
     """
     import numpy as np
     from pathlib import Path
-    from autoconf.fitsable import hdu_list_for_output_from
+    from autonerves.fitsable import hdu_list_for_output_from
 
     output_path = Path(output_path)
 

--- a/autogalaxy/galaxy/plot/galaxies_plots.py
+++ b/autogalaxy/galaxy/plot/galaxies_plots.py
@@ -242,7 +242,7 @@ def fits_galaxy_images(
         Directory in which to write ``galaxy_images.fits``.
     """
     from pathlib import Path
-    from autoconf.fitsable import hdu_list_for_output_from
+    from autonerves.fitsable import hdu_list_for_output_from
 
     image_list = [galaxy.image_2d_from(grid=grid).native_for_fits for galaxy in galaxies]
     hdu_list = hdu_list_for_output_from(

--- a/autogalaxy/galaxy/to_inversion.py
+++ b/autogalaxy/galaxy/to_inversion.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import numpy as np
 from typing import Dict, List, Optional, Type, Union
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 import autoarray as aa
 

--- a/autogalaxy/imaging/fit_imaging.py
+++ b/autogalaxy/imaging/fit_imaging.py
@@ -18,7 +18,7 @@ import functools
 import numpy as np
 from typing import Dict, List, Optional
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 import autoarray as aa
 

--- a/autogalaxy/imaging/model/analysis.py
+++ b/autogalaxy/imaging/model/analysis.py
@@ -19,7 +19,7 @@ from typing import Optional
 import autofit as af
 import autoarray as aa
 
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 
 from autogalaxy.analysis.adapt_images.adapt_images import AdaptImages
 from autogalaxy.analysis.analysis.dataset import AnalysisDataset

--- a/autogalaxy/imaging/model/latent.py
+++ b/autogalaxy/imaging/model/latent.py
@@ -17,7 +17,7 @@ from typing import Callable, Dict, List, Optional
 import numpy as np
 
 import autofit as af
-from autoconf import conf
+from autonerves import conf
 
 logger = logging.getLogger(__name__)
 

--- a/autogalaxy/imaging/model/plotter.py
+++ b/autogalaxy/imaging/model/plotter.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 
 import autoarray as aa
 

--- a/autogalaxy/imaging/plot/fit_imaging_plots.py
+++ b/autogalaxy/imaging/plot/fit_imaging_plots.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import autoarray as aa
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 from autoarray.plot.utils import subplots, conf_subplot_figsize, tight_layout
 
 from autogalaxy.imaging.fit_imaging import FitImaging

--- a/autogalaxy/interferometer/fit_interferometer.py
+++ b/autogalaxy/interferometer/fit_interferometer.py
@@ -15,7 +15,7 @@ import functools
 import numpy as np
 from typing import Dict, List, Optional
 
-from autoconf import cached_property
+from autonerves import cached_property
 
 import autoarray as aa
 

--- a/autogalaxy/interferometer/model/analysis.py
+++ b/autogalaxy/interferometer/model/analysis.py
@@ -13,8 +13,8 @@ import logging
 import numpy as np
 from typing import Optional
 
-from autoconf.dictable import to_dict
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.dictable import to_dict
+from autonerves.fitsable import hdu_list_for_output_from
 
 import autofit as af
 import autoarray as aa

--- a/autogalaxy/interferometer/model/plotter.py
+++ b/autogalaxy/interferometer/model/plotter.py
@@ -2,7 +2,7 @@ import autoarray as aa
 
 from autoarray.dataset.plot.interferometer_plots import subplot_interferometer_dataset
 
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 
 from autogalaxy.interferometer.fit_interferometer import FitInterferometer
 from autogalaxy.interferometer.plot import fit_interferometer_plots

--- a/autogalaxy/interferometer/plot/fit_interferometer_plots.py
+++ b/autogalaxy/interferometer/plot/fit_interferometer_plots.py
@@ -2,7 +2,7 @@ import numpy as np
 from pathlib import Path
 
 import autoarray as aa
-from autoconf.fitsable import hdu_list_for_output_from
+from autonerves.fitsable import hdu_list_for_output_from
 from autoarray.plot import plot_visibilities_1d
 from autoarray.plot.utils import subplots, conf_subplot_figsize, tight_layout
 

--- a/autogalaxy/operate/lens_calc.py
+++ b/autogalaxy/operate/lens_calc.py
@@ -22,7 +22,7 @@ import logging
 import numpy as np
 from typing import List, Tuple, Union
 
-from autoconf import conf
+from autonerves import conf
 
 import autoarray as aa
 

--- a/autogalaxy/plot/plot_utils.py
+++ b/autogalaxy/plot/plot_utils.py
@@ -263,7 +263,7 @@ def fits_array(array, file_path, overwrite=False, ext_name=None):
     ext_name : str or None
         FITS extension name.  Auto-detected for masks (``"mask"``).
     """
-    from autoconf.fitsable import output_to_fits
+    from autonerves.fitsable import output_to_fits
 
     values, header_dict, auto_ext_name = _fits_values_and_header(array)
     if ext_name is None:
@@ -337,7 +337,7 @@ def _critical_curves_method():
     If ``"zero_contour"`` is requested but ``jax_zero_contour`` is not installed
     (e.g. Python <3.11), falls back to ``"marching_squares"`` with a warning.
     """
-    from autoconf import conf
+    from autonerves import conf
 
     try:
         method = conf.instance["visualize"]["general"]["general"]["critical_curves_method"]

--- a/autogalaxy/profiles/light/linear/abstract.py
+++ b/autogalaxy/profiles/light/linear/abstract.py
@@ -17,7 +17,7 @@ import itertools
 import numpy as np
 from typing import Dict, List, Optional
 
-from autoconf import cached_property
+from autonerves import cached_property
 import autoarray as aa
 
 from autogalaxy.profiles.light.operated.abstract import (

--- a/autogalaxy/util/plot_utils.py
+++ b/autogalaxy/util/plot_utils.py
@@ -263,7 +263,7 @@ def fits_array(array, file_path, overwrite=False, ext_name=None):
     ext_name : str or None
         FITS extension name.  Auto-detected for masks (``"mask"``).
     """
-    from autoconf.fitsable import output_to_fits
+    from autonerves.fitsable import output_to_fits
 
     values, header_dict, auto_ext_name = _fits_values_and_header(array)
     if ext_name is None:
@@ -337,7 +337,7 @@ def _critical_curves_method():
     If ``"zero_contour"`` is requested but ``jax_zero_contour`` is not installed
     (e.g. Python <3.11), falls back to ``"marching_squares"`` with a warning.
     """
-    from autoconf import conf
+    from autonerves import conf
 
     try:
         method = conf.instance["visualize"]["general"]["general"]["critical_curves_method"]

--- a/docs/general/configs.md
+++ b/docs/general/configs.md
@@ -15,7 +15,7 @@ The configuration path can also be set manually in a script using the project **
 command (the path to the `output` folder where the results of a non-linear search are stored is also set below):
 
 ```bash
-from autoconf import conf
+from autonerves import conf
 
 conf.instance.push(
     config_path="path/to/config",

--- a/docs/installation/source.md
+++ b/docs/installation/source.md
@@ -32,7 +32,7 @@ git clone https://github.com/PyAutoLabs/PyAutoGalaxy
 Next, install the **PyAuto** parent projects via pip:
 
 ```bash
-pip install autoconf
+pip install autonerves
 pip install autofit
 pip install autoarray
 ```
@@ -96,7 +96,7 @@ git clone https://github.com/PyAutoLabs/PyAutoGalaxy
 Next, install **PyAutoConf** via pip:
 
 ```bash
-pip install autoconf
+pip install autonerves
 ```
 
 Next, install the source build dependencies of each project via pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ local_scheme = "no-local-version"
 
 [project.optional-dependencies]
 jax = [
-    "autoconf[jax]",
+    "autonerves[jax]",
     "jax_zero_contour>=2.0.0,<3.0.0; python_version >= '3.11'"
 ]
 optional = [

--- a/test_autogalaxy/analysis/analysis/test_analysis.py
+++ b/test_autogalaxy/analysis/analysis/test_analysis.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from autoconf.dictable import from_json
+from autonerves.dictable import from_json
 
 import autofit as af
 import autogalaxy as ag

--- a/test_autogalaxy/conftest.py
+++ b/test_autogalaxy/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from matplotlib import pyplot
 from unittest.mock import MagicMock
 
-from autoconf import conf
+from autonerves import conf
 from autogalaxy import fixtures
 
 import logging

--- a/test_autogalaxy/galaxy/test_galaxy.py
+++ b/test_autogalaxy/galaxy/test_galaxy.py
@@ -2,7 +2,7 @@ import numpy as np
 from pathlib import Path
 import pytest
 
-from autoconf.dictable import from_json, output_to_json
+from autonerves.dictable import from_json, output_to_json
 import autogalaxy as ag
 
 from autogalaxy import exc

--- a/test_autogalaxy/profiles/test_dict.py
+++ b/test_autogalaxy/profiles/test_dict.py
@@ -1,5 +1,5 @@
 import pytest
-from autoconf.dictable import to_dict, from_dict
+from autonerves.dictable import to_dict, from_dict
 
 import autogalaxy as ag
 from autogalaxy.profiles.geometry_profiles import GeometryProfile


### PR DESCRIPTION
## What

Switch the `autoconf` dependency to its renamed form **`autonerves`**: pyproject pins and every `import autoconf` / `from autoconf` (including the config re-export block). Repo-name references (`PyAutoConf`) are unchanged — they flip with the GitHub repo rename.

⚠️ **Breaking / coordinated**: pairs with PyAutoConf#135 and the other library PRs on the **same-named branch**. CI resolves `autonerves` from the same-named PyAutoConf branch. Merge together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ciVftxvYpefh59wSkR7jN)_