### PR TITLE
Fix mge_model_from ignoring the centre_fixed value

### DIFF
--- a/autogalaxy/analysis/model_util.py
+++ b/autogalaxy/analysis/model_util.py
@@ -127,7 +127,7 @@ def mge_model_from(
 
     def _make_centre_priors():
         if centre_fixed is not None:
-            return centre[0], centre[1]
+            return centre_fixed[0], centre_fixed[1]
         elif centre_prior_is_uniform:
             return (
                 af.UniformPrior(

--- a/test_autogalaxy/analysis/test_model_util.py
+++ b/test_autogalaxy/analysis/test_model_util.py
@@ -74,6 +74,19 @@ def test__mge_model_from__centre_fixed_with_two_bases():
     assert model.prior_count == 4
 
 
+def test__mge_model_from__centre_fixed_uses_the_fixed_value():
+    model = ag.model_util.mge_model_from(
+        mask_radius=1.0,
+        total_gaussians=5,
+        gaussian_per_basis=1,
+        centre_fixed=(1.5, -2.5),
+    )
+    assert model.prior_count == 2
+
+    instance = model.instance_from_prior_medians()
+    assert instance.profile_list[0].centre == (1.5, -2.5)
+
+
 def test__mge_model_from__centre_fixed_overrides_centre_per_basis():
     model = ag.model_util.mge_model_from(
         mask_radius=1.0,


### PR DESCRIPTION
## Summary

`mge_model_from`'s `_make_centre_priors` returned `centre[0], centre[1]` when `centre_fixed` was set, silently ignoring the `centre_fixed` value. Any caller passing only `centre_fixed=(y, x)` got Gaussians fixed at the default `centre=(0.0, 0.0)` — the docstring's documented behaviour ("fix all Gaussian centres to this (y, x) value") was never honoured.

Surfaced while writing the HowToLens scaling-relation tutorial; the autolens_workspace scaling-relation modeling scripts (imaging and multi_galaxy variants) pass only `centre_fixed=tuple(centre)` and are affected.

## Changes

- `autogalaxy/analysis/model_util.py`: return `centre_fixed[0], centre_fixed[1]`.
- `test_autogalaxy/analysis/test_model_util.py`: regression test with a **non-zero** fixed centre asserting it lands on the instance — the existing tests only ever used `centre_fixed=(0.0, 0.0)`, which coincides with the default centre, which is why the bug was invisible.

## Validation

Full suite: **1007 passed, 1 skipped** (Python 3.12).

No public API change — behaviour now matches the existing docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxKfSZisjnEn91LRGkN4SU

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxKfSZisjnEn91LRGkN4SU)_