### PR TITLE
docs: document the [jax] install extra; sync __version__

### DIFF
--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -128,7 +128,7 @@ from autonerves.fitsable import header_obj_from
 from autonerves.fitsable import output_to_fits
 from autonerves.fitsable import hdu_list_for_output_from
 
-__version__ = "2026.7.9.1"
+__version__ = "2026.7.22.1"
 
 from autonerves import check_version
 

--- a/autogalaxy/__init__.py
+++ b/autogalaxy/__init__.py
@@ -128,7 +128,7 @@ from autonerves.fitsable import header_obj_from
 from autonerves.fitsable import output_to_fits
 from autonerves.fitsable import hdu_list_for_output_from
 
-__version__ = "2026.7.22.1"
+__version__ = "2026.7.23.1"
 
 from autonerves import check_version
 

--- a/docs/installation/conda.md
+++ b/docs/installation/conda.md
@@ -37,8 +37,14 @@ The latest version of **PyAutoGalaxy** is installed via pip as follows (the comm
 caching issues impacting the installation):
 
 ```bash
-pip install autogalaxy --no-cache-dir
+pip install autogalaxy[jax] --no-cache-dir
 ```
+
+The `[jax]` extra installs \[**JAX**\](<https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html>), which
+**PyAutoGalaxy** uses for just-in-time compilation and GPU acceleration. **JAX is not installed by default** — to
+install without it, use `pip install autogalaxy --no-cache-dir` instead. The extra installs CPU-only JAX; for GPU
+support, follow the official \[JAX installation guide\](<https://jax.readthedocs.io/en/latest/installation.html>)
+**before** installing.
 
 If pip prints warnings about dependency version conflicts, these can usually be ignored — the instructions below
 will identify clearly if the installation is a success.

--- a/docs/installation/pip.md
+++ b/docs/installation/pip.md
@@ -24,8 +24,14 @@ The latest version of **PyAutoGalaxy** is installed via pip as follows (specifyi
 the installation has clean dependencies):
 
 ```bash
-pip install autogalaxy
+pip install autogalaxy[jax]
 ```
+
+The `[jax]` extra installs \[**JAX**\](<https://docs.jax.dev/en/latest/notebooks/thinking_in_jax.html>), which
+**PyAutoGalaxy** uses for just-in-time compilation and GPU acceleration. **JAX is not installed by default** — a
+plain `pip install autogalaxy` gives a fully working install that runs on NumPy, without JAX acceleration. The
+extra installs CPU-only JAX; for GPU support, follow the official
+\[JAX installation guide\](<https://jax.readthedocs.io/en/latest/installation.html>) **before** installing.
 
 If pip prints warnings about dependency version conflicts, these can usually be ignored — the instructions below
 will identify clearly if the installation is a success.


### PR DESCRIPTION
## Why

The install docs never mention that JAX is an optional extra. `pip install autogalaxy` installs no JAX, so users following the docs get the NumPy path with no indication that acceleration exists or how to enable it.

## Changes

- Document `pip install autogalaxy[jax]` in both pip and conda install docs, with the JAX-free variant noted.
- Clarify the extra installs CPU-only JAX; GPU needs the JAX guide first.
- Sync `__version__` to `2026.7.22.1`.

Companion to PyAutoLens#642, which fixes an actively false claim in that repo's install docs.