### PR TITLE
docs: add the autogalaxy_assistant signpost to llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -5,6 +5,7 @@
 ## Use it (examples & tutorials)
 
 - [autogalaxy_workspace navigator](https://github.com/PyAutoLabs/autogalaxy_workspace/blob/main/llms.txt): end-to-end example scripts and notebooks per science case — the paste-friendly task router. Send any "how do I model / simulate / analyse X?" question here.
+- [autogalaxy_assistant](https://github.com/PyAutoLabs/autogalaxy_assistant): the PyAutoGalaxy AI assistant — task skills, a curated API reference and a bundled real JWST dataset in one repo you drive by conversation (browser chat via a GitHub connector, or a local coding agent); start from its `llms.txt` front door.
 - [HowToGalaxy](https://github.com/PyAutoLabs/HowToGalaxy): from-first-principles lecture series on galaxy morphology and Bayesian fitting.
 
 ## API reference & docs


### PR DESCRIPTION
Phase 2 external signpost of PyAutoLabs/PyAutoBrain#188 — the assistant bullet PyAutoGalaxy's llms.txt lacked (README/RTD already link it), mirroring PyAutoLens/llms.txt. Merge after autogalaxy_assistant#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVSbY4u1JLfqRMgXYtnN9v