### PR TITLE
feat: public register_galaxies_classes, the autolens register_tracer_classes counterpart

### DIFF
--- a/autogalaxy/jax/__init__.py
+++ b/autogalaxy/jax/__init__.py
@@ -1,0 +1,1 @@
+from autogalaxy.jax.registration import register_galaxies_classes

--- a/autogalaxy/jax/registration.py
+++ b/autogalaxy/jax/registration.py
@@ -1,0 +1,111 @@
+"""Lazy JAX pytree registration for `Galaxies` and the classes it contains.
+
+When a user wraps a PyAutoGalaxy call in their own ``@jax.jit`` and the call
+receives a ``Galaxies`` as a traced argument, every concrete class reachable
+from it must be registered as a JAX pytree node so JAX can flatten and
+unflatten across the JIT boundary.
+
+This module is the counterpart of ``AnalysisImaging._register_fit_imaging_pytrees``
+(and its interferometer equivalent) for code paths that do not go through an
+``Analysis`` — custom forward models and hand-built likelihood functions.
+
+Unlike PyAutoLens's ``autolens.jax.register_tracer_classes``, which
+``PointSolver`` and ``Simulator`` call automatically, **nothing inside
+autogalaxy calls this function**: both ``Analysis`` classes already register
+their pytrees inline from ``fit_from``. It exists purely as the public entry
+point for user code, so do not remove it as unused.
+
+Mirrors PyAutoFit's ``autofit/jax/pytrees.py`` layout. Idempotent:
+re-registration of a class is a silent no-op.
+"""
+from typing import Iterable
+
+
+def register_galaxies_classes(galaxies) -> bool:
+    """Register every concrete class reachable from ``galaxies`` as a JAX pytree.
+
+    Registers ``Galaxies`` itself (via the shared
+    ``register_galaxies_pytree``, which installs the custom flatten a ``list``
+    subclass needs), then walks each galaxy and registers ``Galaxy`` plus every
+    light / mass profile class encountered.
+
+    Both halves are required. Registering ``Galaxies`` alone still fails with
+    ``TypeError: ... problematic value is of type Galaxy ... at path
+    galaxies[0]`` the first time a jitted function is handed a ``Galaxies``.
+
+    Returns ``True`` if registration ran (or was already complete), ``False``
+    if JAX is not installed (in which case the call is a silent no-op).
+    """
+    try:
+        import jax  # noqa: F401
+    except ImportError:
+        return False
+
+    from autogalaxy.analysis.jax_pytrees import register_galaxies_pytree
+
+    register_galaxies_pytree()
+
+    for galaxy in galaxies:
+        _register_object_classes(galaxy)
+
+    return True
+
+
+def _register_object_classes(obj) -> None:
+    """Walk an object recursively and register each non-builtin class it carries.
+
+    Used to register ``Galaxy`` plus every concrete profile class
+    (``Sersic``, ``Isothermal``, ``NFW``, ...) the galaxy holds. Skips builtin
+    types (numbers, strings, sequences) since those are not user classes that
+    JAX needs flatten/unflatten functions for.
+    """
+    from autoarray.abstract_ndarray import register_instance_pytree
+
+    cls = type(obj)
+    if _is_builtin(cls):
+        return
+
+    register_instance_pytree(cls)
+
+    for value in _iter_attribute_values(obj):
+        _register_object_classes(value)
+
+
+def _iter_attribute_values(obj) -> Iterable:
+    """Yield each attribute value of ``obj`` worth recursing into.
+
+    Walks ``obj.__dict__`` (if present) and recurses one level into list /
+    tuple / dict containers to reach profile objects held in collections.
+    """
+    if not hasattr(obj, "__dict__"):
+        return
+
+    for value in vars(obj).values():
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                yield item
+        elif isinstance(value, dict):
+            for item in value.values():
+                yield item
+        else:
+            yield value
+
+
+def _is_builtin(cls) -> bool:
+    """True for primitive / container / standard-library / numerical-backend
+    types that should not be registered as JAX pytrees.
+
+    Catches the JAX tracer types (``DynamicJaxprTracer`` et al.) explicitly:
+    if a walker happens to recurse into JAX-traced state (because it ran
+    inside a ``jax.jit`` trace), registering ``type(tracer)`` would make every
+    subsequent tracer-flatten call route into our dict-based flatten, which
+    fails because tracers do not have ``__dict__``.
+    """
+    if cls is type(None):
+        return True
+    module = cls.__module__
+    if module == "builtins":
+        return True
+    if module.startswith(("numpy", "jax", "jaxlib")):
+        return True
+    return False


