### PR TITLE
test: make the MGE bitwise sigma-ladder guards portable across CPUs

### DIFF
--- a/test_autogalaxy/analysis/test_model_util.py
+++ b/test_autogalaxy/analysis/test_model_util.py
@@ -157,6 +157,14 @@ def test__mge_model_from__default_sigma_list_is_bitwise_unchanged():
     `pytest.approx(rel=1e-8)` is deliberately NOT used: it only fails once the ladder
     has moved by a relative ~1e-7, which is already past the point where the
     identifier changes.
+
+    PORTABILITY TRAP -- the expected ladder is built element by element, exactly as
+    `mge_model_from` builds it (`10 ** log10_sigma_list[i]`), and must stay that way.
+    A vectorised `10 ** np.linspace(...)` is a DIFFERENT numpy code path: numpy does
+    not guarantee its scalar and SIMD power loops agree bit for bit, and on AVX-512
+    hardware they differ by 1 ULP, so writing the expectation vectorised makes this
+    test pass on GitHub's runners and fail on an AVX-512 developer machine. Comparing
+    like for like keeps the assertion exact without measuring the host's CPU.
     """
     for mask_radius, total_gaussians in [(3.0, 20), (3.5, 30), (7.5, 10), (1.0, 5)]:
         model = ag.model_util.mge_model_from(
@@ -166,9 +174,11 @@ def test__mge_model_from__default_sigma_list_is_bitwise_unchanged():
         instance = model.instance_from_prior_medians()
         sigma_list = [profile.sigma for profile in instance.profile_list]
 
-        assert sigma_list == list(
-            10 ** np.linspace(-4, np.log10(mask_radius), total_gaussians)
-        )
+        log10_sigma_list = np.linspace(-4, np.log10(mask_radius), total_gaussians)
+
+        assert sigma_list == [
+            10 ** log10_sigma_list[i] for i in range(total_gaussians)
+        ]
 
 
 def test__mge_point_model_from__returns_basis_model_with_correct_gaussians():
@@ -207,6 +217,12 @@ def test__mge_point_model_from__default_sigma_list_is_bitwise_unchanged():
     As for `mge_model_from`, the default `sigma_min=0.01` must reproduce the
     hardcoded `min_log10_sigma = -2.0` ladder that predates the argument EXACTLY,
     so the identifier of an existing point-source fit does not change.
+
+    The same portability trap applies here: build the expected ladder element by
+    element, the way `mge_point_model_from` does, so both sides take numpy's scalar
+    power path. A vectorised `10 ** np.linspace(...)` disagrees with it by 1 ULP on
+    AVX-512 hardware -- see `test__mge_model_from__default_sigma_list_is_bitwise_unchanged`
+    for the full reasoning, including why `pytest.approx(rel=1e-8)` is not the fix.
     """
     for pixel_scales, total_gaussians in [(0.1, 10), (0.05, 5), (0.2, 3), (0.001, 4)]:
         model = ag.model_util.mge_point_model_from(
@@ -217,9 +233,11 @@ def test__mge_point_model_from__default_sigma_list_is_bitwise_unchanged():
 
         max_sigma = max(2.0 * pixel_scales, 10**-2.0)
 
-        assert sigma_list == list(
-            10 ** np.linspace(-2.0, np.log10(max_sigma), total_gaussians)
-        )
+        log10_sigma_list = np.linspace(-2.0, np.log10(max_sigma), total_gaussians)
+
+        assert sigma_list == [
+            10 ** log10_sigma_list[i] for i in range(total_gaussians)
+        ]
 
 
 def test__mge_point_model_from__sigma_min_input_sets_smallest_gaussian():


### PR DESCRIPTION
Closes #550.

## What changed

`test__mge_model_from__default_sigma_list_is_bitwise_unchanged` and
`test__mge_point_model_from__default_sigma_list_is_bitwise_unchanged` (added with #549)
asserted exact equality between two *different* numpy code paths. The implementation
builds each sigma with a per-element scalar power
(`gaussian.sigma = 10 ** log10_sigma_list[i]`, `autogalaxy/analysis/model_util.py:190`
and `:271`); the tests built their expectation with a vectorised `10 ** np.linspace(...)`.
numpy does not guarantee its scalar and SIMD power loops agree bit for bit, so the two
disagree by 1 ULP on AVX-512 hardware — green on GitHub's runners, red on an AVX-512
developer machine. The regression guard was not portable.

This builds the expected ladder **element by element**, so both sides take the same
numpy path. The comparison stays bitwise; only the code path producing the expectation
changes.

**Test-only.** No library source is touched.

## What was deliberately not done

`pytest.approx(rel=1e-8)` is still not used. The test docstring rules it out and the
reasoning holds — it only fails once the ladder has moved by a relative ~1e-7, already
past the point where the PyAutoFit identifier (`RESOLUTION = 1e-8`) changes. That
reasoning is kept verbatim; both docstrings now additionally carry a `PORTABILITY TRAP`
note explaining why the expectation must stay element-wise, so a later tidy-up does not
re-vectorise it.

## Verification

The host used for this change is itself AVX-512 (`avx512f/bw/cd/dq/vl/vnni`) with numpy
2.4.6, so the failure was **reproduced, not assumed** — both tests fail on the unmodified
tree and pass after.

The reported footprint was narrower than the real one. Drift occurs at:

| test | case | index |
|---|---|---|
| `mge_model_from` | `mask_radius=3.0, total_gaussians=20` | 18 (the reported one) |
| `mge_model_from` | `mask_radius=3.5, total_gaussians=30` | 8 |
| `mge_point_model_from` | `pixel_scales=0.1, total_gaussians=10` | 4, 9 |
| `mge_point_model_from` | `pixel_scales=0.05, total_gaussians=5` | 3 |

Both guards were broken, not just the first.

**Control test** — an element-wise expectation risks becoming vacuous (the test merely
restating the implementation), so this was checked rather than assumed: perturbing the
implementation defaults by a relative 1e-7 (`sigma_min` `1e-4` → `1.0000001e-4`,
`0.01` → `0.010000001`) still fails both tests. The exactness guarantee survives the
change. The implementation was restored afterwards; only the test file is modified here.

Also verified: `np.log10(1e-4) == -4.0` and `np.log10(0.01) == -2.0` exactly, so the
tests' literal endpoints remain a faithful stand-in for the implementation's
`np.log10(sigma_min)`.

**Suites:** `test_autogalaxy/analysis/test_model_util.py` 29 passed; full
`test_autogalaxy/` 1004 passed, 3 skipped. Run locally on Python 3.11 (the only
interpreter with a stack in that sandbox) — CI grades 3.12/3.13, and the change is
pure-Python test code with no version-sensitive surface.

## Scope

Test-only, so no downstream workspace impact and no `pending-release` gate. The
neighbouring `pytest.approx(..., 1.0e-8)` assertions (L129, L237) are tolerance-based by
design and are untouched. PyAutoLens has no equivalent exact-equality
`10 ** np.linspace` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011tJFsEesnF7rZmn2xvfxUe

---
_Generated by [Claude Code](https://claude.ai/code/session_011tJFsEesnF7rZmn2xvfxUe)_