### PR TITLE
docs: point multi-dataset example links at the renamed `multi_dataset` package

### DIFF
--- a/docs/general/model_cookbook.md
+++ b/docs/general/model_cookbook.md
@@ -242,7 +242,7 @@ but certain parameters are free to vary across the datasets.
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/multi/start_here.ipynb>
+<https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/multi_dataset/start_here.ipynb>
 
 ## Relations (Advanced)
 
@@ -251,7 +251,7 @@ We can compose models where the free parameter(s) vary according to a user-speci
 
 The following example notebooks show how to compose and fit these models:
 
-<https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/multi/features/wavelength_dependence/modeling.ipynb>
+<https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/multi_dataset/features/wavelength_dependence/modeling.ipynb>
 
 ## PyAutoFit API
 

--- a/docs/overview/overview_2_new_user_guide.md
+++ b/docs/overview/overview_2_new_user_guide.md
@@ -40,7 +40,7 @@ You now need to decide what type of data you are interested in:
 
 - **CDD Imaging**: For image data from telescopes like Hubble and James Webb, go to [imaging/start_here.ipynb](https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/imaging/start_here.ipynb).
 - **Interferometer**: For radio / sub-mm interferometer from instruments like ALMA, go to [interferometer/start_here.ipynb](https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/interferometer/start_here.ipynb).
-- **Multi-Band Imaging**: For galaxies observed in multiple wavebands go to [multi/start_here.ipynb](https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/multi/start_here.ipynb).
+- **Multi-Band Imaging**: For galaxies observed in multiple wavebands go to [multi_dataset/start_here.ipynb](https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/notebooks/multi_dataset/start_here.ipynb).
 
 ## Google Colab
 
@@ -54,7 +54,7 @@ so you can check it is the right software for you before going through the insta
   Galaxy modeling with CCD imaging (e.g. Hubble, James Webb, ground-based telescopes).
 - [interferometer/start_here.ipynb](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.29.2/notebooks/interferometer/start_here.ipynb):
   Galaxy modeling with interferometer data (e.g. ALMA), fitting directly in the uv-plane.
-- [multi_band/start_here.ipynb](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.29.2/notebooks/multi/start_here.ipynb):
+- [multi_band/start_here.ipynb](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.29.2/notebooks/multi_dataset/start_here.ipynb):
   Multi-band galaxy modeling to study colour gradients and wavelength-dependent structure.
 - [multi_galaxy/start_here.ipynb](https://colab.research.google.com/github/PyAutoLabs/autogalaxy_workspace/blob/2026.7.29.2/notebooks/multi_galaxy/start_here.ipynb):
   Blended multi-galaxy systems — one free light model per galaxy, fitted simultaneously.

--- a/docs/overview/overview_3_features.md
+++ b/docs/overview/overview_3_features.md
@@ -57,7 +57,7 @@ The appearance of the galaxy changes as a function of wavelength, therefore mult
 more about the different components in a galaxy (e.g a redder bulge and bluer disk) or when imaging and interferometer
 data are combined, we can compare the emission from stars and dust.
 
-Checkout the `autogalaxy_workspace/*/multi` package to get started, however combining datasets is a more advanced
+Checkout the `autogalaxy_workspace/*/multi_dataset` package to get started, however combining datasets is a more advanced
 feature and it is recommended you first get to grips with the core API.
 
 ## Ellipse Fitting


### PR DESCRIPTION
Phase 3 of the `multi` → `multi_dataset` example-package rename (PyAutoLabs/autolens_workspace#408).

Docs-only — **no library source touched**.

## ⚠️ Merge order

**This must merge _after_ PyAutoLabs/autogalaxy_workspace#194.** The links updated here are `blob/main` URLs into the workspace; they resolve to the new path only once the package has actually moved on `main`.

## What changed

- `docs/general/model_cookbook.md` — GitHub `blob/main` links into the multi-dataset examples.
- `docs/overview/overview_2_new_user_guide.md` — the Multi-Band Imaging pointer, plus the **version-pinned Colab link**.
- `docs/overview/overview_3_features.md` — the `*/multi` package pointer in prose.

### On the version-pinned Colab link

`overview_2_new_user_guide.md` carries `.../blob/2026.7.29.2/notebooks/multi/start_here.ipynb`. PyAutoHands' `bump_colab_urls` rewrites only the **version** component at release, never the path — so leaving it as `multi/` would make it permanently wrong after the next release, whereas renaming it makes it correct from the next release onward. Renamed, accepting the interim window (the same one the `blob/main` links above have).

## Deliberately NOT changed

`bound: multi` in `test_autogalaxy/config/non_linear.yaml` is a **Dynesty search kwarg**, unrelated to this package.

Refs PyAutoLabs/autolens_workspace#408