### PR DESCRIPTION
## Summary

PyAutoLens ships `autolens.jax.register_tracer_classes(tracer)` — the public,
one-time JAX pytree registration for code paths that do **not** go through an
`Analysis`: a user's own `@jax.jit` that receives the aggregate object as a
traced argument. PyAutoGalaxy had no equivalent public entry point.

Surfaced while writing the `__Custom Likelihood Functions__` section of
`autogalaxy_workspace/scripts/guides/using_jax.py`
(PyAutoLabs/autogalaxy_workspace#181, merged): the guide could document the
`Analysis`, hand-rolled-inside-jit and `Fitness` paths, but not passing a
`Galaxies` **as a jit argument**, because no public call made it work.

## Why the existing helper wasn't enough

`autogalaxy/analysis/jax_pytrees.py::register_galaxies_pytree` registers **only**
the `Galaxies` list subclass, and is private — reached solely from the two
`Analysis` classes via `fit_from`. Measured on the installed stack with:

```python
@jax.jit
def log_likelihood(galaxies):
    return ag.FitImaging(dataset=masked_dataset, galaxies=galaxies, xp=jnp).log_likelihood
```

| Registration | Result |
|---|---|
| none | `TypeError: ... problematic value is of type Galaxies ... at path galaxies` |
| `register_galaxies_pytree()` only | still fails — `... of type Galaxy ... at path galaxies[0]` |
| both steps | works; `-270175.0553756637`, exactly the eager value |

## What this adds

- `autogalaxy/jax/__init__.py` — exports `register_galaxies_classes`, mirroring `autolens/jax/__init__.py`.
- `autogalaxy/jax/registration.py` — `register_galaxies_classes(galaxies) -> bool`, which calls the existing shared `register_galaxies_pytree()` and then walks each galaxy registering `Galaxy` and every profile class. Idempotent; returns `False` as a silent no-op when JAX is absent.

Nothing else changes: `register_galaxies_pytree`, both `Analysis` classes and
all of autolens are untouched. `autogalaxy.jax` is auto-discovered by
`[tool.setuptools.packages.find]`, so no packaging change is needed.

## Two things a reviewer should know

**1. Nothing inside autogalaxy calls this.** Unlike autolens — where
`PointSolver` and `Simulator` invoke `register_tracer_classes` automatically —
both autogalaxy `Analysis` classes already register their pytrees inline from
`fit_from`. This is purely the public entry point for user code. The module
docstring says so explicitly so it isn't later deleted as dead code.

**2. The ~60-line recursive walker is duplicated** from
`autolens/jax/registration.py` rather than shared. Deliberate, and the human's
call: it keeps this to one repo and one reversible PR instead of coupling
autolens `main` to autogalaxy `main` immediately after the `2026.7.29.2`
release. Deduping (autogalaxy would own it; autolens may import autogalaxy) is
recorded as a follow-up, not done here.

## Test Plan

- [x] `python -m pytest test_autogalaxy/` — **1009 passed**, 0 failed
- [x] Three-way probe against this branch: none → fails on `Galaxies`; `register_galaxies_pytree()` only → fails on `Galaxy`; `register_galaxies_classes(galaxies)` → works and matches the eager log likelihood exactly
- [x] Idempotent — a second call returns `True` and re-registers nothing
- [x] `import autogalaxy` does **not** eagerly import `autogalaxy.jax` (verified via `sys.modules`), so the new module adds no import cost
- [x] With `import jax` forced to raise, `register_galaxies_classes` returns `False` and does not raise

Unit tests in this repo are NumPy-only by policy, so the JAX behaviour is
validated by the probe rather than by `test_autogalaxy/`.

## Follow-ups (not in this PR)

- **Workspace guide mention** — document the jit-argument case and this call in `autogalaxy_workspace/scripts/guides/using_jax.py`, matching how the autolens guide points at `register_tracer_classes`. Blocked on this PR merging (library-first).
- **Dedupe the walker** across `autolens/jax/registration.py` and `autogalaxy/jax/registration.py`.
- **Verify a neighbouring doc claim:** `using_jax.py` states "The simulator handles pytree registration internally", but `autogalaxy/imaging/simulator.py` and `interferometer/simulator.py` contain no pytree registration calls. Either an autoarray base does it, or that sentence is wrong too. Pre-existing text, not introduced here.

Generated by the PyAutoLabs agent workflow.
