### PR TITLE
Bump draft-pdf actions to fleet standard

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -8,14 +8,14 @@ jobs:
     name: Paper Draft
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build draft PDF
         uses: openjournals/openjournals-draft-action@master
         with:
           journal: joss
           paper-path: paper/paper.md
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: paper
           path: paper/paper.pdf


### PR DESCRIPTION
Part 3 of 4 for PyAutoLabs/PyAutoHands#217: `checkout@v2`→v4, `upload-artifact@v1`→v4. Mechanical version strings only. (Disjoint from the in-flight plot-guides-restructure claim on this repo — this touches only `.github/workflows/draft-pdf.yml`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)